### PR TITLE
[Update] 플레이어 캐릭터에 무기 슬롯 구현 및 무기 전환 로직 구현

### DIFF
--- a/Content/Blueprints/Actor/Dungeon/BP_SwordWeapon.uasset
+++ b/Content/Blueprints/Actor/Dungeon/BP_SwordWeapon.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a81cdbdc5afe0af20abe00f123a56e7a19c9b684340a10c361746abd50a12359
-size 55738
+oid sha256:402bc04871105ec4d224825d0cdc34fbde240cacaa8903972ce883c2fdeb5db0
+size 47724

--- a/Source/RogShop/ActorComponent/RSPlayerWeaponComponent.h
+++ b/Source/RogShop/ActorComponent/RSPlayerWeaponComponent.h
@@ -9,6 +9,14 @@
 
 class ARSBaseWeapon;
 
+UENUM(BlueprintType)
+enum class EWeaponSlot : uint8
+{
+	FirstWeaponSlot,
+	SecondWeaponSlot,
+	NONE
+};
+
 UCLASS( ClassGroup=(Custom), meta=(BlueprintSpawnableComponent) )
 class ROGSHOP_API URSPlayerWeaponComponent : public UActorComponent
 {
@@ -33,18 +41,26 @@ public:
 
 	void ResetCombo();
 
-	void SetWeaponActor(ARSBaseWeapon* WeaponActor);
+	UFUNCTION(BlueprintCallable)
+	void EquipWeaponToSlot(ARSBaseWeapon* WeaponActor);
+
+	void EquipWeaponToCharacter(EWeaponSlot TargetWeaponSlot);
 
 private:
-	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = "Weapon", meta = (AllowPrivateAccess = true))
-	TObjectPtr<ARSBaseWeapon> WeaponActor; // 무기 액터
+	// 무기
+	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Weapon", meta = (AllowPrivateAccess = true))
+	TArray<TObjectPtr<ARSBaseWeapon>> WeaponActors; // 무기 액터
 
 	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Weapon", meta = (AllowPrivateAccess = true))
-	bool bIsAttack;
+	EWeaponSlot WeaponSlot;
+
+	// 애니메이션을 위한 상태
+	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Weapon", meta = (AllowPrivateAccess = true))
+	bool bIsAttack;	// 공격 중인 상태
 
 	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Weapon", meta = (AllowPrivateAccess = true))
-	bool bComboInputBuffered;
+	bool bComboInputBuffered;	// 공격 중일 때 들어온 입력 버퍼
 
 	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Weapon", meta = (AllowPrivateAccess = true))
-	int32 ComboIndex;
+	int32 ComboIndex;	// 콤보 공격을 위한 인덱스 값
 };

--- a/Source/RogShop/Character/RSDunPlayerCharacter.cpp
+++ b/Source/RogShop/Character/RSDunPlayerCharacter.cpp
@@ -264,6 +264,8 @@ void ARSDunPlayerCharacter::FirstWeaponSlot(const FInputActionValue& value)
     {
         GEngine->AddOnScreenDebugMessage(-1, 1.0f, FColor::Green, TEXT("FirstWeaponSlot Activated"));
     }
+
+    WeaponComp->EquipWeaponToCharacter(EWeaponSlot::FirstWeaponSlot);
 }
 
 void ARSDunPlayerCharacter::SecondWeaponSlot(const FInputActionValue& value)
@@ -274,6 +276,8 @@ void ARSDunPlayerCharacter::SecondWeaponSlot(const FInputActionValue& value)
     {
         GEngine->AddOnScreenDebugMessage(-1, 1.0f, FColor::Green, TEXT("SecondWeaponSlot Activated"));
     }
+
+    WeaponComp->EquipWeaponToCharacter(EWeaponSlot::SecondWeaponSlot);
 }
 
 URSPlayerWeaponComponent* ARSDunPlayerCharacter::GetRSPlayerWeaponComponent()


### PR DESCRIPTION
무기 슬롯이라는 개념으로, 플레이어 캐릭터가 무기로 2개 가지고있을 수 있도록 구현한다.

1번 무기를 들고 있을 경우 2번 슬롯을 선택했을 때 2번 슬롯의 무기로 전환되도록 구현

무기가 하나도 없을 때 무기를 획득하면 1번 슬롯부터 무기가 추가된다.
이때, 무기를 바로 들고있지 않는다.

1번 무기를 들고 있을 때 해당 무기를 버린다면, 맨손이 된다.