### PR TITLE
[Bugfix] 무기 슬롯 시스템에 있던 버그 수정

### DIFF
--- a/Source/RogShop/ActorComponent/RSPlayerWeaponComponent.h
+++ b/Source/RogShop/ActorComponent/RSPlayerWeaponComponent.h
@@ -12,9 +12,9 @@ class ARSBaseWeapon;
 UENUM(BlueprintType)
 enum class EWeaponSlot : uint8
 {
+	NONE,
 	FirstWeaponSlot,
 	SecondWeaponSlot,
-	NONE
 };
 
 UCLASS( ClassGroup=(Custom), meta=(BlueprintSpawnableComponent) )
@@ -52,7 +52,7 @@ private:
 	TArray<TObjectPtr<ARSBaseWeapon>> WeaponActors; // 무기 액터
 
 	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Weapon", meta = (AllowPrivateAccess = true))
-	EWeaponSlot WeaponSlot;
+	EWeaponSlot WeaponSlot;	// 1-based, 현재 장착중인 무기 슬롯을 의미한다.
 
 	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Weapon", meta = (AllowPrivateAccess = true))
 	int32 WeaponSlotSize;	// 최대 슬롯 수


### PR DESCRIPTION
EWeaponSlot을 0-based에서 1-based로 변경하며, 변경된 값에 따라 로직을 수정했습니다.

Enum class의 0번 값은 NONE으로 사용하기로 정했기 때문에 해당 값들을 변경해주었습니다.

다음과 같은 상황에서의 버그를 수정해주었습니다.

- 무기 슬롯은 가득 찼고, 착용 중인 무기가 없을 때 추가적으로 무기를 획득하는 경우
- 장착하려는 슬롯에 무기가 없는 경우
- 장착하려는 슬롯이 이미 장착 중인 경우

위의 버그는 조건식을 사용하여 해결했습니다.