### PR TITLE
[Update] 아이템 적용 로직 일부 추가 및 물품 중복 생성 방지 로직 구현

### DIFF
--- a/Content/Blueprints/DataTables/DunShop/ShopItemDataTable.uasset
+++ b/Content/Blueprints/DataTables/DunShop/ShopItemDataTable.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5eefc537333f4d85bc5d9904ea231130b7548ad1163739a232d33e84dddd02af
-size 10332
+oid sha256:4937b265346977eaed05a8305e34e5889d07b045f36ccfab583348a850da55c9
+size 10970

--- a/Content/Blueprints/GameInstance/BP_RSGameInstance.uasset
+++ b/Content/Blueprints/GameInstance/BP_RSGameInstance.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6d12dc0acb244fb37c8ae6aa1e0d2ca36c0e218c1a97a9a36da8f5078ac402f7
+size 5827

--- a/Source/RogShop/GameInstance/RSGameInstance.cpp
+++ b/Source/RogShop/GameInstance/RSGameInstance.cpp
@@ -1,0 +1,5 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "RSGameInstance.h"
+

--- a/Source/RogShop/GameInstance/RSGameInstance.h
+++ b/Source/RogShop/GameInstance/RSGameInstance.h
@@ -1,0 +1,19 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Engine/GameInstance.h"
+#include "RSGameInstance.generated.h"
+
+/**
+ * 
+ */
+UCLASS()
+class ROGSHOP_API URSGameInstance : public UGameInstance
+{
+	GENERATED_BODY()
+	
+public:
+	TArray<FName> PurchasedItemIDs;
+};

--- a/Source/RogShop/RogShop.Build.cs
+++ b/Source/RogShop/RogShop.Build.cs
@@ -14,9 +14,9 @@ public class RogShop : ModuleRules
             Path.Combine(ModuleDirectory, "Character"),
             Path.Combine(ModuleDirectory, "Character", "AI"),
             Path.Combine(ModuleDirectory, "Controller"),
-            Path.Combine(ModuleDirectory, "Widget"),
             Path.Combine(ModuleDirectory, "Widget", "DunShop"),
             Path.Combine(ModuleDirectory, "AnimInstances"),
+            Path.Combine(ModuleDirectory, "GameInstance"),
         });
 
         PublicDependencyModuleNames.AddRange(new string[] { "Core", "CoreUObject", "Engine", "InputCore", "EnhancedInput", "AIModule" });

--- a/Source/RogShop/Widget/DunShop/DunItemWidget.cpp
+++ b/Source/RogShop/Widget/DunShop/DunItemWidget.cpp
@@ -1,9 +1,13 @@
 // Fill out your copyright notice in the Description page of Project Settings.
 #include "DunItemWidget.h"
+#include "RSDunBaseCharacter.h"
+#include "Kismet/GameplayStatics.h"
 
 #include "Components/Button.h"
 #include "Components/TextBlock.h"
 #include "Components/Image.h"
+
+#include "DunShopWidget.h"
 
 void UDunItemWidget::NativeConstruct()
 {
@@ -26,6 +30,8 @@ void UDunItemWidget::OnBuyClicked()
     {
         BuyBtn->SetIsEnabled(false);
     }
+
+    BuyItem();
 }
 
 void UDunItemWidget::SetItemName(FText ItemName)
@@ -59,3 +65,66 @@ void UDunItemWidget::SetItemIcon(UTexture2D* ItemIcon)
         ItemImage->SetBrushFromTexture(ItemIcon);
     }
 }
+
+void UDunItemWidget::SetItemType(EItemList InItemList)
+{
+    ItemListType = InItemList;
+}
+
+void UDunItemWidget::SetItemRarity(ERarity InItemRarity)
+{
+    ItemRarity = InItemRarity;
+}
+
+void UDunItemWidget::SetItemID(FName InItemID)
+{
+    ItemID = InItemID;
+}
+
+void UDunItemWidget::SetParentShop(UDunShopWidget* InShop)
+{
+    ParentShop = InShop;
+}
+
+void UDunItemWidget::BuyItem()
+{
+    ARSDunBaseCharacter* Character = Cast<ARSDunBaseCharacter>(UGameplayStatics::GetPlayerCharacter(this, 0));
+    if (!Character) return;
+
+    switch (ItemListType)
+    {
+        case EItemList::Potion:
+        {
+            float PotionValue = 0.0f;
+
+            switch (ItemRarity)
+            {
+                case ERarity::Common: PotionValue = 1.0f; break;
+                case ERarity::Rare: PotionValue = 2.0f; break;
+                case ERarity::Epic: PotionValue = 3.0f; break;
+                case ERarity::Legendary: PotionValue = 4.0f; break;
+            }
+
+            Character->AddHP(PotionValue);  // 캐릭터 클래스에 이 함수 구현 필요
+            break;
+        }
+        case EItemList::Sword:
+        {
+            // ...
+            break;
+        }
+        default:
+            UE_LOG(LogTemp, Warning, TEXT("Not Define Item."));
+            break;
+    }
+
+    if (ParentShop)
+    {
+        ParentShop->HandleItemPurchase(ItemID);
+    }
+    else 
+    {
+        UE_LOG(LogTemp, Warning, TEXT("ParentShop is nullptr"));
+    }
+}
+

