### PR TITLE
[Feature] 던전(숲) 보스 몬스터 1마리의 공격, 죽음 애니메이션 구현

### DIFF
--- a/Content/Assets/CarnivorousPlant/AnimMontage/AM_BossFlower_Attack1.uasset
+++ b/Content/Assets/CarnivorousPlant/AnimMontage/AM_BossFlower_Attack1.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4e0a8610b2b42bd68f32ad3c44acc4d0cca9f17355794948f717c23e9e07d7c0
+size 10449

--- a/Content/Assets/CarnivorousPlant/AnimMontage/AM_BossFlower_Death.uasset
+++ b/Content/Assets/CarnivorousPlant/AnimMontage/AM_BossFlower_Death.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2b006108ddc8a673eda99488ab94adf524b14484cb23d465d657ebafac802e42
+size 9870

--- a/Content/Blueprints/AnimInstance/ABP_RSDunBossFlowerAnim.uasset
+++ b/Content/Blueprints/AnimInstance/ABP_RSDunBossFlowerAnim.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5f26dcfa4ee920ceb05600eed80bab364618d1e4944d7a69a9a340390c8dd26c
+size 70769

--- a/Content/Blueprints/Characters/BP_RSDunBossFlowerCharacter.uasset
+++ b/Content/Blueprints/Characters/BP_RSDunBossFlowerCharacter.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:31d217de202c2b1b2cbd6de540cc6866e552a6b88bb0c2448c7cc231a1eed7b0
+size 37906

--- a/Content/Blueprints/Characters/BP_RSDunBossWormCharacter.uasset
+++ b/Content/Blueprints/Characters/BP_RSDunBossWormCharacter.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a73d2e3cb0f38bb68e7d942e6d8539a64ab4cb7c65d9dbdd6441f2fe8a12b469
+size 23818

--- a/Source/RogShop/Character/Monster/RSDunBossFlowerCharacter.cpp
+++ b/Source/RogShop/Character/Monster/RSDunBossFlowerCharacter.cpp
@@ -1,0 +1,26 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "RSDunBossFlowerCharacter.h"
+
+ARSDunBossFlowerCharacter::ARSDunBossFlowerCharacter()
+{
+}
+
+void ARSDunBossFlowerCharacter::PlayBaseAttackAnim()
+{
+	PlayAnimMontage(BaseAttackMontage);
+	UE_LOG(LogTemp, Warning, TEXT("BossFlower Attack Success!!"));
+}
+
+void ARSDunBossFlowerCharacter::PlayHitReactAnim()
+{
+	PlayAnimMontage(HitReactMontage);
+	UE_LOG(LogTemp, Warning, TEXT("BossFlower HitReact Success!!"));
+}
+
+void ARSDunBossFlowerCharacter::PlayDeathAnim()
+{
+	PlayAnimMontage(DeathMontage);
+	UE_LOG(LogTemp, Warning, TEXT("BossFlower Death Success!!"));
+}

--- a/Source/RogShop/Character/Monster/RSDunBossFlowerCharacter.h
+++ b/Source/RogShop/Character/Monster/RSDunBossFlowerCharacter.h
@@ -1,0 +1,24 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "RSDunMonsterCharacter.h"
+#include "RSDunBossFlowerCharacter.generated.h"
+
+/**
+ * 
+ */
+UCLASS()
+class ROGSHOP_API ARSDunBossFlowerCharacter : public ARSDunMonsterCharacter
+{
+	GENERATED_BODY()
+	
+public:
+	ARSDunBossFlowerCharacter();
+
+	void PlayBaseAttackAnim() override;
+	void PlayHitReactAnim() override;
+	void PlayDeathAnim() override;
+
+};

--- a/Source/RogShop/Character/Monster/RSDunBossWormCharacter.cpp
+++ b/Source/RogShop/Character/Monster/RSDunBossWormCharacter.cpp
@@ -1,0 +1,26 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "RSDunBossWormCharacter.h"
+
+ARSDunBossWormCharacter::ARSDunBossWormCharacter()
+{
+}
+
+void ARSDunBossWormCharacter::PlayBaseAttackAnim()
+{
+	PlayAnimMontage(BaseAttackMontage);
+	UE_LOG(LogTemp, Warning, TEXT("BossWorm Attack Success!!"));
+}
+
+void ARSDunBossWormCharacter::PlayHitReactAnim()
+{
+	PlayAnimMontage(HitReactMontage);
+	UE_LOG(LogTemp, Warning, TEXT("BossWorm HitReact Success!!"));
+}
+
+void ARSDunBossWormCharacter::PlayDeathAnim()
+{
+	PlayAnimMontage(DeathMontage);
+	UE_LOG(LogTemp, Warning, TEXT("BossWorm Death Success!!"));
+}

--- a/Source/RogShop/Character/Monster/RSDunBossWormCharacter.h
+++ b/Source/RogShop/Character/Monster/RSDunBossWormCharacter.h
@@ -1,0 +1,24 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "RSDunMonsterCharacter.h"
+#include "RSDunBossWormCharacter.generated.h"
+
+/**
+ * 
+ */
+UCLASS()
+class ROGSHOP_API ARSDunBossWormCharacter : public ARSDunMonsterCharacter
+{
+	GENERATED_BODY()
+
+public:
+	ARSDunBossWormCharacter();
+
+	void PlayBaseAttackAnim() override;
+	void PlayHitReactAnim() override;
+	void PlayDeathAnim() override;
+
+};

--- a/Source/RogShop/CheatManager/RSCheatManager.cpp
+++ b/Source/RogShop/CheatManager/RSCheatManager.cpp
@@ -16,6 +16,7 @@ URSCheatManager::URSCheatManager()
     MonsterMap.Add("bossspiderqueen", LoadClass<AActor>(nullptr, TEXT("/Game/Blueprints/Characters/BP_RSDunBossSpiderQueenCharacter.BP_RSDunBossSpiderQueenCharacter_C")));
     MonsterMap.Add("boar", LoadClass<AActor>(nullptr, TEXT("/Game/Blueprints/Characters/BP_RSDunBoarCharacter.BP_RSDunBoarCharacter_C")));
     MonsterMap.Add("skeleton", LoadClass<AActor>(nullptr, TEXT("/Game/Blueprints/Characters/BP_RSDunSkeletonCharacter.BP_RSDunSkeletonCharacter_C")));
+    MonsterMap.Add("bossflower", LoadClass<AActor>(nullptr, TEXT("/Game/Blueprints/Characters/BP_RSDunBossFlowerCharacter.BP_RSDunBossFlowerCharacter_C")));
    
 }
 


### PR DESCRIPTION
- #108 

## 던전(숲) 보스 몬스터 1마리의 공격, 죽음 구현 [완료]
- 공격, 죽음은 애님 몽타주 연결 및 함수 구현
- Idle 상태는 각 몬스터의 애님 인스턴스를 상속 받는 애니메이션 블루프린트의 애님 그래프에서 StateMachine을 활용해 구현
- 사막 보스는 수,목요일 저녁까지 알집 파일로 올려주신다고 확인 받음.
- 그래서 숲 보스인 거대 꽃만 일단 구현함.