### PR TITLE
[Update] 던전 캐릭터의 체력 관련 함수 구현 및 bIsDead 변수 추가

### DIFF
--- a/Source/RogShop/Character/RSDunBaseCharacter.cpp
+++ b/Source/RogShop/Character/RSDunBaseCharacter.cpp
@@ -7,4 +7,50 @@ ARSDunBaseCharacter::ARSDunBaseCharacter()
 {
 	MaxHP = 100.f;
 	HP = MaxHP;
+
+	bIsDead = false;
+}
+
+float ARSDunBaseCharacter::GetMaxHP() const
+{
+	return MaxHP;
+}
+
+void ARSDunBaseCharacter::IncreaseMaxHP(float Amount)
+{
+	float NewMaxHP = Amount + MaxHP;
+	MaxHP = NewMaxHP;
+}
+
+void ARSDunBaseCharacter::DecreaseMaxHP(float Amount)
+{
+	float NewMaxHP = FMath::Clamp(MaxHP - Amount, 0.0f, MaxHP);
+	MaxHP = NewMaxHP;
+}
+
+float ARSDunBaseCharacter::GetHP() const
+{
+	return HP;
+}
+
+void ARSDunBaseCharacter::IncreaseHP(float Amount)
+{
+	float NewHP = FMath::Clamp(HP + Amount, 0.0f, MaxHP);
+	HP = NewHP;
+}
+
+void ARSDunBaseCharacter::DecreaseHP(float Amount)
+{
+	float NewHP = FMath::Clamp(HP - Amount, 0.0f, MaxHP);
+	HP = NewHP;
+}
+
+bool ARSDunBaseCharacter::GetIsDead()
+{
+	return bIsDead;
+}
+
+void ARSDunBaseCharacter::OnDeath()
+{
+	bIsDead = true;
 }

--- a/Source/RogShop/Character/RSDunBaseCharacter.h
+++ b/Source/RogShop/Character/RSDunBaseCharacter.h
@@ -16,12 +16,29 @@ class ROGSHOP_API ARSDunBaseCharacter : public ACharacter
 
 public:
 	ARSDunBaseCharacter();
-	
-protected:
+
+// 스탯 관련
+public:
+	float GetMaxHP() const;
+	void IncreaseMaxHP(float Amount);
+	void DecreaseMaxHP(float Amount);
+
+	float GetHP() const;
+	void IncreaseHP(float Amount);
+	void DecreaseHP(float Amount);
+
+private:
 	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, meta = (AllowPrivateAccess = "true"))
 	float WalkSpeed;
 	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, category = "Stat", meta = (AllowPrivateAccess = "true"))
 	float MaxHP;
-	UPROPERTY(EditInstanceOnly, BlueprintReadOnly, category = "Stat", meta = (AllowPrivateAccess = "true"))
+	UPROPERTY(VisibleInstanceOnly, BlueprintReadOnly, category = "Stat", meta = (AllowPrivateAccess = "true"))
 	float HP;
+
+// 상태 관련
+public:
+	bool GetIsDead();
+	virtual void OnDeath();
+private:
+	bool bIsDead;
 };

--- a/Source/RogShop/Character/RSDunMonsterCharacter.cpp
+++ b/Source/RogShop/Character/RSDunMonsterCharacter.cpp
@@ -51,7 +51,8 @@ float ARSDunMonsterCharacter::TakeDamage(float DamageAmount, FDamageEvent const&
 	/*if (bIsDead) return 0.0f;*/ // TODO : 만약 선국님이 bIsDead 변수 만들어 주면 넣을 로직
 
 	float damage = Super::TakeDamage(DamageAmount, DamageEvent, EventInstigator, DamageCauser);
-	HP -= damage;
+	
+	DecreaseHP(damage);
 
 	// 데미지 받으면 로그에 추가! (임시)
 	UE_LOG(LogTemp, Warning, TEXT("[%s] took %.1f damage from [%s]"),
@@ -60,7 +61,7 @@ float ARSDunMonsterCharacter::TakeDamage(float DamageAmount, FDamageEvent const&
 		DamageCauser ? *DamageCauser->GetName() : TEXT("Unknown"));
 
 	
-	if (HP <= 0)
+	if (GetHP() <= 0)
 	{
 		OnDeath();
 	}

--- a/Source/RogShop/Character/RSDunPlayerCharacter.cpp
+++ b/Source/RogShop/Character/RSDunPlayerCharacter.cpp
@@ -128,11 +128,9 @@ float ARSDunPlayerCharacter::TakeDamage(float DamageAmount, FDamageEvent const& 
 {
     const float Damage = Super::TakeDamage(DamageAmount, DamageEvent, EventInstigator, DamageCauser);
 
-    float NewHP = FMath::Clamp(HP - Damage, 0.0f, MaxHP);
+    DecreaseHP(Damage);
 
-    HP = NewHP;
-
-    if (HP <= 0)
+    if (GetHP() <= 0)
     {
         OnDeath();
     }
@@ -142,6 +140,8 @@ float ARSDunPlayerCharacter::TakeDamage(float DamageAmount, FDamageEvent const& 
 
 void ARSDunPlayerCharacter::OnDeath()
 {
+    Super::OnDeath();
+
     // 레벨 오브젝트를 제외한 모든 오브젝트와 충돌하지 않도록 콜리전 설정 변경
     GetCapsuleComponent()->SetCollisionProfileName(TEXT("DeadCharacter"));
     GetMesh()->SetCollisionProfileName(TEXT("DeadCharacter"));


### PR DESCRIPTION
스탯 관련한 함수 추가

- float GetMaxHP() const;
- void IncreaseMaxHP(float Amount);
- void DecreaseMaxHP(float Amount);

- float GetHP() const;
- void IncreaseHP(float Amount);
- void DecreaseHP(float Amount);

기존의 체력과 이동속도는 private로 변경
접근제어 지정자를 변경함에 따라 기존 로직에서 변수를 사용한 경우 코드 수정
ARSDunPlayerCharacter의 TakeDamage
ARSDunMonsterCharacter의 TakeDamage

죽었는지 상태를 나타내는 변수 bIsDead 추가

해당 변수와 관련된 함수 추가

- bool GetIsDead();
- virtual void OnDeath();
  - 해당 함수는 체력이 0이되면 호출하도록한다.
  
  ARSDunMonsterCharacter에서 OnDeath를 overrdie하도록 해야한다.