### PR TITLE
[Update] 기존 메인메뉴 레벨 이동 로직을 게임인스턴스의 함수로 변경

### DIFF
--- a/Content/Blueprints/Widgets/MainMenu/WBP_MainMenu.uasset
+++ b/Content/Blueprints/Widgets/MainMenu/WBP_MainMenu.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:be220618a67f8ff92aca3287ae19a3146c457169d65e0a555d12139be7827b09
-size 37198
+oid sha256:cfc034399ffc6064a25141e0ffe34d0f666de5453f47d02dd1c238c94ed57dc3
+size 37365

--- a/Source/RogShop/Widget/MainMenu/MainMenuWidget.cpp
+++ b/Source/RogShop/Widget/MainMenu/MainMenuWidget.cpp
@@ -5,6 +5,7 @@
 #include "Components/Button.h"
 #include "Kismet/GameplayStatics.h"
 #include "GameFramework/PlayerController.h"
+#include "RSGameInstance.h"
 
 
 void UMainMenuWidget::NativeConstruct()
@@ -34,12 +35,19 @@ void UMainMenuWidget::NativeConstruct()
 
 void UMainMenuWidget::OnStartButtonClicked()
 {
-	UGameplayStatics::OpenLevel(this, FName("BaseAreaMap"));
+	// TODO : ê¸°ì¡´ ì„¸ì´ë¸Œ ì œê±°
+
+	// ë ˆë²¨ ì´ë™
+	URSGameInstance* RSGameInstance = Cast<URSGameInstance>(GetWorld()->GetGameInstance());
+	if (RSGameInstance)
+	{
+		RSGameInstance->TravelToLevel(NewGameTargetLevelAsset);
+	}
 }
 
 void UMainMenuWidget::OnLoadButtonClicked()
 {
-	//UGameplayStatics::OpenLevel(this, FName("´ÙÀ½·¹º§ ÀÌ¸§"));
+	//UGameplayStatics::OpenLevel(this, FName("ë‹¤ìŒë ˆë²¨ ì´ë¦„"));
 }
 
 void UMainMenuWidget::OnOptionButtonClicked()

--- a/Source/RogShop/Widget/MainMenu/MainMenuWidget.h
+++ b/Source/RogShop/Widget/MainMenu/MainMenuWidget.h
@@ -50,5 +50,7 @@ protected:
 	UPROPERTY(meta = (BindWidget))
 	class UButton* ExitButton;
 
-	
+private:
+	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Level", meta = (AllowPrivateAccess = true))
+	TSoftObjectPtr<UWorld> NewGameTargetLevelAsset;
 };


### PR DESCRIPTION
기존에 버튼 클릭 시 UGameplayStatics::OpenLevel를 호출하던 로직을 게임 인스턴스의 TravelToLevel함수를 호출하도록 변경
TravelToLevel함수에 필요한 매개변수를 위해 위젯에서 이동하고자하는 레벨 애셋을 소프트 레퍼런스로 저장한다.