### PR TITLE
[Update] 아이템 데이터 테이블을 이용하여 등급에 따른 확률 적용을 통한 랜덤 상점 아이템 생성 로직 구현

### DIFF
--- a/Content/Blueprints/DataTables/DunShop/ShopItemDataTable.uasset
+++ b/Content/Blueprints/DataTables/DunShop/ShopItemDataTable.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5eefc537333f4d85bc5d9904ea231130b7548ad1163739a232d33e84dddd02af
+size 10332

--- a/Content/Blueprints/Widgets/DunShop/WBP_DunItemWidget.uasset
+++ b/Content/Blueprints/Widgets/DunShop/WBP_DunItemWidget.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2a79ce6d1a9d41cffc026967b68dd327495da0272d5377b4ba985485e81fe648
-size 32477
+oid sha256:e0ef573431afe549446fef33ed1e2a9b0e9fb80d1dd49caa90c4de9c5026ba10
+size 34246

--- a/Content/Blueprints/Widgets/DunShop/WBP_DunShopWidget.uasset
+++ b/Content/Blueprints/Widgets/DunShop/WBP_DunShopWidget.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b2690d00af85dc6665abe69a51e1ec64d7af0ab8f3f83ff4973a6958b3c223f1
-size 33344
+oid sha256:ba251d047038dc8f9a67e00f5a6a985a079737581208fbf1bac2df8395b426f6
+size 37259

--- a/Source/RogShop/Widget/DunShop/DunItemWidget.cpp
+++ b/Source/RogShop/Widget/DunShop/DunItemWidget.cpp
@@ -1,7 +1,9 @@
 // Fill out your copyright notice in the Description page of Project Settings.
 #include "DunItemWidget.h"
+
 #include "Components/Button.h"
 #include "Components/TextBlock.h"
+#include "Components/Image.h"
 
 void UDunItemWidget::NativeConstruct()
 {
@@ -23,5 +25,37 @@ void UDunItemWidget::OnBuyClicked()
     if (BuyBtn)
     {
         BuyBtn->SetIsEnabled(false);
+    }
+}
+
+void UDunItemWidget::SetItemName(FText ItemName)
+{
+    if (ItemNameText)
+    {
+        ItemNameText->SetText(ItemName);
+    }
+}
+
+void UDunItemWidget::SetItemDescription(FText ItemDescription)
+{
+    if (ItemDesText)
+    {
+        ItemDesText->SetText(ItemDescription);
+    }
+}
+
+void UDunItemWidget::SetItemPrice(int32 ItemPrice)
+{
+    if (ItemPriceText)
+    {
+        ItemPriceText->SetText(FText::AsNumber(ItemPrice));
+    }
+}
+
+void UDunItemWidget::SetItemIcon(UTexture2D* ItemIcon)
+{
+    if (ItemImage && ItemIcon)
+    {
+        ItemImage->SetBrushFromTexture(ItemIcon);
     }
 }

--- a/Source/RogShop/Widget/DunShop/DunItemWidget.h
+++ b/Source/RogShop/Widget/DunShop/DunItemWidget.h
@@ -17,9 +17,17 @@ class ROGSHOP_API UDunItemWidget : public UUserWidget
 public:
     virtual void NativeConstruct() override;
 
+    void SetItemName(FText ItemName);
+    void SetItemDescription(FText ItemDescription);
+    void SetItemPrice(int32 ItemPrice);
+    void SetItemIcon(UTexture2D* ItemIcon);
+
 protected:
     UPROPERTY(meta = (BindWidget))
     class UImage* ItemImage;
+
+    UPROPERTY(meta = (BindWidget))
+    class UTextBlock* ItemNameText;
 
     UPROPERTY(meta = (BindWidget))
     class UTextBlock* ItemDesText;

--- a/Source/RogShop/Widget/DunShop/DunShopWidget.cpp
+++ b/Source/RogShop/Widget/DunShop/DunShopWidget.cpp
@@ -2,6 +2,8 @@
 
 
 #include "DunShopWidget.h"
