### PR TITLE
[Add] 유물 인벤토리 추가

### DIFF
--- a/Config/DefaultGame.ini
+++ b/Config/DefaultGame.ini
@@ -7,6 +7,7 @@ ProjectID=5CA3406745E67F59496430BF4BC3F3F5
 IngredientDataTable=/Game/Datas/IngredientDataTable.IngredientDataTable
 FoodDataTable=/Game/Datas/CookFoodDataTable.CookFoodDataTable
 WeaponDataTable=/Game/Datas/DungeonWeaponDataTable.DungeonWeaponDataTable
+RelicDataTable=/Game/Datas/DungeonRelicDataTable.DungeonRelicDataTable
 
 [/Script/UnrealEd.ProjectPackagingSettings]
 Build=IfProjectHasCode

--- a/Source/RogShop/ActorComponent/RSRelicInventoryComponent.cpp
+++ b/Source/RogShop/ActorComponent/RSRelicInventoryComponent.cpp
@@ -1,0 +1,47 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "RSRelicInventoryComponent.h"
+#include "RogShop/UtilDefine.h"
+#include "RSDataSubsystem.h"
+#include "DungeonItemData.h"
+
+URSRelicInventoryComponent::URSRelicInventoryComponent()
+{
+	PrimaryComponentTick.bCanEverTick = true;
+
+	// ...
+}
+
+
+void URSRelicInventoryComponent::BeginPlay()
+{
+	Super::BeginPlay();
+
+	// ...
+	
+}
+
+void URSRelicInventoryComponent::AddRelic(FName RelicKey)
+{
+	if (CheckValidRelicKey(RelicKey))
+	{
+		RelicList.Add(RelicKey);
+	}
+	else
+	{
+		RS_LOG_C("Failed to add item", FColor::Red);
+	}
+}
+
+bool URSRelicInventoryComponent::CheckValidRelicKey(const FName& RelicKey)
+{
+	URSDataSubsystem* Data = GetWorld()->GetGameInstance()->GetSubsystem<URSDataSubsystem>();
+
+	if (FDungeonItemData* Row = Data->Relic->FindRow<FDungeonItemData>(RelicKey, TEXT("Contains DungeonItemData")))
+	{
+		return true;
+	}
+
+	return false;
+}

--- a/Source/RogShop/ActorComponent/RSRelicInventoryComponent.h
+++ b/Source/RogShop/ActorComponent/RSRelicInventoryComponent.h
@@ -1,0 +1,40 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Components/ActorComponent.h"
+#include "RSRelicInventoryComponent.generated.h"
+
+
+UCLASS( ClassGroup=(Custom), meta=(BlueprintSpawnableComponent) )
+class ROGSHOP_API URSRelicInventoryComponent : public UActorComponent
+{
+	GENERATED_BODY()
+
+public:	
+	URSRelicInventoryComponent();
+
+protected:
+	virtual void BeginPlay() override;
+
+// 데이터 관리
+public:	
+	void AddRelic(FName RelicKey);
+
+	const TArray<FName> GetRelicList() const { return RelicList; }
+
+private:
+	bool CheckValidRelicKey(const FName& RelicKey);
+
+private:
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Relic", meta = (AllowPrivateAccess = true))
+	TArray<FName> RelicList;
+
+// 세이브/로드
+public:
+	void SaveRelicData();
+
+private:
+	void LoadRelicData();
+};

--- a/Source/RogShop/Character/RSDunPlayerCharacter.cpp
+++ b/Source/RogShop/Character/RSDunPlayerCharacter.cpp
@@ -11,6 +11,7 @@
 #include "Kismet/KismetSystemLibrary.h"
 #include "Components/CapsuleComponent.h"
 #include "RSPlayerWeaponComponent.h"
+#include "RSRelicInventoryComponent.h"
 #include "RSDungeonInventoryComponent.h"
 #include "RSInteractable.h"
 #include "DrawDebugHelpers.h"
@@ -49,6 +50,9 @@ ARSDunPlayerCharacter::ARSDunPlayerCharacter()
 
     // 무기 컴포넌트
     WeaponComp = CreateDefaultSubobject<URSPlayerWeaponComponent>(TEXT("RSPlayerWeapon"));
