### PR TITLE
[Update] 던전 플레이어 캐릭터에 AI퍼셉션 자극 소스 추가

### DIFF
--- a/Content/Blueprints/Characters/BP_DunPlayerCharacter.uasset
+++ b/Content/Blueprints/Characters/BP_DunPlayerCharacter.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5682aea234524e1831a5cd171d4e73c4c5e778d98e0964d54fade842c5089123
-size 39218
+oid sha256:c48fff161061fc77deacf03ff74061c0f9d170bc77980b7fcef5abc66f3f0065
+size 39302

--- a/Source/RogShop/Character/RSDunPlayerCharacter.cpp
+++ b/Source/RogShop/Character/RSDunPlayerCharacter.cpp
@@ -12,6 +12,8 @@
 #include "RSPlayerWeaponComponent.h"
 #include "RSInteractable.h"
 #include "DrawDebugHelpers.h"
+#include "Perception/AIPerceptionStimuliSourceComponent.h"
+#include "Perception/AISense_Sight.h"
 
 // Sets default values
 ARSDunPlayerCharacter::ARSDunPlayerCharacter()
@@ -48,6 +50,11 @@ ARSDunPlayerCharacter::ARSDunPlayerCharacter()
     // 상호작용
     InteractActor = nullptr;
     InteractDistance = 200.f;
+
+    // AI퍼셉션 자극 소스
+    AIPerceptionStimuliSourceComp = CreateDefaultSubobject<UAIPerceptionStimuliSourceComponent>(TEXT("AIPerceptionStimuliSource"));
+    AIPerceptionStimuliSourceComp->bAutoRegister = true;
+    AIPerceptionStimuliSourceComp->RegisterForSense(UAISense_Sight::StaticClass());
 }
 
 // Called when the game starts or when spawned

--- a/Source/RogShop/Character/RSDunPlayerCharacter.h
+++ b/Source/RogShop/Character/RSDunPlayerCharacter.h
@@ -9,6 +9,7 @@
 class USpringArmComponent;
 class UCameraComponent;
 class URSPlayerWeaponComponent;
+class UAIPerceptionStimuliSourceComponent;
 
 struct FInputActionValue;
 
@@ -74,7 +75,7 @@ public:
 	URSPlayerWeaponComponent* GetRSPlayerWeaponComponent();
 
 private:
-	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Camera", meta = (AllowPrivateAccess = true))
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Weapon", meta = (AllowPrivateAccess = true))
 	TObjectPtr<URSPlayerWeaponComponent> WeaponComp;
 
 // 상호작용 관련
@@ -84,4 +85,9 @@ private:
 private:
 	AActor* InteractActor;	// 라인트레이스를 통해 찾은 상호작용 가능한 액터
 	float InteractDistance;	// 라인트레이스를 할 거리
+
+// AI퍼셉션 자극 소스
+private:
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "AI", meta = (AllowPrivateAccess = true))
+	TObjectPtr<UAIPerceptionStimuliSourceComponent> AIPerceptionStimuliSourceComp;
 };


### PR DESCRIPTION
던전 플레이어 캐릭터에 UAIPerceptionStimuliSourceComponent 컴포넌트 추가

bAutoRegister의 값을 true로 설정하여 해당 액터가 생성 및 스폰 됐을 때 감지 시스템에 자동으로 등록 되도록 설정

RegisterForSense으로 시야 감각을 자극원으로 설정

에디터에는 해당 자극원이 추가됐다고 표기되는 변경사항이 없다.
런타임 중에 반영되기 때문으로 보인다.