### PR TITLE
[Update] 플레이어 캐릭터 상호작용 LineTraceSingleByChannel에서 OverlapMultiByChannel로 변경

### DIFF
--- a/Source/RogShop/Character/RSDunPlayerCharacter.cpp
+++ b/Source/RogShop/Character/RSDunPlayerCharacter.cpp
@@ -8,12 +8,14 @@
 #include "GameFramework/CharacterMovementComponent.h"
 #include "Camera/CameraComponent.h"
 #include "Kismet/KismetMathLibrary.h"
+#include "Kismet/KismetSystemLibrary.h"
 #include "Components/CapsuleComponent.h"
 #include "RSPlayerWeaponComponent.h"
 #include "RSInteractable.h"
 #include "DrawDebugHelpers.h"
 #include "Perception/AIPerceptionStimuliSourceComponent.h"
 #include "Perception/AISense_Sight.h"
+#include "Engine/OverlapResult.h"
 
 // Sets default values
 ARSDunPlayerCharacter::ARSDunPlayerCharacter()
@@ -49,7 +51,7 @@ ARSDunPlayerCharacter::ARSDunPlayerCharacter()
 
     // 상호작용
     InteractActor = nullptr;
-    InteractDistance = 200.f;
+    InteractRadius = 200.f;
 
     // AI퍼셉션 자극 소스
     AIPerceptionStimuliSourceComp = CreateDefaultSubobject<UAIPerceptionStimuliSourceComponent>(TEXT("AIPerceptionStimuliSource"));
@@ -310,44 +312,96 @@ URSPlayerWeaponComponent* ARSDunPlayerCharacter::GetRSPlayerWeaponComponent()
 
 void ARSDunPlayerCharacter::InteractTrace()
 {
-    FVector Start = GetActorLocation();
-    FVector ForwardVector = GetActorForwardVector();
-    FVector End = Start + (ForwardVector * InteractDistance);
+    // 캐릭터를 중심으로 사용할 위치 선정
+    FVector Center = GetActorLocation();
 
-    FHitResult Hit;
+    // 무시할 액터, 자기 자신은 제외
     FCollisionQueryParams Params;
     Params.AddIgnoredActor(this);
 
-    bool bHit = GetWorld()->LineTraceSingleByChannel(Hit, Start, End, ECC_GameTraceChannel1, Params);
+    // 오버랩된 액터를 저장할 배열
+    TArray<FOverlapResult> OutOverlaps;
+
+    // 캐릭터를 중심으로 반지름 크기의 구체를 사용해 InteractTrace 채널과 오버랩된 액터들을 탐색한다.
+    bool bHit = GetWorld()->OverlapMultiByChannel(OutOverlaps, Center, FQuat::Identity, ECC_GameTraceChannel1, FCollisionShape::MakeSphere(InteractRadius), Params);
     
-    if (bHit)
+    if (!bHit)
     {
-        AActor* HitActor = Hit.GetActor();
-        if (HitActor && HitActor->GetClass()->ImplementsInterface(URSInteractable::StaticClass()))
+        InteractActor = nullptr;
+        DrawDebugSphere(GetWorld(), Center, InteractRadius, 32, FColor::Red, false, 0.f, 0, 1.0f);
+        return;
+    }
+
+    FVector Forward = GetActorForwardVector();
+
+    // 전방 내에 있는 액터와 가장 가까이 있는 액터를 병행해서 계산한다.
+    AActor* ClosestInFront = nullptr;
+    float ClosestInFrontDist = TNumericLimits<float>::Max();
+
+    AActor* ClosestActor = nullptr;
+    float CosestActorDistance = TNumericLimits<float>::Max();
+
+    for (const FOverlapResult& Result : OutOverlaps)
+    {
+        AActor* Target = Result.GetActor();
+        if (!Target)
         {
-            IRSInteractable* Interactable = Cast<IRSInteractable>(HitActor);
+            continue;
+        }
+
+        // 대상 액터까지의 벡터 및 거리 계산
+        FVector ToTarget = Target->GetActorLocation() - Center;
+        float Distance = ToTarget.Size();
+        FVector DirToTarget = ToTarget.GetSafeNormal();
+
+        // 전방 벡터와의 내적으로 전방과의 각도 계산
+        float Dot = FVector::DotProduct(Forward, DirToTarget);
+        float Angle = FMath::RadiansToDegrees(FMath::Acos(Dot));
+
+        // 전방 내 혀용 각도 안에 있으며, 현재까지 가장 가까운 액터일 경우
+        if (Angle <= InteractAngle && Distance < ClosestInFrontDist)
+        {
+            ClosestInFront = Target;
+            ClosestInFrontDist = Distance;
+        }
+
+        // 전방 여부와 관계없이 가장 가까운 액터일 경우
+        if (Distance < CosestActorDistance)
+        {
+            ClosestActor = Target;
+            CosestActorDistance = Distance;
+        }
+    }
+
+    // 전방 또는 전체 액터 중 유효한 액터가 있는 경우
+    if (ClosestInFront || ClosestActor)
+    {
+        // 전방을 우선으로 사용한다.
+        AActor* TargetActor = (ClosestInFront != nullptr) ? ClosestInFront : ClosestActor;
+
+        // 대상 액터가 상호작용 인터페이스를 구현했는지 확인하고 구현했다면 저장한다.
+        if (TargetActor && TargetActor->GetClass()->ImplementsInterface(URSInteractable::StaticClass()))
+        {
+            IRSInteractable* Interactable = Cast<IRSInteractable>(TargetActor);
             if (Interactable)
             {
-                InteractActor = HitActor;
+                InteractActor = TargetActor;
 
-                DrawDebugLine(GetWorld(), Start, End, FColor::Green, false, 1.0f, 0, 2.0f);
+                DrawDebugSphere(GetWorld(), Center, InteractRadius, 32, FColor::Green, false, 0.f, 0, 1.0f);
             }
             else
             {
-                DrawDebugLine(GetWorld(), Start, End, FColor::Red, false, 1.0f, 0, 2.0f);
-                InteractActor = nullptr;
+                DrawDebugSphere(GetWorld(), Center, InteractRadius, 32, FColor::Red, false, 0.f, 0, 1.0f);
             }
         }
         else
         {
-            DrawDebugLine(GetWorld(), Start, End, FColor::Red, false, 1.0f, 0, 2.0f);
-            InteractActor = nullptr;
+            DrawDebugSphere(GetWorld(), Center, InteractRadius, 32, FColor::Red, false, 0.f, 0, 1.0f);
         }
     }
     else
     {
-        DrawDebugLine(GetWorld(), Start, End, FColor::Red, false, 1.0f, 0, 2.0f);
-        InteractActor = nullptr;
+        DrawDebugSphere(GetWorld(), Center, InteractRadius, 32, FColor::Red, false, 0.f, 0, 1.0f);
     }
 }
 

