### PR TITLE
[Add] 레벨 이동을 위한 액터 구현

### DIFF
--- a/Content/Blueprints/Actor/BP_InteractableLevelTravel.uasset
+++ b/Content/Blueprints/Actor/BP_InteractableLevelTravel.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:363d1424742fad849252c69e98fec169fbd65f0c12fe04fb073d45ade60b6bcd
+size 33227

--- a/Source/RogShop/Actor/RSInteractableLevelTravel.cpp
+++ b/Source/RogShop/Actor/RSInteractableLevelTravel.cpp
@@ -1,0 +1,44 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "RSInteractableLevelTravel.h"
+#include "Kismet/GameplayStatics.h"
+
+// Sets default values
+ARSInteractableLevelTravel::ARSInteractableLevelTravel()
+{
+ 	// Set this actor to call Tick() every frame.  You can turn this off to improve performance if you don't need it.
+	PrimaryActorTick.bCanEverTick = false;
+
+	SceneComp = CreateDefaultSubobject<USceneComponent>(TEXT("Scene"));
+	SetRootComponent(SceneComp);
+
+	MeshComp = CreateDefaultSubobject<UStaticMeshComponent>(TEXT("StaticMesh"));
+	MeshComp->SetupAttachment(SceneComp);
+	MeshComp->SetCollisionProfileName("Interactable");
+}
+
+// Called when the game starts or when spawned
+void ARSInteractableLevelTravel::BeginPlay()
+{
+	Super::BeginPlay();
+	
+}
+
+// Called every frame
+void ARSInteractableLevelTravel::Tick(float DeltaTime)
+{
+	Super::Tick(DeltaTime);
+
+}
+
+void ARSInteractableLevelTravel::Interact(ARSDunPlayerCharacter* Interactor)
+{
+	if (TargetLevel.Get())
+	{
+		// TODO : 레벨을 이동하기 전에 세이브 처리가 필요하다.
+		FString AssetName = TargetLevel->GetName();
+		FName LevelName = FName(*AssetName);
+		UGameplayStatics::OpenLevel(GetWorld(), LevelName);
+	}
+}

--- a/Source/RogShop/Actor/RSInteractableLevelTravel.h
+++ b/Source/RogShop/Actor/RSInteractableLevelTravel.h
@@ -1,0 +1,42 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GameFramework/Actor.h"
+#include "RSInteractable.h"
+#include "RSInteractableLevelTravel.generated.h"
+
+UCLASS()
+class ROGSHOP_API ARSInteractableLevelTravel : public AActor, public IRSInteractable
+{
+	GENERATED_BODY()
+	
+public:	
+	// Sets default values for this actor's properties
+	ARSInteractableLevelTravel();
+
+protected:
+	// Called when the game starts or when spawned
+	virtual void BeginPlay() override;
+
+public:	
+	// Called every frame
+	virtual void Tick(float DeltaTime) override;
+
+// 상호작용
+public:
+	virtual void Interact(ARSDunPlayerCharacter* Interactor) override;
+
+// 레벨 이동
+private:
+	UPROPERTY(EditInstanceOnly, BlueprintReadOnly, Category = "Level", meta = (AllowPrivateAccess = true))
+	TWeakObjectPtr<UWorld> TargetLevel;
+
+// 컴포넌트
+private:
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Component", meta = (AllowPrivateAccess = true))
+	TObjectPtr<USceneComponent> SceneComp;
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Component", meta = (AllowPrivateAccess = true))
+	TObjectPtr<UStaticMeshComponent> MeshComp;	// 임시, 나중에 나이아가라 등으로 대체될 수 있다.
+};


### PR DESCRIPTION
상호작용을 통해 레벨을 이동하는 액터 추가

소프트 레퍼런스로 저장하면 로직이 좀 더 복잡하고, 레벨의 수가 많지 않기 때문에 메모리에 항상 로드되어있어도 문제가 되지 않을 것 으로 판단된다.

간단한 로직으로 레벨의 이동을 빠르게 구현하기 위해서 레벨을 하드 레퍼런스로 저장합니다.
나중에 필요한 경우 소프트 레퍼런스로 전환하고자 합니다.

하드 레퍼런스를 사용했을 때 참조된 레벨에서 참조중인 액터가 있는 레벨로 이동할 때 에러가 나면서 프로그램이 터지는 문제가 있었습니다.
메모리 문제인 것 같기 때문에 TWeakObjectPtr을 사용했고, 문제는 해결했습니다.

나중에 레벨 이동 전에 세이브하는 기능이 필요합니다.