+
+    // 유물 컴포넌트
+    RelicInventoryComp = CreateDefaultSubobject<URSRelicInventoryComponent>(TEXT("RSRelicInventory"));
 
     // 인벤토리 컴포넌트
     InventoryComp = CreateDefaultSubobject<URSDungeonInventoryComponent>(TEXT("RSPlayerInventory"));

--- a/Source/RogShop/Character/RSDunPlayerCharacter.h
+++ b/Source/RogShop/Character/RSDunPlayerCharacter.h
@@ -10,6 +10,7 @@
 class USpringArmComponent;
 class UCameraComponent;
 class URSPlayerWeaponComponent;
+class URSRelicInventoryComponent;
 class URSDungeonInventoryComponent;
 class UAIPerceptionStimuliSourceComponent;
 
@@ -90,6 +91,14 @@ public:
 private:
 	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Weapon", meta = (AllowPrivateAccess = true))
 	TObjectPtr<URSPlayerWeaponComponent> WeaponComp;
+
+// 유물 관련
+public:
+	URSRelicInventoryComponent* GetURSRelicInventoryComponent() { return RelicInventoryComp; }
+
+private:
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Relic", meta = (AllowPrivateAccess = true))
+	TObjectPtr<URSRelicInventoryComponent> RelicInventoryComp;
 
 // 인벤토리 관련
 public:

--- a/Source/RogShop/DataTable/DungeonItemData.h
+++ b/Source/RogShop/DataTable/DungeonItemData.h
@@ -32,9 +32,6 @@ struct ROGSHOP_API FDungeonItemData : public FTableRowBase
 	
 public:
 	UPROPERTY(EditAnywhere, BlueprintReadWrite)
-	int32 ItemID;
-
-	UPROPERTY(EditAnywhere, BlueprintReadWrite)
 	EItemType ItemType;
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite)

--- a/Source/RogShop/GameInstanceSubsystem/RSDataSubsystem.cpp
+++ b/Source/RogShop/GameInstanceSubsystem/RSDataSubsystem.cpp
@@ -14,8 +14,10 @@ void URSDataSubsystem::Initialize(FSubsystemCollectionBase& Collection)
 	Food = DataSettings->FoodDataTable.LoadSynchronous();
 	Ingredient = DataSettings->IngredientDataTable.LoadSynchronous();
 	Weapon = DataSettings->WeaponDataTable.LoadSynchronous();
+	Relic = DataSettings->RelicDataTable.LoadSynchronous();
 
 	check(Food)
 	check(Ingredient)
 	check(Weapon)
+	check(Relic)
 }

--- a/Source/RogShop/GameInstanceSubsystem/RSDataSubsystem.h
+++ b/Source/RogShop/GameInstanceSubsystem/RSDataSubsystem.h
@@ -26,4 +26,7 @@ public:
 
 	UPROPERTY()
 	TObjectPtr<UDataTable> Weapon;
+
+	UPROPERTY()
+	TObjectPtr<UDataTable> Relic;
 };

--- a/Source/RogShop/RSDataSubsystemSettings.h
+++ b/Source/RogShop/RSDataSubsystemSettings.h
@@ -23,4 +23,7 @@ public:
 
 	UPROPERTY(Config, EditAnywhere)
 	TSoftObjectPtr<UDataTable> WeaponDataTable;
+
+	UPROPERTY(Config, EditAnywhere)
+	TSoftObjectPtr<UDataTable> RelicDataTable;
 };


### PR DESCRIPTION
RSDataSubsystemSettings 및 URSDataSubsystem에 Relic에 대한 데이터 테이블 추가했습니다.

유물을 관리할 인벤토리 클래스를 위해 액터 컴포넌트 사용합니다.
해당 액터 컴포넌트에서는 TArray를 사용합니다.

기본적으로 배열에 값을 추가할 함수와 주어진 키워드가 유효한지 확인하는 함수를 추가했습니다.

플레이어 캐릭터에서 해당 액터 컴포넌트를 가지도록 로직을 추가했습니다.

아이템 데이터 테이블에서 필요 없는 데이터를 제거했습니다.