### PR TITLE
[BugFix] 무브먼트 컴포넌트의 MaxWalkSpeed의 값 변경 수정

### DIFF
--- a/Source/RogShop/Character/RSDunBaseCharacter.cpp
+++ b/Source/RogShop/Character/RSDunBaseCharacter.cpp
@@ -5,12 +5,12 @@
 #include "GameFramework/CharacterMovementComponent.h"
 
 ARSDunBaseCharacter::ARSDunBaseCharacter()
-{
-	GetCharacterMovement()->MaxWalkSpeed = MoveSpeed;
-
+{	
 	MoveSpeed = 600.f;
 	MaxHP = 100.f;
 	HP = MaxHP;
+
+	GetCharacterMovement()->MaxWalkSpeed = MoveSpeed;
 
 	bIsDead = false;
 }


### PR DESCRIPTION
변수 값이 변경 되기 전에 무브먼트 컴포넌트의 MaxWalkSpeed의 값 변경됐고, 해당 문제로 인해 캐릭터의 이동속도가 0이었습니다.

로직 순서를 변경하며 버그를 해결했습니다.