### PR TITLE
[Add] 던전 플레이어 캐릭터의 재료 인벤토리 구현

### DIFF
--- a/Source/RogShop/Actor/Dungeon/RSDungeonGroundItem.h
+++ b/Source/RogShop/Actor/Dungeon/RSDungeonGroundItem.h
@@ -21,6 +21,7 @@ protected:
 	virtual void BeginPlay() override;
 
 // 해당 엑터의 메시 세팅 및 상호작용에 필요한 변수 세팅
+public:
 	void InitItemInfo(FName NewDataTableKey, UStaticMesh* NewMesh);
 
 // 상호작용

--- a/Source/RogShop/ActorComponent/RSBaseInventoryComponent.cpp
+++ b/Source/RogShop/ActorComponent/RSBaseInventoryComponent.cpp
@@ -1,0 +1,96 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "RSBaseInventoryComponent.h"
+#include "RogShop/UtilDefine.h"
+#include "RogShop/GameInstanceSubsystem/RSDataSubsystem.h"
+#include "RogShop/DataTable/CookFoodData.h"
+
+URSBaseInventoryComponent::URSBaseInventoryComponent()
+{
+	PrimaryComponentTick.bCanEverTick = false;
+
+	SlotMaxSize = 5;
+}
+
+
+void URSBaseInventoryComponent::BeginPlay()
+{
+	Super::BeginPlay();
+
+	LoadItemData();
+	
+}
+
+void URSBaseInventoryComponent::AddItem(FName ItemKey, int32 Amount)
+{
+	if (GetFilledSize() >= GetSlotMaxSize() && !ItemMap.Contains(ItemKey))
+	{
+		RS_LOG_C("인벤토리가 가득 찼습니다", FColor::Red)
+		
+		return;
+	}
+
+	if (CheckValidItem(ItemKey))
+	{
+		ItemMap.Add(ItemKey, Amount);
+	}
+	else
+	{
+		RS_LOG_C("아이템 추가를 실패했습니다", FColor::Red);
+	}
+}
+
+void URSBaseInventoryComponent::RemoveItem(FName ItemKey, int32 Amount)
+{
+	if (CheckValidItem(ItemKey))
+	{
+		if (!ItemMap.Contains(ItemKey))
+		{
+			ItemMap.Add(ItemKey, 0);
+		}
+
+		ItemMap[ItemKey] -= Amount;
+
+		if (ItemMap[ItemKey] < 0)
+		{
+			ItemMap.Remove(ItemKey);
+		}
+	}
+	else
+	{
+		RS_LOG_C("아이템 삭제를 실패했습니다", FColor::Red);
+	}
+}
+
+int32 URSBaseInventoryComponent::GetAmount(const FName& ItemKey)
+{
+	return ItemMap.Contains(ItemKey) ? ItemMap[ItemKey] : INDEX_NONE;
+}
+
+void URSBaseInventoryComponent::SaveItemData()
+{
+	// TODO : 가지고 있는 음식 파일 세이브
+}
+
+void URSBaseInventoryComponent::LoadItemData()
+{
+	// TODO : 가지고 있는 음식 파일 로드
+}
+
+bool URSBaseInventoryComponent::CheckValidItem(const FName& ItemKey)
+{
+	URSDataSubsystem* Data = GetWorld()->GetGameInstance()->GetSubsystem<URSDataSubsystem>();
+
+	if (FCookFoodData* Row = Data->Food->FindRow<FCookFoodData>(ItemKey, TEXT("Contains FoodData")))
+	{
+		return true;
+	}
+
+	if (FIngredientData* Row = Data->Ingredient->FindRow<FIngredientData>(ItemKey, TEXT("Contains IngredientData")))
+	{
+		return true;
+	}
+
+	return false;
+}

