### PR TITLE
[Update] 플레이어 캐릭터에 스탯 구현

### DIFF
--- a/Source/RogShop/Character/RSDunBaseCharacter.cpp
+++ b/Source/RogShop/Character/RSDunBaseCharacter.cpp
@@ -2,13 +2,28 @@
 
 
 #include "RSDunBaseCharacter.h"
+#include "GameFramework/CharacterMovementComponent.h"
 
 ARSDunBaseCharacter::ARSDunBaseCharacter()
 {
+	GetCharacterMovement()->MaxWalkSpeed = MoveSpeed;
+
+	MoveSpeed = 600.f;
 	MaxHP = 100.f;
 	HP = MaxHP;
 
 	bIsDead = false;
+}
+
+void ARSDunBaseCharacter::ChangeMoveSpeed(float Amount)
+{
+	MoveSpeed = Amount;
+
+	UCharacterMovementComponent* MovementComp = GetCharacterMovement();
+	if (MovementComp)
+	{
+		MovementComp->MaxWalkSpeed = MoveSpeed;
+	}
 }
 
 float ARSDunBaseCharacter::GetMaxHP() const
@@ -26,6 +41,18 @@ void ARSDunBaseCharacter::DecreaseMaxHP(float Amount)
 {
 	float NewMaxHP = FMath::Clamp(MaxHP - Amount, 0.0f, MaxHP);
 	MaxHP = NewMaxHP;
+
+	// 현재 체력이 더 많은 경우 최대체력으로 갱신
+	if (HP > MaxHP)
+	{
+		HP = MaxHP;
+	}
+
+	// 현재 체력이 0이하가 된 경우 사망 처리
+	if (HP <= 0.f)
+	{
+		OnDeath();
+	}
 }
 
 float ARSDunBaseCharacter::GetHP() const
@@ -43,6 +70,12 @@ void ARSDunBaseCharacter::DecreaseHP(float Amount)
 {
 	float NewHP = FMath::Clamp(HP - Amount, 0.0f, MaxHP);
 	HP = NewHP;
+
+	// 현재 체력이 0이하가 된 경우 사망 처리
+	if (HP <= 0.f)
+	{
+		OnDeath();
+	}
 }
 
 bool ARSDunBaseCharacter::GetIsDead()

--- a/Source/RogShop/Character/RSDunBaseCharacter.h
+++ b/Source/RogShop/Character/RSDunBaseCharacter.h
@@ -19,6 +19,9 @@ public:
 
 // 스탯 관련
 public:
+	float GetMoveSpeed() const;
+	void ChangeMoveSpeed(float Amount);
+
 	float GetMaxHP() const;
 	void IncreaseMaxHP(float Amount);
 	void DecreaseMaxHP(float Amount);
@@ -28,11 +31,11 @@ public:
 	void DecreaseHP(float Amount);
 
 private:
-	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, meta = (AllowPrivateAccess = "true"))
-	float WalkSpeed;
-	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, category = "Stat", meta = (AllowPrivateAccess = "true"))
+	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, category = "Status", meta = (AllowPrivateAccess = "true"))
+	float MoveSpeed;
+	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, category = "Status", meta = (AllowPrivateAccess = "true"))
 	float MaxHP;
-	UPROPERTY(VisibleInstanceOnly, BlueprintReadOnly, category = "Stat", meta = (AllowPrivateAccess = "true"))
+	UPROPERTY(VisibleInstanceOnly, BlueprintReadOnly, category = "Status", meta = (AllowPrivateAccess = "true"))
 	float HP;
 
 // 상태 관련
@@ -40,5 +43,6 @@ public:
 	bool GetIsDead();
 	virtual void OnDeath();
 private:
+	UPROPERTY(VisibleInstanceOnly, BlueprintReadOnly, category = "State", meta = (AllowPrivateAccess = "true"))
 	bool bIsDead;
 };

