### PR TITLE
[BugFix] InteractTrace의 찾은 액터를 계속 저장하고 있던 오류 수정

### DIFF
--- a/Source/RogShop/Character/RSDunPlayerCharacter.cpp
+++ b/Source/RogShop/Character/RSDunPlayerCharacter.cpp
@@ -312,15 +312,18 @@ void ARSDunPlayerCharacter::InteractTrace()
             else
             {
                 DrawDebugLine(GetWorld(), Start, End, FColor::Red, false, 1.0f, 0, 2.0f);
+                InteractActor = nullptr;
             }
         }
         else
         {
             DrawDebugLine(GetWorld(), Start, End, FColor::Red, false, 1.0f, 0, 2.0f);
+            InteractActor = nullptr;
         }
     }
     else
     {
         DrawDebugLine(GetWorld(), Start, End, FColor::Red, false, 1.0f, 0, 2.0f);
+        InteractActor = nullptr;
     }
 }


### PR DESCRIPTION
`InteractTrace` 함수 실행시 기존에는 가장 마지막에 찾던 액터가 저장되고 값이 변경되지 않는다는 문제가 있었다.

 액터를 찾지 못했을 때 찾은 액터를 저장하던 `InteractActor` 의 값을 nullptr로 변경하도록 수정했다.