--- a/Source/RogShop/ActorComponent/RSBaseInventoryComponent.cpp
+++ b/Source/RogShop/ActorComponent/RSBaseInventoryComponent.cpp
@@ -43,18 +43,20 @@ void URSBaseInventoryComponent::AddItem(FName ItemKey, int32 Amount)
 
 void URSBaseInventoryComponent::RemoveItem(FName ItemKey, int32 Amount)
 {
+	// 키가 유효한지 확인
 	if (CheckValidItem(ItemKey))
 	{
-		if (!ItemMap.Contains(ItemKey))
+		// 인벤토리에 들어있는 경우
+		if (ItemMap.Contains(ItemKey))
 		{
-			ItemMap.Add(ItemKey, 0);
-		}
+			// 아이템 개수만큼 제거
+			ItemMap[ItemKey] -= Amount;
 
-		ItemMap[ItemKey] -= Amount;
-
-		if (ItemMap[ItemKey] < 0)
-		{
-			ItemMap.Remove(ItemKey);
+			// 개수가 0 이하인 경우 맵에서 데이터 제거
+			if (ItemMap[ItemKey] <= 0)
+			{
+				ItemMap.Remove(ItemKey);
+			}
 		}
 	}
 	else
@@ -81,11 +83,6 @@ void URSBaseInventoryComponent::LoadItemData()
 bool URSBaseInventoryComponent::CheckValidItem(const FName& ItemKey)
 {
 	URSDataSubsystem* Data = GetWorld()->GetGameInstance()->GetSubsystem<URSDataSubsystem>();
-
-	if (FCookFoodData* Row = Data->Food->FindRow<FCookFoodData>(ItemKey, TEXT("Contains FoodData")))
-	{
-		return true;
-	}
 
 	if (FIngredientData* Row = Data->Ingredient->FindRow<FIngredientData>(ItemKey, TEXT("Contains IngredientData")))
 	{

--- a/Source/RogShop/ActorComponent/RSBaseInventoryComponent.h
+++ b/Source/RogShop/ActorComponent/RSBaseInventoryComponent.h
@@ -1,0 +1,50 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Components/ActorComponent.h"
+#include "RSBaseInventoryComponent.generated.h"
+
+
+UCLASS( ClassGroup=(Custom), meta=(BlueprintSpawnableComponent) )
+class ROGSHOP_API URSBaseInventoryComponent : public UActorComponent
+{
+	GENERATED_BODY()
+
+public:	
+	URSBaseInventoryComponent();
+
+protected:
+	virtual void BeginPlay() override;
+
+// 데이터 관리
+public:
+	UFUNCTION(BlueprintCallable, Category = "Inventory")
+	void AddItem(FName ItemKey, int32 Amount = 1);
+
+	UFUNCTION(BlueprintCallable, Category = "Inventory")
+	void RemoveItem(FName ItemKey, int32 Amount = 1);
+
+	int32 GetAmount(const FName& ItemKey);
+	const TMap<FName, int32>& GetItems() const { return ItemMap; }
+	int32 GetFilledSize() const { return ItemMap.Num(); }	//현재 채워진 인벤토리 크기
+	int32 GetSlotMaxSize() const { return SlotMaxSize; }	//인벤토리 크기
+
+protected:
+	bool CheckValidItem(const FName& ItemKey); //유효한 키값인지 검사
+
+protected:
+	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	TMap<FName, int32> ItemMap; //가지고 있는 아이템들
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	int32 SlotMaxSize; //인벤토리의 최대 크기
+
+// 세이브/로드
+public:
+	void SaveItemData();
+
+private:
+	void LoadItemData();
+};

--- a/Source/RogShop/ActorComponent/RSDungeonInventoryComponent.cpp
+++ b/Source/RogShop/ActorComponent/RSDungeonInventoryComponent.cpp
@@ -1,0 +1,44 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "RSDungeonInventoryComponent.h"
+#include "RogShop/UtilDefine.h"
+#include "RSDungeonGroundItem.h"
+#include "GameFramework/Character.h"
+#include "RSDataSubsystem.h"
+#include "DungeonItemData.h"
+
+void URSDungeonInventoryComponent::DropItem(FName ItemKey)
+{
+	// TODO : 인벤토리에 있는 아이템이 땅에 버려지도록 구현해야한다.
+
+	if (CheckValidItem(ItemKey))
+	{
+		if (ItemMap.Contains(ItemKey))
+		{
+			ACharacter* CurCharacter = GetOwner<ACharacter>();
+			if (CurCharacter)
+			{
+				ARSDungeonGroundItem* DungeonGroundItem = GetWorld()->SpawnActor<ARSDungeonGroundItem>(ARSDungeonGroundItem::StaticClass(), CurCharacter->GetActorTransform());
+
+				FDungeonItemData* Data = CurCharacter->GetGameInstance()->GetSubsystem<URSDataSubsystem>()->Ingredient->FindRow<FDungeonItemData>(ItemKey, TEXT("Get Ingredient"));
+
+				if (Data)
+				{
+					UStaticMesh* ItemStaticMesh = Data->ItemStaticMesh;
+
+					if (DungeonGroundItem && ItemStaticMesh)
+					{
+						DungeonGroundItem->InitItemInfo(ItemKey, ItemStaticMesh);
+
+						RemoveItem(ItemKey, ItemMap[ItemKey]);
+
+						return;
+					}
+				}
+			}
+		}
+	}
+
+	RS_LOG_C("아이템 드랍에 실패했습니다.", FColor::Red);
+}

--- a/Source/RogShop/ActorComponent/RSDungeonInventoryComponent.h
+++ b/Source/RogShop/ActorComponent/RSDungeonInventoryComponent.h
@@ -1,0 +1,19 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "RSBaseInventoryComponent.h"
+#include "RSDungeonInventoryComponent.generated.h"
+
+/**
+ * 
+ */
+UCLASS()
+class ROGSHOP_API URSDungeonInventoryComponent : public URSBaseInventoryComponent
+{
+	GENERATED_BODY()
+	
+public:
+	void DropItem(FName ItemKey);
+};

--- a/Source/RogShop/ActorComponent/RSTycoonInventoryComponent.cpp
+++ b/Source/RogShop/ActorComponent/RSTycoonInventoryComponent.cpp
@@ -15,83 +15,8 @@ URSTycoonInventoryComponent::URSTycoonInventoryComponent()
 	PrimaryComponentTick.bCanEverTick = false;
 }
 
-void URSTycoonInventoryComponent::AddItem(FName ItemKey, int32 Amount)
-{
-	if (GetFilledSize() >= GetSize())
-	{
-		RS_LOG_C("인벤토리가 가득 찼습니다", FColor::Red)
-		return;
-	}
-
-	if (CheckValidItem(ItemKey))
-	{
-		ItemMap.Add(ItemKey, Amount);
-	}
-	else
-	{
-		RS_LOG_C("아이템 추가를 실패했습니다", FColor::Red);
-	}
-}
-
-void URSTycoonInventoryComponent::RemoveItem(FName ItemKey, int32 Amount)
-{
-	if (CheckValidItem(ItemKey))
-	{
-		if (!ItemMap.Contains(ItemKey))
-		{
-			ItemMap.Add(ItemKey, 0);
-		}
-
-		ItemMap[ItemKey] -= Amount;
-
-		if (ItemMap[ItemKey] < 0)
-		{
-			ItemMap.Remove(ItemKey);
-		}
-	}
-	else
-	{
-		RS_LOG_C("아이템 삭제를 실패했습니다", FColor::Red);
-	}
-}
-
-int32 URSTycoonInventoryComponent::GetAmount(const FName& ItemKey)
-{
-	return ItemMap.Contains(ItemKey) ? ItemMap[ItemKey] : INDEX_NONE;
-}
-
 void URSTycoonInventoryComponent::BeginPlay()
 {
 	Super::BeginPlay();
 
-	LoadItemData();
-
-	// Widget = CreateWidget(GetWorld()->GetFirstPlayerController(), WidgetType);
-}
-
-void URSTycoonInventoryComponent::LoadItemData()
-{
-	//가지고 있는 음식 파일 로드
-}
-
-bool URSTycoonInventoryComponent::CheckValidItem(const FName& ItemKey)
-{
-	URSDataSubsystem* Data = GetWorld()->GetGameInstance()->GetSubsystem<URSDataSubsystem>();
-
-	if (FCookFoodData* Row = Data->Food->FindRow<FCookFoodData>(ItemKey, TEXT("Contains FoodData")))
-	{
-		return true;
-	}
-
-	if (FIngredientData* Row = Data->Ingredient->FindRow<FIngredientData>(ItemKey, TEXT("Contains IngredientData")))
-	{
-		return true;
-	}
-
-	return false;
-}
-
-void URSTycoonInventoryComponent::SaveItemData()
-{
-	//가지고 있는 음식 파일 세이브
 }

--- a/Source/RogShop/ActorComponent/RSTycoonInventoryComponent.h
+++ b/Source/RogShop/ActorComponent/RSTycoonInventoryComponent.h
@@ -3,47 +3,19 @@
 #pragma once
 
 #include "CoreMinimal.h"
-#include "Components/ActorComponent.h"
+#include "RSBaseInventoryComponent.h"
 #include "RSTycoonInventoryComponent.generated.h"
 
 
 UCLASS(ClassGroup=(Custom), meta=(BlueprintSpawnableComponent))
-class ROGSHOP_API URSTycoonInventoryComponent : public UActorComponent
+class ROGSHOP_API URSTycoonInventoryComponent : public URSBaseInventoryComponent
 {
 	GENERATED_BODY()
 
 public:
 	URSTycoonInventoryComponent();
 
-	UFUNCTION(BlueprintCallable, Category="Inventory")
-	void AddItem(FName ItemKey, int32 Amount = 1);
-	
-	UFUNCTION(BlueprintCallable, Category="Inventory")
-	void RemoveItem(FName ItemKey, int32 Amount = 1);
-
-	void SaveItemData();
-
-	int32 GetAmount(const FName& ItemKey);
-	const TMap<FName, int32>& GetItems() const { return ItemMap; }
-	int32 GetFilledSize() const { return ItemMap.Num(); }	//현재 채워진 인벤토리 크기
-	int32 GetSize() const { return Size; }					//인벤토리 크기
-
 protected:
 	virtual void BeginPlay() override;
 
-private:
-	void LoadItemData();
-	bool CheckValidItem(const FName& ItemKey); //유효한 키값인지 검사
-
-protected:
-	UPROPERTY(EditAnywhere, BlueprintReadWrite)
-	TMap<FName, int32> ItemMap; //가지고 있는 아이템들
-
-	UPROPERTY(EditAnywhere, BlueprintReadWrite)
-	int32 Size = 5; //인벤토리의 최대 크기
-
-	UPROPERTY(EditDefaultsOnly)
-	TSubclassOf<UUserWidget> WidgetType;
-
-	TObjectPtr<UUserWidget> Widget;
 };

--- a/Source/RogShop/Character/RSDunPlayerCharacter.cpp
+++ b/Source/RogShop/Character/RSDunPlayerCharacter.cpp
@@ -11,6 +11,7 @@
 #include "Kismet/KismetSystemLibrary.h"
 #include "Components/CapsuleComponent.h"
 #include "RSPlayerWeaponComponent.h"
+#include "RSDungeonInventoryComponent.h"
 #include "RSInteractable.h"
 #include "DrawDebugHelpers.h"
 #include "Perception/AIPerceptionStimuliSourceComponent.h"
@@ -48,6 +49,9 @@ ARSDunPlayerCharacter::ARSDunPlayerCharacter()
 
     // 무기 컴포넌트
     WeaponComp = CreateDefaultSubobject<URSPlayerWeaponComponent>(TEXT("RSPlayerWeapon"));
+
+    // 인벤토리 컴포넌트
+    InventoryComp = CreateDefaultSubobject<URSDungeonInventoryComponent>(TEXT("RSPlayerInventory"));
 
     // 상호작용
     InteractActor = nullptr;
@@ -308,6 +312,11 @@ void ARSDunPlayerCharacter::SecondWeaponSlot(const FInputActionValue& value)
 URSPlayerWeaponComponent* ARSDunPlayerCharacter::GetRSPlayerWeaponComponent()
 {
     return WeaponComp;
+}
+
+URSDungeonInventoryComponent* ARSDunPlayerCharacter::GetRSDungeonInventoryComponent()
+{
+    return InventoryComp;
 }
 
 void ARSDunPlayerCharacter::InteractTrace()

--- a/Source/RogShop/Character/RSDunPlayerCharacter.h
+++ b/Source/RogShop/Character/RSDunPlayerCharacter.h
@@ -9,6 +9,7 @@
 class USpringArmComponent;
 class UCameraComponent;
 class URSPlayerWeaponComponent;
+class URSDungeonInventoryComponent;
 class UAIPerceptionStimuliSourceComponent;
 
 struct FInputActionValue;
@@ -77,6 +78,14 @@ public:
 private:
 	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Weapon", meta = (AllowPrivateAccess = true))
 	TObjectPtr<URSPlayerWeaponComponent> WeaponComp;
+
+// 인벤토리 관련
+public:
+	URSDungeonInventoryComponent* GetRSDungeonInventoryComponent();
+
+private:
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Inventory", meta = (AllowPrivateAccess = true))
+	TObjectPtr<URSDungeonInventoryComponent> InventoryComp;
 
 // 상호작용 관련
 private:

--- a/Source/RogShop/RogShop.Build.cs
+++ b/Source/RogShop/RogShop.Build.cs
@@ -29,6 +29,7 @@ public class RogShop : ModuleRules
             Path.Combine(ModuleDirectory, "Interface"),
             Path.Combine(ModuleDirectory, "DataTable"),
             Path.Combine(ModuleDirectory, "Object", "Relic"),
+            Path.Combine(ModuleDirectory, "GameInstanceSubsystem"),
         });
 
         PublicDependencyModuleNames.AddRange(new string[] { "Core", "CoreUObject", "Engine", "InputCore", "EnhancedInput", "AIModule", "NavigationSystem", "DeveloperSettings" });


### PR DESCRIPTION
#32 

플레이어의 인벤토리를 구현한다.

인벤토리의 슬롯은 5개
인벤토리의 슬롯에는 재료 아이템이 들어가게 되며, 같은 재료 아이템을 먹었을 경우 기존에 있던 슬롯에서 개수가 증가하도록 구현했습니다.
재료 아이템을 버릴 수 있습니다.
인벤토리에 들어있는 아이템을 제거하는 함수도 구현했습니다.

인벤토리 클래스는 컴포넌트로 구현했습니다.
타이쿤에서 김영웅님이 준비해준 인벤토리 컴포넌트를 기반으로 상속 관계를 구현해서 타이쿤과 던전 인벤토리를 분리하여 구현했습니다.

UI는 구현되지 않은 상태입니다.