### PR TITLE
[Add] 몬스터가 죽었을 때 드랍될 아이템 액터 구현

### DIFF
--- a/Content/Blueprints/Actor/Dungeon/BP_DungeonGroundItem.uasset
+++ b/Content/Blueprints/Actor/Dungeon/BP_DungeonGroundItem.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f42917072b32278253a3c053dc88c60921e9c8ef983d361fecd0ad570dcc2366
+size 33264

--- a/Source/RogShop/Actor/Dungeon/RSDungeonGroundItem.cpp
+++ b/Source/RogShop/Actor/Dungeon/RSDungeonGroundItem.cpp
@@ -1,0 +1,60 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "RSDungeonGroundItem.h"
+#include "RogShop/UtilDefine.h"
+#include "Components/BoxComponent.h"
+
+// Sets default values
+ARSDungeonGroundItem::ARSDungeonGroundItem()
+{
+ 	// Set this actor to call Tick() every frame.  You can turn this off to improve performance if you don't need it.
+	PrimaryActorTick.bCanEverTick = false;
+
+	SceneComp = CreateDefaultSubobject<USceneComponent>(TEXT("Scene"));
+	SetRootComponent(SceneComp);
+
+	MeshComp = CreateDefaultSubobject<UStaticMeshComponent>(TEXT("StaticMesh"));
+	MeshComp->SetupAttachment(SceneComp);
+	MeshComp->SetCollisionProfileName(TEXT("Interactable"));
+	MeshComp->SetCollisionEnabled(ECollisionEnabled::NoCollision);
+}
+
+// Called when the game starts or when spawned
+void ARSDungeonGroundItem::BeginPlay()
+{
+	Super::BeginPlay();
+	
+}
+
+void ARSDungeonGroundItem::InitItemInfo(FName NewDataTableKey, UStaticMesh* NewMesh)
+{
+	if (!NewMesh)
+	{
+		RS_LOG_C("Invalid StaticMesh Used", FColor::Red);
+	}
+
+	DataTableKey = NewDataTableKey;
+
+	MeshComp->SetStaticMesh(NewMesh);
+
+	MeshComp->SetCollisionEnabled(ECollisionEnabled::QueryAndPhysics);
+}
+
+void ARSDungeonGroundItem::Interact(ARSDunPlayerCharacter* Interactor)
+{
+	if (!Interactor)
+	{
+		return;
+	}
+
+	// TODO : 플레이어의 인벤토리에 아이템을 추가하는 로직 작성
+	//플레이어인벤토리컴포넌트* 변수명 = Interactor->Get플레이어인벤토리컴포넌트();
+	//if (널체크)
+	//{
+	//	플레이어 인벤토리 컴포넌트->인벤토리에 아이템 추가하는 함수 호출;
+	// 
+	//	Destroy();
+	//}
+}
+

--- a/Source/RogShop/Actor/Dungeon/RSDungeonGroundItem.h
+++ b/Source/RogShop/Actor/Dungeon/RSDungeonGroundItem.h
@@ -1,0 +1,41 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GameFramework/Actor.h"
+#include "RSInteractable.h"
+#include "RSDungeonGroundItem.generated.h"
+
+UCLASS()
+class ROGSHOP_API ARSDungeonGroundItem : public AActor, public IRSInteractable
+{
+	GENERATED_BODY()
+	
+public:	
+	// Sets default values for this actor's properties
+	ARSDungeonGroundItem();
+
+protected:
+	// Called when the game starts or when spawned
+	virtual void BeginPlay() override;
+
+// 해당 엑터의 메시 세팅 및 상호작용에 필요한 변수 세팅
+	void InitItemInfo(FName NewDataTableKey, UStaticMesh* NewMesh);
+
+// 상호작용
+public:
+	virtual void Interact(ARSDunPlayerCharacter* Interactor) override;
+
+	// 컴포넌트
+private:
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Component", meta = (AllowPrivateAccess = true))
+	TObjectPtr<USceneComponent> SceneComp;
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Component", meta = (AllowPrivateAccess = true))
+	TObjectPtr<UStaticMeshComponent> MeshComp;
+
+	// 데이터 테이블의 RowName을 ID값으로 사용한다.
+private:
+	FName DataTableKey;
+
+};


### PR DESCRIPTION
#109 

데이터 테이블의 RowName을 FName으로 저장하거나 데이터 테이블에 정의된 StaticMesh로 액터를 세팅한다는 점이 ARSInteractableWeapon 클래스와 비슷한 로직을 가진다.

또한, 상호작용을 한다는 점이 같기 때문에 후에 리팩토링 할 경우 공통된 부모를 가지도록 상속 관계를 변경할 예정

후에 인벤토리 구현시 플레이어 캐릭터의 인벤토리로 들어갈 수 있도록 로직을 구현해야합니다..
이때, 인벤토리에 액터를 저장하지 않고, 액터의 FName을 저장하여 UI에서는 데이터 테이블에 접근해서 필요한 변수를 가져와 UI를 세팅할 수 있도록 구현해야합니다.