### PR TITLE
[Update] 던전 메인 UI의 슬롯 부분이 갱신 될 수 있도록 컨트롤러와 컴포넌트 수정

### DIFF
--- a/Source/RogShop/ActorComponent/RSPlayerWeaponComponent.cpp
+++ b/Source/RogShop/ActorComponent/RSPlayerWeaponComponent.cpp
@@ -7,9 +7,10 @@
 #include "RSDunPlayerCharacter.h"
 #include "Kismet/GameplayStatics.h"
 #include "Components/BoxComponent.h"
-#include "RogShop/GameInstanceSubsystem/RSDataSubsystem.h"
+#include "RSDataSubsystem.h"
 #include "DungeonItemData.h"
 #include "RSInteractableWeapon.h"
+#include "RSDunPlayerController.h"
 
 // Sets default values for this component's properties
 URSPlayerWeaponComponent::URSPlayerWeaponComponent()
@@ -212,11 +213,21 @@ void URSPlayerWeaponComponent::EquipWeaponToSlot(ARSBaseWeapon* NewWeaponActor)
 		// 기존에 장착하던 무기 제거
 		WeaponActors[Index]->Destroy();
 		WeaponActors[Index] = NewWeaponActor;
-		WeaponSlot = EWeaponSlot::NONE;
 
 		// 새로운 무기를 장착
-		EquipWeaponToCharacter(WeaponSlot);
+		EWeaponSlot TempWeaponSlot = WeaponSlot;
+		WeaponSlot = EWeaponSlot::NONE;
+		EquipWeaponToCharacter(TempWeaponSlot);
 	}
+
+	FName NewWeaponKey = NewWeaponActor->GetDataTableKey();
+
+	ARSDunPlayerController* PC = Cast<ARSDunPlayerController>(CurCharacter->GetController());
+
+	if (PC)
+	{
+		PC->OnWeaponSlotChange.Broadcast(static_cast<uint8>(WeaponSlot) - 1, NewWeaponKey);
+	}	
 }
 
 void URSPlayerWeaponComponent::EquipWeaponToCharacter(EWeaponSlot TargetWeaponSlot)

--- a/Source/RogShop/CheatManager/RSCheatManager.cpp
+++ b/Source/RogShop/CheatManager/RSCheatManager.cpp
@@ -163,9 +163,9 @@ void URSCheatManager::ShowRSDunMainWidget()
 {
     ARSDunPlayerController* PC = Cast<ARSDunPlayerController>(GetOuterAPlayerController());
 
-    if (PC && PC->RSDunMainWidget)
+    if (PC && PC->GetRSDunMainWidget())
     {
-        PC->RSDunMainWidget->AddToViewport();
+        PC->GetRSDunMainWidget()->AddToViewport();
     }
     else
     {

--- a/Source/RogShop/Controller/RSDunPlayerController.cpp
+++ b/Source/RogShop/Controller/RSDunPlayerController.cpp
@@ -17,7 +17,12 @@ void ARSDunPlayerController::BeginPlay()
 
     AddMapping();
 
-    ShowRSDunMainWidget();
+    InitializeRSDunMainWidget();
+
+    if (RSDunMainWidget)
+    {
+        //OnWeaponSlotChange.AddDynamic(RSDunMainWidget, &URSDunMainWidget::UpdateWeaponSlot);
+    }
 }
 
 void ARSDunPlayerController::AddMapping()
@@ -48,7 +53,7 @@ void ARSDunPlayerController::RemoveAllMapping()
     }
 }
 
