### PR TITLE
[Update] 플레이어 체력 즉시 회복 아이템 구매시 내용 적용되도록 로직 추가 및 불필요한 로그 출력 제거

### DIFF
--- a/Source/RogShop/Actor/NPC/RSDunShopNpcActor.cpp
+++ b/Source/RogShop/Actor/NPC/RSDunShopNpcActor.cpp
@@ -36,8 +36,6 @@ void ARSDunShopNpcActor::Interact(ARSDunPlayerCharacter* Interactor)
 	if (!StoreWidget) return;
 
 	StoreWidget->AddToViewport();
-
-	UE_LOG(LogTemp, Warning, TEXT("Widget opened from NPC"));
 }
 
 

--- a/Source/RogShop/CheatManager/RSCheatManager.cpp
+++ b/Source/RogShop/CheatManager/RSCheatManager.cpp
@@ -152,8 +152,6 @@ void URSCheatManager::SpawnWeaponPad()
     FRotator SpawnRotation = FRotator::ZeroRotator;
 
     GetWorld()->SpawnActor<AActor>(WeaponSpawnPadBPClass, SpawnLocation, SpawnRotation);
-
-    UE_LOG(LogTemp, Warning, TEXT("Suc !"));
 }
 
 void URSCheatManager::OpenTycoonLevel()

--- a/Source/RogShop/Widget/DunShop/DunItemWidget.cpp
+++ b/Source/RogShop/Widget/DunShop/DunItemWidget.cpp
@@ -106,17 +106,17 @@ bool UDunItemWidget::BuyItem()
 
     switch (ItemData.ItemList)
     {
-        case EItemList::Potion:
+        case EItemList::Potion: // 체력 즉시 회복
         {
             switch (ItemData.Rarity)
             {
-                case ERarity::Common: FinalValue = 1.0f; break;
-                case ERarity::Rare: FinalValue = 2.0f; break;
-                case ERarity::Epic: FinalValue = 3.0f; break;
-                case ERarity::Legendary: FinalValue = 4.0f; break;
+                case ERarity::Common: FinalValue = 10.0f; break;
+                case ERarity::Rare: FinalValue = 20.0f; break;
+                case ERarity::Epic: FinalValue = 30.0f; break;
+                case ERarity::Legendary: FinalValue = 40.0f; break;
             }
 
-            // Character->AddHP(FinalValue);  // 플레이어 HP 수정 관련 함수 또는 public 변수 필요
+            PlayerChar->IncreaseHP(FinalValue);
 
             break;
         }
@@ -134,7 +134,7 @@ bool UDunItemWidget::BuyItem()
 
             break;
         }
-        case EItemList::WalkSpeedRelic:
+        case EItemList::WalkSpeedRelic: // 임시
         {
             switch (ItemData.Rarity)
             {
@@ -148,7 +148,7 @@ bool UDunItemWidget::BuyItem()
 
             break;
         }
-        case EItemList::AttackRelic:
+        case EItemList::AttackRelic: // 임시
         {
             switch (ItemData.Rarity)
             {
@@ -162,7 +162,7 @@ bool UDunItemWidget::BuyItem()
 
             break;
         }
-        case EItemList::AttackSpeedRelic:
+        case EItemList::AttackSpeedRelic: // 임시
         {
             switch (ItemData.Rarity)
             {

--- a/Source/RogShop/Widget/DunShop/DunShopWidget.cpp
+++ b/Source/RogShop/Widget/DunShop/DunShopWidget.cpp
@@ -17,8 +17,6 @@ void UDunShopWidget::NativeConstruct()
 {
     Super::NativeConstruct();
 
-    UE_LOG(LogTemp, Warning, TEXT("DunShopWidget Open !"));
-
     SetMouseMode(true);
 
     if (ExitBtn)
@@ -52,7 +50,6 @@ void UDunShopWidget::HandleItemPurchase(FName PurchasedID)
     if (GI)
     {
         GI->PurchasedItemIDs.Add(PurchasedID);  // 아이템 구매 후 아이디 추가
-        UE_LOG(LogTemp, Warning, TEXT("Item Purchased: %s"), *PurchasedID.ToString());
     }
 }
 


### PR DESCRIPTION
- #3 

- 유물 적용 관련 로직은 유물 데이터를 어떻게 보유하고 있을지 결정된 후에 구현 예정