### PR TITLE
[Add] 모듈식 캐릭터 메시 적용

### DIFF
--- a/Content/Assets/AdventurersKit/BodyA/Armor_01/SKM_BodyA_Armor_01.uasset
+++ b/Content/Assets/AdventurersKit/BodyA/Armor_01/SKM_BodyA_Armor_01.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b55ce266ccdba09eaf1b3351364df390fd78f3d210364367e5f7728acfbf2483
+oid sha256:1c96c7105ddc36731e6a4c9a126dca0bad578cb4e912e661937439c79c4f14d9
 size 1400503

--- a/Content/Assets/AdventurersKit/BodyA/Armor_01/SK_BodyA_Armor_01.uasset
+++ b/Content/Assets/AdventurersKit/BodyA/Armor_01/SK_BodyA_Armor_01.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4d08bbb3fa8a66cee5e362c4a19d65a61cb257741ec448d638121a84c3b2b1c1
-size 49235
+oid sha256:157dbee1129b9a1c5373bfc989c3d5ac36a1e5d6c700f251f59b66bd4cdc6367
+size 51834

--- a/Content/Blueprints/Characters/BP_DunPlayerCharacter.uasset
+++ b/Content/Blueprints/Characters/BP_DunPlayerCharacter.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c48fff161061fc77deacf03ff74061c0f9d170bc77980b7fcef5abc66f3f0065
-size 39302
+oid sha256:044b440928957389a7045d19c52ea4943fbdfc453d5d86b0f3cf05474c2983c5
+size 38832

--- a/RogShop.uproject
+++ b/RogShop.uproject
@@ -23,6 +23,10 @@
 			"TargetAllowList": [
 				"Editor"
 			]
+		},
+		{
+			"Name": "SkeletalMerging",
+			"Enabled": true
 		}
 	]
 }

--- a/Source/RogShop/Character/RSDunPlayerCharacter.cpp
+++ b/Source/RogShop/Character/RSDunPlayerCharacter.cpp
@@ -72,6 +72,9 @@ void ARSDunPlayerCharacter::BeginPlay()
 {
 	Super::BeginPlay();
 	
+    // ½ºÄÌ·¹Å» ¸Þ½Ã
+    USkeletalMesh* MergeSkeletalMesh = USkeletalMergingLibrary::MergeMeshes(SkeletalMeshMergeParams);
+    GetMesh()->SetSkeletalMeshAsset(MergeSkeletalMesh);
 }
 
 // Called every frame

--- a/Source/RogShop/Character/RSDunPlayerCharacter.h
+++ b/Source/RogShop/Character/RSDunPlayerCharacter.h
@@ -4,6 +4,7 @@
 
 #include "CoreMinimal.h"
 #include "RSDunBaseCharacter.h"
+#include "SkeletalMergingLibrary.h"
 #include "RSDunPlayerCharacter.generated.h"
 
 class USpringArmComponent;
@@ -61,6 +62,11 @@ protected:
 	void FirstWeaponSlot(const FInputActionValue& value);
 	UFUNCTION()
 	void SecondWeaponSlot(const FInputActionValue& value);
+
+// 스켈레탈 메시 관련
+private:
+	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "SkeletalMesh", meta = (AllowPrivateAccess = true))
+	FSkeletalMeshMergeParams SkeletalMeshMergeParams;
 
 // 카메라 관련
 private:

--- a/Source/RogShop/RogShop.Build.cs
+++ b/Source/RogShop/RogShop.Build.cs
@@ -32,7 +32,7 @@ public class RogShop : ModuleRules
             Path.Combine(ModuleDirectory, "GameInstanceSubsystem"),
         });
 
-        PublicDependencyModuleNames.AddRange(new string[] { "Core", "CoreUObject", "Engine", "InputCore", "EnhancedInput", "AIModule", "NavigationSystem", "DeveloperSettings" });
+        PublicDependencyModuleNames.AddRange(new string[] { "Core", "CoreUObject", "Engine", "InputCore", "EnhancedInput", "AIModule", "NavigationSystem", "DeveloperSettings", "SkeletalMerging" });
 
 		PrivateDependencyModuleNames.AddRange(new string[] {  });
 


### PR DESCRIPTION
- SkeletalMerging 플러그인 및 모듈 적용

플레이어 캐릭터에 FSkeletalMeshMergeParams 변수 추가
블루프린트 클래스에서 FSkeletalMeshMergeParams의 변수에 적용할 스켈레탈 메시와 본을 추가한다.

C++의 BeginPlay에서 USkeletalMergingLibrary::MergeMeshes함수를 호출하여 머지된 스켈레탈 메시를 생성하여 플레이어 캐릭터 메시에 적용한다.