### PR TITLE
[Add] 몬스터 스폰 그룹 데이터 테이블 추가

### DIFF
--- a/Content/Datas/MonsterSpawnGroupDataTable.uasset
+++ b/Content/Datas/MonsterSpawnGroupDataTable.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:883e87f0800b83a90752d3852ec05dafb51d6fe248d083503703f23d9d445485
+size 2141

--- a/Source/RogShop/DataTable/MonsterSpawnGroupData.cpp
+++ b/Source/RogShop/DataTable/MonsterSpawnGroupData.cpp
@@ -1,0 +1,5 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "MonsterSpawnGroupData.h"
+

--- a/Source/RogShop/DataTable/MonsterSpawnGroupData.h
+++ b/Source/RogShop/DataTable/MonsterSpawnGroupData.h
@@ -12,7 +12,7 @@ struct FMonsterCount
     GENERATED_BODY()
 
     UPROPERTY(EditAnywhere, BlueprintReadWrite)
-    FString MonsterRowName;
+    FName MonsterRowName;
 
     UPROPERTY(EditAnywhere, BlueprintReadWrite)
     int32 Count;

--- a/Source/RogShop/DataTable/MonsterSpawnGroupData.h
+++ b/Source/RogShop/DataTable/MonsterSpawnGroupData.h
@@ -1,0 +1,29 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Engine/DataTable.h"
+#include "MonsterSpawnGroupData.generated.h"
+
+USTRUCT(BlueprintType)
+struct FMonsterCount
+{
+    GENERATED_BODY()
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite)
+    FString MonsterRowName;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite)
+    int32 Count;
+};
+
+USTRUCT(BlueprintType)
+struct ROGSHOP_API FMonsterSpawnGroupData : public FTableRowBase
+{
+	GENERATED_BODY()
+	
+public:
+    UPROPERTY(EditAnywhere, BlueprintReadWrite)
+    TArray<FMonsterCount> SpawnGroup;
+};


### PR DESCRIPTION
몬스터를 스폰시킬 때 어떤 몬스터를 얼마나 스폰할지 의미하는 데이터테이블을 추가했습니다.

몬스터의 종류가 다양할 수 있으므로, TArray를 사용해주었습니다.

몬스터의 종류는 FName으로 값을 저장하며, 몬스터 데이터 테이블에서 RowName을 위한 키값으로 사용됩니다.
몬스터의 수는 몬스터를 스폰시킬 때 몇 마리 스폰시킬지를 의미합니다.