--- a/Source/RogShop/Character/RSDunPlayerCharacter.h
+++ b/Source/RogShop/Character/RSDunPlayerCharacter.h
@@ -84,7 +84,8 @@ private:
 
 private:
 	AActor* InteractActor;	// 라인트레이스를 통해 찾은 상호작용 가능한 액터
-	float InteractDistance;	// 라인트레이스를 할 거리
+	float InteractRadius;	// 라인트레이스를 할 거리(반지름)
+	float InteractAngle;	// 플레이어가 가장 먼저 상호작용 할 액터를 찾을 각도
 
 // AI퍼셉션 자극 소스
 private:


### PR DESCRIPTION
#93 

기존 플레이어 캐릭터는 라인 트레이스를 사용하여 충돌된 액터를 찾는데, 다른 액터의 충돌체 크기가 너무 작은 경우 충돌되지 않는다는 문제가 발생했기 때문에 변경했습니다.

OverlapMultiByChannel함수를 사용하여 캐릭터를 중심으로 원 모양으로 충돌을 체크합니다.

첫 번째로 전방 방향 중 가장 가까운 액터와 상호작용 합니다.
두 번째로 전방 방향 중 가장 가까운 액터가 없을 때 오버랩 된 액터 중 가장 가까운 액터와 상호작용 합니다.

이 방법으로 라인 트레이스의 충돌 문제를 해결했고, 플레이어 캐릭터가 액터를 정확하게 바라보지 않아도 상호작용을 할 수 있게 됐습니다.
이로 인해 플레이하는 유저의 입장에서 편의성이 증가할 것을 예상합니다.