### PR TITLE
[Update] 메인메뉴에서 거점으로 이동되도록 수정

### DIFF
--- a/Source/RogShop/Controller/RSDunPlayerController.cpp
+++ b/Source/RogShop/Controller/RSDunPlayerController.cpp
@@ -15,6 +15,13 @@ void ARSDunPlayerController::BeginPlay()
 {
     Super::BeginPlay();
 
+    // 마우스 커서를 감추고, Input모드를 게임온리로 변경
+    bShowMouseCursor = false;
+
+    FInputModeGameOnly InputMode;
+    SetInputMode(InputMode);
+
+    // 기본적인 입력 매핑 추가
     AddMapping();
 
     InitializeRSDunMainWidget();

--- a/Source/RogShop/Widget/MainMenu/MainMenuWidget.cpp
+++ b/Source/RogShop/Widget/MainMenu/MainMenuWidget.cpp
@@ -34,7 +34,7 @@ void UMainMenuWidget::NativeConstruct()
 
 void UMainMenuWidget::OnStartButtonClicked()
 {
-	//UGameplayStatics::OpenLevel(this, FName("다음레벨 이름"));
+	UGameplayStatics::OpenLevel(this, FName("BaseAreaMap"));
 }
 
 void UMainMenuWidget::OnLoadButtonClicked()


### PR DESCRIPTION
메인메뉴에서 거점으로 이동 할 때, 버튼의 클릭 이벤트를 사용합니다.

해당 이벤트에 바인딩 된 함수에서는 `UGameplayStatics::OpenLevel`을 사용합니다.

이동할 레벨 이름은 매직 스트링으로 하드 코딩 된 상태입니다.

레벨을 이동할 경우 마우스 커서를 안보이도록 하고, 입력 모드를 게임 온리로 변경합니다.