### PR TITLE
[Update] 구매 또는 상호작용으로 획득하는 무기에 대해서 던전 메인 UI 무기 슬롯 이미지까지 일치하도록 수정

### DIFF
--- a/Content/Datas/DungeonWeaponDataTable.uasset
+++ b/Content/Datas/DungeonWeaponDataTable.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:25e73ab97a8e519e0b0f858681df25464863cecc7448921bb400a0855aea2f98
-size 13754
+oid sha256:c12fcf047916505030f8761888ccb6385d2b1accd7a7ef9d046a25f8192d236e
+size 18760

--- a/Source/RogShop/ActorComponent/RSPlayerWeaponComponent.cpp
+++ b/Source/RogShop/ActorComponent/RSPlayerWeaponComponent.cpp
@@ -10,6 +10,7 @@
 #include "RogShop/GameInstanceSubsystem/RSDataSubsystem.h"
 #include "DungeonItemData.h"
 #include "RSInteractableWeapon.h"
+#include "RSDunPlayerController.h"
 
 // Sets default values for this component's properties
 URSPlayerWeaponComponent::URSPlayerWeaponComponent()
@@ -164,6 +165,22 @@ void URSPlayerWeaponComponent::EquipWeaponToSlot(ARSBaseWeapon* NewWeaponActor)
 			FAttachmentTransformRules AttachmentRules(EAttachmentRule::SnapToTarget, true);
 			NewWeaponActor->AttachToComponent(SkeletalMeshComp, AttachmentRules, FName("Weapon_Hand_r"));
 		}
+	}
+
+	// 무기 이미지 장착한 무기로 변경
+	FName NewWeaponKey = NewWeaponActor->GetDataTableKey();
+
+	FDungeonItemData* NewWeaponData = CurCharacter->GetGameInstance()->GetSubsystem<URSDataSubsystem>()->Weapon->FindRow<FDungeonItemData>(NewWeaponKey, TEXT("Get NewWeaponData"));
+
+	if (NewWeaponData)
+	{
+		ARSDunPlayerController* PC = Cast<ARSDunPlayerController>(UGameplayStatics::GetPlayerController(this, 0));
+
+		PC->OnWeaponSlotChange.Broadcast(static_cast<uint8>(WeaponSlot), NewWeaponData->ItemIcon);
+	}
+	else
+	{
+		RS_LOG("NewWeaponData Error")
 	}
 
 	// 현재 비어있는 무기 슬롯이 있을 경우 비어있는 슬롯에 우선적으로 채운다.

--- a/Source/RogShop/Controller/RSDunPlayerController.cpp
+++ b/Source/RogShop/Controller/RSDunPlayerController.cpp
@@ -16,8 +16,13 @@ void ARSDunPlayerController::BeginPlay()
     Super::BeginPlay();
 
     AddMapping();
-
+    
     ShowRSDunMainWidget();
+
+    if (RSDunMainWidget)
+    {
+        OnWeaponSlotChange.AddDynamic(RSDunMainWidget, &URSDunMainWidget::UpdateWeaponSlot);
+    }
 }
 
 void ARSDunPlayerController::AddMapping()

--- a/Source/RogShop/Controller/RSDunPlayerController.h
+++ b/Source/RogShop/Controller/RSDunPlayerController.h
@@ -10,6 +10,8 @@
 class UInputMappingContext;
 class UInputAction;
 
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_TwoParams(FOnWeaponSlotChange, uint8, SlotIndex, UTexture2D*, NewIcon);
+
 UCLASS()
 class ROGSHOP_API ARSDunPlayerController : public APlayerController
 {
@@ -20,12 +22,14 @@ public:
 
 	virtual void BeginPlay() override;
 
-public:
 	void AddMapping();
 
 	void RemoveAllMapping();
 
 	void ShowRSDunMainWidget();
+
+	UPROPERTY(BlueprintAssignable)
+	FOnWeaponSlotChange OnWeaponSlotChange;
 
 public:
 	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = "Input")

--- a/Source/RogShop/Widget/DunShop/DunItemWidget.cpp
+++ b/Source/RogShop/Widget/DunShop/DunItemWidget.cpp
@@ -165,8 +165,6 @@ bool UDunItemWidget::BuyItem()
             {
                 SpawnedWeapon->SetDataTableKey(CurrentRowName);
                 WeaponComp->EquipWeaponToSlot(SpawnedWeapon);
-
-                PC->RSDunMainWidget->UpdateWeaponImage(ItemData.Icon);
             }
             else
             {

--- a/Source/RogShop/Widget/Dungeon/RSDunMainWidget.cpp
+++ b/Source/RogShop/Widget/Dungeon/RSDunMainWidget.cpp
@@ -16,31 +16,26 @@ void URSDunMainWidget::NativeConstruct()
     UpdateMaxHP();
 }
 
-void URSDunMainWidget::UpdateWeaponImage(UTexture2D* NewWeaponImage)
+void URSDunMainWidget::UpdateWeaponSlot(uint8 index, UTexture2D* NewWeaponImage)
 {
     if (WeaponSlot1->Brush.GetResourceObject() == nullptr)
     {
         WeaponSlot1->SetBrushFromTexture(NewWeaponImage);
     }
-    else if(WeaponSlot2->Brush.GetResourceObject() == nullptr)
+    else if (WeaponSlot2->Brush.GetResourceObject() == nullptr)
     {
         WeaponSlot2->SetBrushFromTexture(NewWeaponImage);
     }
     else
     {
-        UE_LOG(LogTemp, Warning, TEXT("Both weapon slots are full!"));
-    }
-}
-
-void URSDunMainWidget::UpdateWeaponSlot(bool bIsFirst, UTexture2D* NewWeaponImage)
-{
-    if (bIsFirst)
-    {
-        WeaponSlot1->SetBrushFromTexture(NewWeaponImage);
-    }
-    else // 2번째 무기 슬롯
-    {
-        WeaponSlot2->SetBrushFromTexture(NewWeaponImage);
+        if (index == 1)
+        {
+            WeaponSlot1->SetBrushFromTexture(NewWeaponImage);
+        }
+        else // 2 또는 0, 현재 아무것도 착용 안한 0의 상태일때 2번째 무기가 바뀜
+        {
+            WeaponSlot2->SetBrushFromTexture(NewWeaponImage);
+        }
     }
 }
 

--- a/Source/RogShop/Widget/Dungeon/RSDunMainWidget.h
+++ b/Source/RogShop/Widget/Dungeon/RSDunMainWidget.h
@@ -18,10 +18,7 @@ public:
     virtual void NativeConstruct() override;
 
     UFUNCTION(BlueprintCallable)
-    void UpdateWeaponImage(UTexture2D* NewWeaponImage);
-
-    UFUNCTION(BlueprintCallable)
-    void UpdateWeaponSlot(bool bIsFirst, UTexture2D* NewWeaponImage);
+    void UpdateWeaponSlot(uint8 index, UTexture2D* NewWeaponImage);
 
     UFUNCTION(BlueprintCallable)
     void UpdateHP();


### PR DESCRIPTION
- #89 

- 플레이어가 장착하는 무기에 따라 던전 메인 UI 무기 슬롯에 표시되는 이미지도 동기화될 수 있도록 구현
- DungeonWeaponDataTable에 필요 내용 및 이미지 추가
- PC에 델리게이트 선언 후 RSPlayerWeaponComponent에서 브로드캐스트를 통하여 무기 이미지 수정