### PR TITLE
[Update] 기존 레벨 이동 로직을 게임 인스턴스에서 함수화하여 사용하도록 변경

### DIFF
--- a/Source/RogShop/Actor/RSInteractableLevelTravel.cpp
+++ b/Source/RogShop/Actor/RSInteractableLevelTravel.cpp
@@ -2,13 +2,11 @@
 
 
 #include "RSInteractableLevelTravel.h"
-#include "Kismet/GameplayStatics.h"
 #include "RSDunPlayerCharacter.h"
+#include "RSGameInstance.h"
 
-// Sets default values
 ARSInteractableLevelTravel::ARSInteractableLevelTravel()
 {
- 	// Set this actor to call Tick() every frame.  You can turn this off to improve performance if you don't need it.
 	PrimaryActorTick.bCanEverTick = false;
 
 	SceneComp = CreateDefaultSubobject<USceneComponent>(TEXT("Scene"));
@@ -19,46 +17,21 @@ ARSInteractableLevelTravel::ARSInteractableLevelTravel()
 	MeshComp->SetCollisionProfileName("Interactable");
 }
 
-// Called when the game starts or when spawned
 void ARSInteractableLevelTravel::BeginPlay()
 {
 	Super::BeginPlay();
 	
 }
 
-// Called every frame
-void ARSInteractableLevelTravel::Tick(float DeltaTime)
-{
-	Super::Tick(DeltaTime);
-
-}
-
 void ARSInteractableLevelTravel::Interact(ARSDunPlayerCharacter* Interactor)
 {
-	// TODO : ·¹º§À» ÀÌµ¿ÇÏ±â Àü¿¡ ¼¼ÀÌºê Ã³¸®°¡ ÇÊ¿äÇÏ´Ù.
+	// ë ˆë²¨ì„ ì´ë™í•˜ê¸° ì „ì— ì„¸ì´ë¸Œ ìš”ì²­ì„ ì˜ë¯¸í•˜ëŠ” ì´ë²¤íŠ¸ ë””ìŠ¤íŒ¨ì²˜ì— ë°”ì¸ë”© ëœ í•¨ìˆ˜ë¥¼ í˜¸ì¶œí•œë‹¤.
 	Interactor->OnSaveRequested.Broadcast();
 
-	if (TargetLevelAsset.IsValid())
+	// ë ˆë²¨ ì´ë™ í•¨ìˆ˜ í˜¸ì¶œ
+	URSGameInstance* RSGameInstance = Interactor->GetGameInstance<URSGameInstance>();
+	if (RSGameInstance)
 	{
-		// ·ÎµåµÈ °æ¿ì
-
-		FStringAssetReference AssetRef = TargetLevelAsset.ToSoftObjectPath();
-		FString LevelPath = AssetRef.ToString();
-		FName LevelName = FName(*FPackageName::GetShortName(LevelPath));
-		UGameplayStatics::OpenLevel(GetWorld(), LevelName);
-	}
-	else if (TargetLevelAsset.IsNull() == false)
-	{
-		// ¾ÆÁ÷ ·ÎµåµÇÁö ¾Ê¾ÒÀ» °æ¿ì
-		
-		// ÆÐÅ°Áö °æ·Î ¿¹½Ã: /Game/Maps/MyLevel
-		FString LevelPackagePath = TargetLevelAsset.ToSoftObjectPath().GetLongPackageName();
-
-		if (!LevelPackagePath.IsEmpty())
-		{
-			// ·¹º§ ÀÌ¸§¸¸ ÃßÃâ
-			FName LevelName = FName(*FPackageName::GetShortName(LevelPackagePath));
-			UGameplayStatics::OpenLevel(GetWorld(), LevelName);
-		}
+		RSGameInstance->TravelToLevel(TargetLevelAsset);
 	}
 }

--- a/Source/RogShop/Actor/RSInteractableLevelTravel.h
+++ b/Source/RogShop/Actor/RSInteractableLevelTravel.h
@@ -13,30 +13,24 @@ class ROGSHOP_API ARSInteractableLevelTravel : public AActor, public IRSInteract
 	GENERATED_BODY()
 	
 public:	