+#include "DunItemWidget.h"
+
 #include "Components/Button.h"
 #include "Components/TextBlock.h"
 #include "Components/HorizontalBox.h"
@@ -20,27 +22,7 @@ void UDunShopWidget::NativeConstruct()
         ExitBtn->OnClicked.AddDynamic(this, &UDunShopWidget::OnExitClicked);
     }
 
-    const int32 ItemCount = 5;
-
-    for (int32 i = 0; i < ItemCount; ++i)
-    {
-        if (ItemWidgetClass && ItemHorizontalBox)
-        {
-            UUserWidget* NewItemWidget = CreateWidget<UUserWidget>(this, ItemWidgetClass);
-
-            if (NewItemWidget)
-            {
-                // AddChild 후 슬롯을 받아서 Fill 설정
-                UHorizontalBoxSlot* BoxSlot = Cast<UHorizontalBoxSlot>(ItemHorizontalBox->AddChild(NewItemWidget));
-
-                if (BoxSlot)
-                {
-                    BoxSlot->SetSize(FSlateChildSize(ESlateSizeRule::Fill));
-                }
-            }
-        }
-    }
-
+    PopulateShopItems();
 }
 
 void UDunShopWidget::OnExitClicked()
@@ -74,4 +56,90 @@ void UDunShopWidget::SetMouseMode(bool bEnable)
             }
         }
     }
+}
+
+void UDunShopWidget::PopulateShopItems()
+{
+    const int32 ItemCount = 5;
+
+    for (int32 i = 0; i < ItemCount; ++i)
+    {
+        FShopItemStruct* RandomItem = GetRandomItemFromDataTable(ItemDataTable);
+
+        if (RandomItem)
+        {
+            UE_LOG(LogTemp, Warning, TEXT("Selected Item: %s (%s)"),
+                *RandomItem->ItemName.ToString(),
+                *UEnum::GetValueAsString(RandomItem->Rarity));
+
+            if (ItemWidgetClass && ItemHorizontalBox)
+            {
+                // 위젯 생성
+                UDunItemWidget* NewItemWidget = CreateWidget<UDunItemWidget>(this, ItemWidgetClass);
+
+                if (NewItemWidget)
+                {
+                    // 아이템 정보를 설정
+                    NewItemWidget->SetItemName(RandomItem->ItemName);
+                    NewItemWidget->SetItemDescription(RandomItem->Description);
+                    NewItemWidget->SetItemPrice(RandomItem->Price);
+                    NewItemWidget->SetItemIcon(RandomItem->Icon);
+
+                    // 위젯을 수평 박스에 추가
+                    UHorizontalBoxSlot* BoxSlot = Cast<UHorizontalBoxSlot>(ItemHorizontalBox->AddChild(NewItemWidget));
+
+                    if (BoxSlot)
+                    {
+                        BoxSlot->SetSize(FSlateChildSize(ESlateSizeRule::Fill));
+                    }
+                }
+            }
+
+        }
+    }
+}
+
+ERarity UDunShopWidget::GetRandomRarity()
+{
+    int32 Roll = FMath::RandRange(1, 100); // 1 ~ 100 사이 정수
+
+    if (Roll <= 60)
+        return ERarity::Common;
+    else if (Roll <= 85) // 60 + 25
+        return ERarity::Rare;
+    else if (Roll <= 95) // 85 + 10
+        return ERarity::Epic;
+    else
+        return ERarity::Legendary;
+}
+
+FShopItemStruct* UDunShopWidget::GetRandomItemFromDataTable(UDataTable* DataTable)
+{
+    if (!DataTable) return nullptr;
+
+    // 1. 등급을 뽑는다
+    ERarity SelectedRarity = GetRandomRarity();
+
+    // 2. 전체 데이터 테이블 가져오기
+    TArray<FShopItemStruct*> AllItems;
+    DataTable->GetAllRows(TEXT("Context"), AllItems);
+
+    // 3. 뽑은 등급과 일치하는 아이템들 필터링
+    TArray<FShopItemStruct*> FilteredItems;
+    for (FShopItemStruct* Item : AllItems)
+    {
+        if (Item && Item->Rarity == SelectedRarity) // Rarity는 Struct에 추가돼 있어야 함
+        {
+            FilteredItems.Add(Item);
+        }
+    }
+
+    // 4. 필터링된 리스트에서 하나 랜덤 선택
+    if (FilteredItems.Num() > 0)
+    {
+        int32 RandomIndex = FMath::RandRange(0, FilteredItems.Num() - 1);
+        return FilteredItems[RandomIndex];
+    }
+
+    return nullptr; // 선택된 등급에 해당하는 아이템이 없을 경우
 }