--- a/Source/RogShop/Widget/DunShop/DunItemWidget.cpp
+++ b/Source/RogShop/Widget/DunShop/DunItemWidget.cpp
@@ -105,7 +105,8 @@ void UDunItemWidget::BuyItem()
                 case ERarity::Legendary: PotionValue = 4.0f; break;
             }
 
-            Character->AddHP(PotionValue);  // 캐릭터 클래스에 이 함수 구현 필요
+            // Character->AddHP(PotionValue);  // 캐릭터 클래스에 이 함수 구현 필요
+
             break;
         }
         case EItemList::Sword:

--- a/Source/RogShop/Widget/DunShop/DunItemWidget.h
+++ b/Source/RogShop/Widget/DunShop/DunItemWidget.h
@@ -4,11 +4,11 @@
 
 #include "CoreMinimal.h"
 #include "Blueprint/UserWidget.h"
+#include "ShopItemStruct.h"
 #include "DunItemWidget.generated.h"
 
-/**
- * 
- */
+class UDunShopWidget;
+
 UCLASS()
 class ROGSHOP_API UDunItemWidget : public UUserWidget
 {
@@ -21,6 +21,13 @@ public:
     void SetItemDescription(FText ItemDescription);
     void SetItemPrice(int32 ItemPrice);
     void SetItemIcon(UTexture2D* ItemIcon);
+    void SetItemType(EItemList InItemList);
+    void SetItemRarity(ERarity InItemRarity);
+    void SetItemID(FName InItemID);
+
+    void SetParentShop(UDunShopWidget* InShop);
+
+    void BuyItem();
 
 protected:
     UPROPERTY(meta = (BindWidget))
@@ -37,6 +44,18 @@ protected:
 
     UPROPERTY(meta = (BindWidget))
     class UButton* BuyBtn;
+
+    UPROPERTY()
+    EItemList ItemListType;
+
+    UPROPERTY()
+    ERarity ItemRarity;
+
+    UPROPERTY()
+    FName ItemID;
+
+    UPROPERTY()
+    UDunShopWidget* ParentShop;
 
     UFUNCTION()
     void OnBuyClicked();

--- a/Source/RogShop/Widget/DunShop/DunShopWidget.h
+++ b/Source/RogShop/Widget/DunShop/DunShopWidget.h
@@ -26,8 +26,7 @@ public:
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Shop")
     UDataTable* ItemDataTable;
 
-    void SetMouseMode(bool bEnable);
-    void PopulateShopItems();
+    void HandleItemPurchase(FName PurchasedID);
 
     // Èñ±Íµµ ·£´ý ÃßÃâ ÇÔ¼ö
     ERarity GetRandomRarity();
@@ -44,4 +43,7 @@ protected:
 
     UFUNCTION()
     void OnExitClicked();
+
+    void SetMouseMode(bool bEnable);
+    void PopulateShopItems();
 };

--- a/Source/RogShop/Widget/DunShop/ShopItemStruct.h
+++ b/Source/RogShop/Widget/DunShop/ShopItemStruct.h
@@ -13,6 +13,13 @@ enum class ERarity : uint8
     Legendary
 };
 
+UENUM(BlueprintType)
+enum class EItemList : uint8
+{
+    Potion,
+    Sword,
+};
+
 USTRUCT(BlueprintType)
 struct ROGSHOP_API FShopItemStruct : public FTableRowBase
 {
@@ -22,21 +29,24 @@ public:
 
     // 내부 로직 처리용
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Item")
-    FName ItemID;
+    FName ItemID = NAME_None;
 
     // 보여주는 텍스트
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Item")
-    FText ItemName;
+    FText ItemName = FText::FromString(TEXT(""));
 
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Item")
-    FText Description;
+    FText Description = FText::FromString(TEXT(""));
 
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Item")
-    int32 Price;
+    int32 Price = 0;
 
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Item")
-    UTexture2D* Icon;
+    UTexture2D* Icon = nullptr;
 
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Item")
     ERarity Rarity;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Item")
+    EItemList ItemList = EItemList::Potion;
 };


### PR DESCRIPTION
- #3 

1. ShopItemStruct 구조체 기본값 추가
2. 물약 구매시 현재 HP 증가 로직 추가, 캐릭터에서 HP를 Set 해주는 함수 또는 변수 public화 필요
3. 아이템 생성시 중복 생성 X 및 이미 구매한 아이템도 생성 안 되도록 구현
- 처음엔 구매한 아이템이 없으므로 최소 1, 최대 5개의 아이템 생성. 구매 이후부턴 최소 0 (이미 구매한 아이템이 상점에 5번 뜬 경우), 최대 5개의 아이템 생성
4. 구매했던 아이템 데이터 저장을 위한 GameInstance 생성, 공용으로 GameInstance 사용 필요시 해당 파일 사용해야할 수 있음
- 현재 프로젝트 세팅에 넣어두지는 않은 상태