### PR TITLE
[Fix] PatrolPoint 가 올바른 채널에서 오버랩 되도록 수정

### DIFF
--- a/Content/Blueprints/Navigate/PatrolPoint.uasset
+++ b/Content/Blueprints/Navigate/PatrolPoint.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:798602db7b277808929d1504152155e23ab1c689144e2ba4cde08a2e03c08fb9
-size 25304
+oid sha256:789468e651aa132ce02d1377b20ee1f895f55fdfebd92f90d3a9a2751fa7849a
+size 27041


### PR DESCRIPTION
충돌해결중에 채널이 변경되어 해당 클래스에서 오버랩이 필요해서 수정되었음