### PR TITLE
[Update] 플레이어 체력 또는 최대 체력 변경시 자동으로 던전 메인 UI 갱신될 수 있도록 수정

### DIFF
--- a/Source/RogShop/Character/RSDunBaseCharacter.h
+++ b/Source/RogShop/Character/RSDunBaseCharacter.h
@@ -23,12 +23,12 @@ public:
 	void ChangeMoveSpeed(float Amount);
 
 	float GetMaxHP() const;
-	void IncreaseMaxHP(float Amount);
-	void DecreaseMaxHP(float Amount);
+	virtual void IncreaseMaxHP(float Amount);
+	virtual void DecreaseMaxHP(float Amount);
 
 	float GetHP() const;
-	void IncreaseHP(float Amount);
-	void DecreaseHP(float Amount);
+	virtual void IncreaseHP(float Amount);
+	virtual void DecreaseHP(float Amount);
 
 private:
 	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, category = "Status", meta = (AllowPrivateAccess = "true"))

--- a/Source/RogShop/Character/RSDunPlayerCharacter.cpp
+++ b/Source/RogShop/Character/RSDunPlayerCharacter.cpp
@@ -310,6 +310,50 @@ void ARSDunPlayerCharacter::OnDeath()
     }
 }
 
+void ARSDunPlayerCharacter::IncreaseMaxHP(float Amount)
+{
+    Super::IncreaseMaxHP(Amount);
+
+    ARSDunPlayerController* PC = Cast<ARSDunPlayerController>(GetController());
+    if (PC)
+    {
+        PC->OnMaxHPChange.Broadcast();
+    }
+}
+
+void ARSDunPlayerCharacter::DecreaseMaxHP(float Amount)
+{
+    Super::DecreaseMaxHP(Amount);
+
+    ARSDunPlayerController* PC = Cast<ARSDunPlayerController>(GetController());
+    if (PC)
+    {
+        PC->OnMaxHPChange.Broadcast();
+    }
+}
+
+void ARSDunPlayerCharacter::IncreaseHP(float Amount)
+{
+    Super::IncreaseHP(Amount);
+
+    ARSDunPlayerController* PC = Cast<ARSDunPlayerController>(GetController());
+    if (PC)
+    {
+        PC->OnHPChange.Broadcast();
+    }
+}
+
+void ARSDunPlayerCharacter::DecreaseHP(float Amount)
+{
+    Super::DecreaseHP(Amount);
+
+    ARSDunPlayerController* PC = Cast<ARSDunPlayerController>(GetController());
+    if (PC)
+    {
+        PC->OnHPChange.Broadcast();
+    }
+}
+
 void ARSDunPlayerCharacter::Move(const FInputActionValue& value)
 {
     // ī�޶� ������ �����Ͽ� �Է¹��� �������� ĳ���� �̵�

--- a/Source/RogShop/Character/RSDunPlayerCharacter.h
+++ b/Source/RogShop/Character/RSDunPlayerCharacter.h
@@ -38,6 +38,11 @@ public:
 
 	void OnDeath();
 
+	virtual void IncreaseMaxHP(float Amount) override;
+	virtual void DecreaseMaxHP(float Amount) override;
+
+	virtual void IncreaseHP(float Amount) override;
+	virtual void DecreaseHP(float Amount) override;
 
 protected:
 	UFUNCTION()

--- a/Source/RogShop/Controller/RSDunPlayerController.cpp
+++ b/Source/RogShop/Controller/RSDunPlayerController.cpp
@@ -22,6 +22,8 @@ void ARSDunPlayerController::BeginPlay()
     if (RSDunMainWidget)
     {
         OnWeaponSlotChange.AddDynamic(RSDunMainWidget, &URSDunMainWidget::UpdateWeaponSlot);
+        OnHPChange.AddDynamic(RSDunMainWidget, &URSDunMainWidget::UpdateHP);
+        OnMaxHPChange.AddDynamic(RSDunMainWidget, &URSDunMainWidget::UpdateMaxHP);
     }
 }
 

--- a/Source/RogShop/Controller/RSDunPlayerController.h
+++ b/Source/RogShop/Controller/RSDunPlayerController.h
@@ -8,6 +8,8 @@
 #include "RSDunPlayerController.generated.h"
 
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_TwoParams(FOnWeaponSlotChange, uint8, SlotIndex, FName, WeaponKey);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE(FOnHPChange);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE(FOnMaxHPChange);
 
 class UInputMappingContext;
 class UInputAction;
@@ -65,4 +67,10 @@ private:
 public:
 	UPROPERTY(BlueprintAssignable)
 	FOnWeaponSlotChange OnWeaponSlotChange;	// WeaponSlot을 변경하는 시점
+
+	UPROPERTY(BlueprintAssignable)
+	FOnHPChange OnHPChange;
+
+	UPROPERTY(BlueprintAssignable)
+	FOnMaxHPChange OnMaxHPChange;
 };

--- a/Source/RogShop/Object/Relic/RSPlayerStatRelicEffect.cpp
+++ b/Source/RogShop/Object/Relic/RSPlayerStatRelicEffect.cpp
@@ -22,7 +22,6 @@ void URSPlayerStatRelicEffect::ApplyEffect(ARSDunPlayerCharacter* Player, ARSDun
 			}
 
 			Player->IncreaseMaxHP(FinalValue);
-			PC->GetRSDunMainWidget()->UpdateMaxHP();
 
 			break;
 		}

--- a/Source/RogShop/Widget/DunShop/DunItemWidget.cpp
+++ b/Source/RogShop/Widget/DunShop/DunItemWidget.cpp
@@ -123,7 +123,6 @@ bool UDunItemWidget::BuyItem()
             }
 
             PlayerChar->IncreaseHP(FinalValue);
-            PC->GetRSDunMainWidget()->UpdateHP();
 
             break;
         }


### PR DESCRIPTION
- #89 

- 플레이어의 체력 또는 최대 체력이 갱신될 때 플레이어 측에서 던전 메인 UI를 갱신할 수 있도록 로직 변경
- 플레이어 컨트롤러에 델리게이트 등록 후 플레이어가 해당 델리게이트를 사용하는 방식
- 기존에 수동으로 UI 업데이트 하는 부분 제거