-void ARSDunPlayerController::ShowRSDunMainWidget()
+void ARSDunPlayerController::InitializeRSDunMainWidget()
 {
     if (RSDunMainWidgetClass)
     {

--- a/Source/RogShop/Controller/RSDunPlayerController.h
+++ b/Source/RogShop/Controller/RSDunPlayerController.h
@@ -7,6 +7,8 @@
 #include "RSDunMainWidget.h"
 #include "RSDunPlayerController.generated.h"
 
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_TwoParams(FOnWeaponSlotChange, uint8, SlotIndex, FName, WeaponKey);
+
 class UInputMappingContext;
 class UInputAction;
 
@@ -25,7 +27,7 @@ public:
 
 	void RemoveAllMapping();
 
-	void ShowRSDunMainWidget();
+	void InitializeRSDunMainWidget();
 
 public:
 	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = "Input")
@@ -47,11 +49,20 @@ public:
 	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = "Input")
 	TObjectPtr<UInputAction> SecondWeaponSlotAction;
 
-	UPROPERTY()
+// 위젯
+public:
+	URSDunMainWidget* GetRSDunMainWidget() const { return RSDunMainWidget; }
+
+private:
+	// 블루프린트에서 지정할 수 있도록 TSubclassOf로 선언
+	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "UI", meta = (AllowPrivateAccess = true))
+	TSubclassOf<UUserWidget> RSDunMainWidgetClass;
+
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "UI", meta = (AllowPrivateAccess = true))
 	URSDunMainWidget* RSDunMainWidget;
 
-protected:
-	// 블루프린트에서 지정할 수 있도록 TSubclassOf로 선언
-	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "UI")
-	TSubclassOf<UUserWidget> RSDunMainWidgetClass;
+// 이벤트 디스패처
+public:
+	UPROPERTY(BlueprintAssignable)
+	FOnWeaponSlotChange OnWeaponSlotChange;	// WeaponSlot을 변경하는 시점
 };

--- a/Source/RogShop/Object/Relic/RSPlayerStatRelicEffect.cpp
+++ b/Source/RogShop/Object/Relic/RSPlayerStatRelicEffect.cpp
@@ -22,7 +22,7 @@ void URSPlayerStatRelicEffect::ApplyEffect(ARSDunPlayerCharacter* Player, ARSDun
 			}
 
 			Player->IncreaseMaxHP(FinalValue);
-			PC->RSDunMainWidget->UpdateMaxHP();
+			PC->GetRSDunMainWidget()->UpdateMaxHP();
 
 			break;
 		}

--- a/Source/RogShop/Widget/DunShop/DunItemWidget.cpp
+++ b/Source/RogShop/Widget/DunShop/DunItemWidget.cpp
@@ -123,7 +123,7 @@ bool UDunItemWidget::BuyItem()
             }
 
             PlayerChar->IncreaseHP(FinalValue);
-            PC->RSDunMainWidget->UpdateHP();
+            PC->GetRSDunMainWidget()->UpdateHP();
 
             break;
         }
@@ -166,7 +166,7 @@ bool UDunItemWidget::BuyItem()
                 SpawnedWeapon->SetDataTableKey(CurrentRowName);
                 WeaponComp->EquipWeaponToSlot(SpawnedWeapon);
 
-                PC->RSDunMainWidget->UpdateWeaponImage(ItemData.Icon);
+                PC->GetRSDunMainWidget()->UpdateWeaponImage(ItemData.Icon);
             }
             else
             {


### PR DESCRIPTION
플레이어 컨트롤러에서 UI에 대해 접근 제어자를 변경하고 UPROPERTY의 값을 변경해주었습니다.
이벤트 디스패처를 위해 델리게이트 변수를 추가해주었습니다.

해당 델리게이트는 UI의 갱신 시점에 바인딩된 함수를 호출합니다.

무기 슬롯의 데이터를 관리하는 컴포넌트에서 무기를 교체한 경우 델리게이트에 바인딩 된 함수를 호출합니다.
호출할 때 다음 값을 매개변수로 넘겨줍니다.

- 교체된 슬롯의 인덱스
- 데이터테이블에서 무기의 RowName

컴포넌트에서 무기 장착이 제대로 되지 않는 버그를 수정했습니다.