--- a/Source/RogShop/Widget/DunShop/DunShopWidget.h
+++ b/Source/RogShop/Widget/DunShop/DunShopWidget.h
@@ -4,6 +4,7 @@
 
 #include "CoreMinimal.h"
 #include "Blueprint/UserWidget.h"
+#include "ShopItemStruct.h"
 #include "DunShopWidget.generated.h"
 
 class UHorizontalBox;
@@ -22,7 +23,17 @@ public:
     UPROPERTY(EditDefaultsOnly, Category = "Widgets")
     TSubclassOf<UUserWidget> ItemWidgetClass;  // 동적으로 생성할 아이템 위젯의 클래스
 
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Shop")
+    UDataTable* ItemDataTable;
+
     void SetMouseMode(bool bEnable);
+    void PopulateShopItems();
+
+    // 희귀도 랜덤 추출 함수
+    ERarity GetRandomRarity();
+
+    // 데이터 테이블에서 확률 기반 아이템 랜덤 추출 함수
+    FShopItemStruct* GetRandomItemFromDataTable(UDataTable* DataTable);
 
 protected:
     UPROPERTY(meta = (BindWidget))

--- a/Source/RogShop/Widget/DunShop/ShopItemStruct.cpp
+++ b/Source/RogShop/Widget/DunShop/ShopItemStruct.cpp
@@ -1,0 +1,5 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "ShopItemStruct.h"
+

--- a/Source/RogShop/Widget/DunShop/ShopItemStruct.h
+++ b/Source/RogShop/Widget/DunShop/ShopItemStruct.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Engine/DataTable.h" // 데이터 테이블용
+#include "ShopItemStruct.generated.h"
+
+UENUM(BlueprintType)
+enum class ERarity : uint8
+{
+    Common,
+    Rare,
+    Epic,
+    Legendary
+};
+
+USTRUCT(BlueprintType)
+struct ROGSHOP_API FShopItemStruct : public FTableRowBase
+{
+    GENERATED_BODY()
+
+public:
+
+    // 내부 로직 처리용
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Item")
+    FName ItemID;
+
+    // 보여주는 텍스트
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Item")
+    FText ItemName;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Item")
+    FText Description;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Item")
+    int32 Price;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Item")
+    UTexture2D* Icon;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Item")
+    ERarity Rarity;
+};


### PR DESCRIPTION
- #3

- 일반 (Common, 60프로), 고급 (Rare, 25프로), 희귀 (Epic, 10프로), 전설 (Legendary, 5프로) 확률로 상점에 아이템 출현되도록 구현
- 현재는 데이터 테이블에 Sword랑 Potion 아이템만 각 등급별로 존재, 추후 내용 추가 필요
- 아이템 이름, 사진, 설명, 가격, 보유 골드 및 나가기 버튼이 상점 UI에 반영된 상태
- 사진은 언리얼에 기본적으로 있는 임시 사진을 데이터 테이블에 넣어둔 상태

![image](https://github.com/user-attachments/assets/d53dbf46-2b83-404c-98b2-5402cdc0873c)
