### PR TITLE
[Update] 플레이어 캐릭터가 사망시 등록 했던 자극 센서 제거

### DIFF
--- a/Source/RogShop/Character/RSDunPlayerCharacter.cpp
+++ b/Source/RogShop/Character/RSDunPlayerCharacter.cpp
@@ -163,6 +163,11 @@ void ARSDunPlayerCharacter::OnDeath()
     {
         MovementComponent->SetMovementMode(EMovementMode::MOVE_None);
     }
+
+    if (AIPerceptionStimuliSourceComp)
+    {
+        AIPerceptionStimuliSourceComp->UnregisterFromPerceptionSystem();
+    }
 }
 
 void ARSDunPlayerCharacter::Move(const FInputActionValue& value)


### PR DESCRIPTION
#91 

플레이어 캐릭터가 사망한 경우 UAIPerceptionStimuliSourceComponent에 등록된 자극 센서를 모두 제거하도록 로직 추가

하지만, 현재 타겟을 발견한 경우 타겟을 제거하는 로직이 없기 때문에 플레이어를 항상 쫓아간다.
즉, 플레이어 캐릭터가 사망해도 계속 추적한다.