### PR TITLE
[Update] 거점 레벨 추가 및 게임모드 추가와 기존 레벨 이동 액터 버그 수정

### DIFF
--- a/Content/Blueprints/GameMode/BP_BaseAreaGameMode.uasset
+++ b/Content/Blueprints/GameMode/BP_BaseAreaGameMode.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6ccd421b1ef264e36d9f29872c89dd68991bd454076fff1619c212ae82d50ca9
+size 21386

--- a/Content/Maps/BaseAreaMap.umap
+++ b/Content/Maps/BaseAreaMap.umap
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e7a18c56a982c767ec4c6da055b54d8fa580549e4269440872bd04cab324bea7
+size 49987

--- a/Source/RogShop/Actor/RSInteractableLevelTravel.cpp
+++ b/Source/RogShop/Actor/RSInteractableLevelTravel.cpp
@@ -34,11 +34,29 @@ void ARSInteractableLevelTravel::Tick(float DeltaTime)
 
 void ARSInteractableLevelTravel::Interact(ARSDunPlayerCharacter* Interactor)
 {
-	if (TargetLevel.Get())
+	// TODO : 레벨을 이동하기 전에 세이브 처리가 필요하다.
+
+	if (TargetLevelAsset.IsValid())
 	{
-		// TODO : 레벨을 이동하기 전에 세이브 처리가 필요하다.
-		FString AssetName = TargetLevel->GetName();
-		FName LevelName = FName(*AssetName);
+		// 로드된 경우
+
+		FStringAssetReference AssetRef = TargetLevelAsset.ToSoftObjectPath();
+		FString LevelPath = AssetRef.ToString();
+		FName LevelName = FName(*FPackageName::GetShortName(LevelPath));
 		UGameplayStatics::OpenLevel(GetWorld(), LevelName);
+	}
+	else if (TargetLevelAsset.IsNull() == false)
+	{
+		// 아직 로드되지 않았을 경우
+		
+		// 패키지 경로 예시: /Game/Maps/MyLevel
+		FString LevelPackagePath = TargetLevelAsset.ToSoftObjectPath().GetLongPackageName();
+
+		if (!LevelPackagePath.IsEmpty())
+		{
+			// 레벨 이름만 추출
+			FName LevelName = FName(*FPackageName::GetShortName(LevelPackagePath));
+			UGameplayStatics::OpenLevel(GetWorld(), LevelName);
+		}
 	}
 }

--- a/Source/RogShop/Actor/RSInteractableLevelTravel.h
+++ b/Source/RogShop/Actor/RSInteractableLevelTravel.h
@@ -31,7 +31,7 @@ public:
 // 레벨 이동
 private:
 	UPROPERTY(EditInstanceOnly, BlueprintReadOnly, Category = "Level", meta = (AllowPrivateAccess = true))
-	TWeakObjectPtr<UWorld> TargetLevel;
+	TSoftObjectPtr<UWorld> TargetLevelAsset;
 
 // 컴포넌트
 private:

--- a/Source/RogShop/GameModeBase/RSBaseAreaGameModeBase.cpp
+++ b/Source/RogShop/GameModeBase/RSBaseAreaGameModeBase.cpp
@@ -1,0 +1,5 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "RSBaseAreaGameModeBase.h"
+

--- a/Source/RogShop/GameModeBase/RSBaseAreaGameModeBase.h
+++ b/Source/RogShop/GameModeBase/RSBaseAreaGameModeBase.h
@@ -1,0 +1,17 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GameFramework/GameModeBase.h"
+#include "RSBaseAreaGameModeBase.generated.h"
+
+/**
+ * 
+ */
+UCLASS()
+class ROGSHOP_API ARSBaseAreaGameModeBase : public AGameModeBase
+{
+	GENERATED_BODY()
+	
+};


### PR DESCRIPTION
거점 레벨 추가

- BaseAreaMap

거점 레벨을 위한 게임모드 추가

- RSBaseAreaGameModeBase
- BP_RSBaseAreaGameMode

기존 레벨 이동 액터에서 레벨을 TWeakObjectPtr을 사용했는데, 참조가 사라지는 문제가 있어서 TSoftObjectPtr을 사용했습니다.
이에 따라 레벨을 이동하기 위해 참조된 애셋의 이름을 가져오는 로직을 수정하였습니다.