--- a/Source/RogShop/Character/RSDunPlayerCharacter.cpp
+++ b/Source/RogShop/Character/RSDunPlayerCharacter.cpp
@@ -55,6 +55,10 @@ ARSDunPlayerCharacter::ARSDunPlayerCharacter()
     AIPerceptionStimuliSourceComp = CreateDefaultSubobject<UAIPerceptionStimuliSourceComponent>(TEXT("AIPerceptionStimuliSource"));
     AIPerceptionStimuliSourceComp->bAutoRegister = true;
     AIPerceptionStimuliSourceComp->RegisterForSense(UAISense_Sight::StaticClass());
+
+    // 스탯
+    AttackPower = 0.f;
+    AttackSpeed = 1.f;
 }
 
 // Called when the game starts or when spawned
@@ -338,4 +342,39 @@ void ARSDunPlayerCharacter::InteractTrace()
         DrawDebugLine(GetWorld(), Start, End, FColor::Red, false, 1.0f, 0, 2.0f);
         InteractActor = nullptr;
     }
+}
+
+float ARSDunPlayerCharacter::GetAttackPower() const
+{
+    return AttackPower;
+}
+
+void ARSDunPlayerCharacter::IncreaseAttackPower(float Amount)
+{
+    float NewAttackPower = AttackPower + Amount;
+    AttackPower = Amount;
+}
+
+void ARSDunPlayerCharacter::DecreaseAttackPower(float Amount)
+{
+    float NewAttackPower = AttackPower - Amount;
+    AttackPower = NewAttackPower;
+}
+
+float ARSDunPlayerCharacter::GetAttackSpeed() const
+{
+    return AttackSpeed;
+}
+
+void ARSDunPlayerCharacter::IncreaseAttackSpeed(float Amount)
+{
+    float NewAttackSpeed = AttackSpeed + Amount;
+    AttackSpeed = NewAttackSpeed;
+}
+
+void ARSDunPlayerCharacter::DecreaseAttackSpeed(float Amount)
+{
+    // 애니메이션의 재생 속도가 음수값이 된다면 애니메이션이 역재생 되므로, 예외처리
+    float NewAttackSpeed = FMath::Max(AttackSpeed - Amount, 0.0f);
+    AttackSpeed = NewAttackSpeed;
 }

--- a/Source/RogShop/Character/RSDunPlayerCharacter.h
+++ b/Source/RogShop/Character/RSDunPlayerCharacter.h
@@ -90,4 +90,21 @@ private:
 private:
 	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "AI", meta = (AllowPrivateAccess = true))
 	TObjectPtr<UAIPerceptionStimuliSourceComponent> AIPerceptionStimuliSourceComp;
+
+// ½ºÅÈ °ü·Ã
+public:
+	float GetAttackPower() const;
+	void IncreaseAttackPower(float Amount);
+	void DecreaseAttackPower(float Amount);
+
+	float GetAttackSpeed() const;
+	void IncreaseAttackSpeed(float Amount);
+	void DecreaseAttackSpeed(float Amount);
+
+private:
+	UPROPERTY(VisibleInstanceOnly, BlueprintReadOnly, category = "Status", meta = (AllowPrivateAccess = "true"))
+	float AttackPower;
+
+	UPROPERTY(VisibleInstanceOnly, BlueprintReadOnly, category = "Status", meta = (AllowPrivateAccess = "true"))
+	float AttackSpeed;
 };


### PR DESCRIPTION
https://github.com/NbcampUnreal/2nd-Team1-Final-Project/issues/95

플레이어 캐릭터 스탯 개념 구현

- 체력
- 이동속도
- 공격속도
- 캐릭터 공격력, 무기 공격력
  - 무기 공격력의 경우 무기가 가집니다.

체력, 공격속도, 공격력은 Increase, Decrease함수로 값을 변경하도록 했습니다.  
체력 및 공격 속도의 경우 값의 범위를 지정해주었습니다.

공격 속도는 공격 애니메이션 재생시 사용합니다.
기존에 공격 애니메이션을 재생시키던 로직에 적용했습니다.

이동 속도의 값 변경시 바로 캐릭터의 이동속도를 변경시키도록 함수를 구현했습니다.