### PR TITLE
[Add] 비주얼 스튜디오 기본 인코딩 설정 변경

### DIFF
--- a/Source/.editorconfig
+++ b/Source/.editorconfig
@@ -1,0 +1,4 @@
+root = true
+
+[*]
+charset = utf-8


### PR DESCRIPTION
.editorconfig 파일을 생성하여 utf-8이 되도록 설정했습니다.

.editorconfig 파일은 프로젝트 폴더의 Source 폴더에 위치합니다.