-	// Sets default values for this actor's properties
 	ARSInteractableLevelTravel();
 
 protected:
-	// Called when the game starts or when spawned
 	virtual void BeginPlay() override;
 
-public:	
-	// Called every frame
-	virtual void Tick(float DeltaTime) override;
-
-// »óÈ£ÀÛ¿ë
+// ìƒí˜¸ì‘ìš©
 public:
 	virtual void Interact(ARSDunPlayerCharacter* Interactor) override;
 
-// ·¹º§ ÀÌµ¿
+// ë ˆë²¨ ì´ë™
 private:
 	UPROPERTY(EditInstanceOnly, BlueprintReadOnly, Category = "Level", meta = (AllowPrivateAccess = true))
 	TSoftObjectPtr<UWorld> TargetLevelAsset;
 
-// ÄÄÆ÷³ÍÆ®
+// ì»´í¬ë„ŒíŠ¸
 private:
 	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Component", meta = (AllowPrivateAccess = true))
 	TObjectPtr<USceneComponent> SceneComp;
 	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Component", meta = (AllowPrivateAccess = true))
-	TObjectPtr<UStaticMeshComponent> MeshComp;	// ÀÓ½Ã, ³ªÁß¿¡ ³ªÀÌ¾Æ°¡¶ó µîÀ¸·Î ´ëÃ¼µÉ ¼ö ÀÖ´Ù.
+	TObjectPtr<UStaticMeshComponent> MeshComp;	// ì„ì‹œ, ë‚˜ì¤‘ì— ë‚˜ì´ì•„ê°€ë¼ ë“±ìœ¼ë¡œ ëŒ€ì²´ë  ìˆ˜ ìˆë‹¤.
 };

--- a/Source/RogShop/GameInstance/RSGameInstance.cpp
+++ b/Source/RogShop/GameInstance/RSGameInstance.cpp
@@ -2,4 +2,21 @@
 
 
 #include "RSGameInstance.h"
+#include "RogShop/UtilDefine.h"
+#include "Kismet/GameplayStatics.h"
 
+void URSGameInstance::TravelToLevel(const TSoftObjectPtr<UWorld>& TargetLevelAsset) const
+{
+	if (TargetLevelAsset.IsNull())
+	{
+		RS_LOG_C("TargetLevelAsset is Null", FColor::Red)
+		return;
+	}
+
+	// 패키지 경로 예시 -> /Game/Maps/MyLevel
+	FString LevelPath = TargetLevelAsset.ToSoftObjectPath().GetLongPackageName();
+
+	// 레벨 이름만 추출하고 이동
+	FName LevelName = FName(*FPackageName::GetShortName(LevelPath));
+	UGameplayStatics::OpenLevel(GetWorld(), LevelName);
+}

--- a/Source/RogShop/GameInstance/RSGameInstance.h
+++ b/Source/RogShop/GameInstance/RSGameInstance.h
@@ -15,5 +15,8 @@ class ROGSHOP_API URSGameInstance : public UGameInstance
 	GENERATED_BODY()
 	
 public:
+	void TravelToLevel(const TSoftObjectPtr<UWorld>& TargetLevelAsset) const;
+
+public:
 	TArray<FName> PurchasedItemIDs;
 };


### PR DESCRIPTION
기존에 ARSInteractableLevelTravel에서 사용하던 레벨 이동 로직을 URSGameInstance의 함수로 변경

기존 로직을 함수로 변경했으므로, 게임 인스턴스를 참조하여 함수를 호출하도록 로직 변경

함수로 변경하면서 기존 레벨 이동 로직을 최적화 하였습니다.

- UGameplayStatics::OpenLevel 함수는 레벨이 아직 로드되지 않았어도 패키지 경로가 유효하다면 자동으로 로딩하기 때문에 로딩 됐는지 확인하는 로직을 제거했습니다.
- 경로를 패키지 경로만 사용하도록 변경했습니다.
  - ToSoftObjectPath함수는 애셋에서 전체 경로를 가져오는데, toString()을 사용할 경우 확장자가 포함됩니다.
  - ToSoftObjectPath함수에 GetLongPackageName를 사용할 경우 확장자를 제거한 패키지의 전체 경로만 가져옵니다.