### PR TITLE
[Add] 몬스터 스탯, 스킬, 설정 데이터 테이블 생성 및 각 테이블의 TableRow에 필요한 변수들 기본적인 거 추가

### DIFF
--- a/Content/Datas/MonsterConfigDataTable.uasset
+++ b/Content/Datas/MonsterConfigDataTable.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b94e937d6ac8885f6e46a845d560b6605514469f2a58f37a462dfe18f09decaa
+size 2113

--- a/Content/Datas/MonsterSkillDataTable.uasset
+++ b/Content/Datas/MonsterSkillDataTable.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:feae2eb90a08bcc332e313d6996d5ac8a270c4f33b742e5b12a8f45fc118d6da
+size 2106

--- a/Content/Datas/MonsterStatDataTable.uasset
+++ b/Content/Datas/MonsterStatDataTable.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:487c53e0694ed9fc4817ad5343dbafc5e06a85ea1a3e8cb46564449dceb2842b
+size 2099

--- a/Source/RogShop/Character/RSDunMonsterCharacter.h
+++ b/Source/RogShop/Character/RSDunMonsterCharacter.h
@@ -25,7 +25,7 @@ public:
 
 	virtual void BeginPlay()override;
 
-	// ¾Ö´Ï¸ŞÀÌ¼Ç ½ÇÇà ÇÔ¼ö
+	// ì• ë‹ˆë©”ì´ì…˜ ì‹¤í–‰ í•¨ìˆ˜
 	virtual void PlayBaseAttackAnim();
 	virtual void PlayDeathAnim();
 	UFUNCTION(BlueprintCallable)
@@ -36,7 +36,7 @@ public:
 	virtual void PlaySkill_3();
 
 	UFUNCTION()
-	void OnDeathMontageEnded(UAnimMontage* montage, bool bInterrupted);//»ç¸Á ¸ğ¼ÇÀÌ ³¡³­ °æ¿ì
+	void OnDeathMontageEnded(UAnimMontage* montage, bool bInterrupted);  //ì‚¬ë§ ëª¨ì…˜ì´ ëë‚œ ê²½ìš°
 
 	//Navigation Invoker function
 	FORCEINLINE class UNavigationInvokerComponent* GetNavInvoker() const { return navInvoker; };
@@ -62,12 +62,9 @@ public:
 	void OnDeath();
 
 protected:
-	// ¾Ö´Ï¸ŞÀÌ¼Ç ¸ùÅ¸ÁÖ
+	// ì• ë‹ˆë©”ì´ì…˜ ëª½íƒ€ì£¼
 	UPROPERTY(EditAnywhere, BlueprintReadOnly)
 	TObjectPtr<UAnimMontage> BaseAttackMontage;
-
-	UPROPERTY(EditAnywhere, BlueprintReadOnly)
-	TObjectPtr<UAnimMontage> HitReactMontage;
 
 	UPROPERTY(EditAnywhere, BlueprintReadOnly)
 	TObjectPtr<UAnimMontage> DeathMontage;
@@ -102,28 +99,28 @@ protected:
 	UPROPERTY(BlueprintReadWrite, Category = "Patrol")
 	float maxDetectPatrolRoute;
 
-	// Æ®·¹ÀÌ½º °ü·Ã
+	// íŠ¸ë ˆì´ìŠ¤ ê´€ë ¨
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "AttackTrace")
 	FVector TraceBoxHalfSize;
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "AttackTrace")
-	float TraceLength;        // Æ®·¹ÀÌ½º ±æÀÌ (¾ÕÀ¸·Î ¾ó¸¶¸¸Å­ ½òÁö)
+	float TraceLength;			// íŠ¸ë ˆì´ìŠ¤ ê¸¸ì´ (ì•ìœ¼ë¡œ ì–¼ë§ˆë§Œí¼ ì ì§€)
 
 	UPROPERTY(EditAnywhere, Category = "AttackTrace")
-	float TraceForwardOffset; // ¼ÒÄÏ ±âÁØ ¾ÕÀ¸·Î ¾ó¸¶³ª ¹ĞÁö
+	float TraceForwardOffset;	// ì†Œì¼“ ì‹œì‘ì  ì•ë’¤ ë³´ì •
 
 	UPROPERTY(EditAnywhere, Category = "AttackTrace")
-	float TraceRightOffset;     // (¼±ÅÃ) ÁÂ¿ì º¸Á¤
+	float TraceRightOffset;     // ì†Œì¼“ ì‹œì‘ì  ì¢Œìš° ë³´ì •
 
 	UPROPERTY(EditAnywhere, Category = "AttackTrace")
-	float TraceUpOffset;        // (¼±ÅÃ) ³ôÀÌ º¸Á¤
+	float TraceUpOffset;        // ì†Œì¼“ ì‹œì‘ì  ë†’ì´ ë³´ì •
 
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "AttackTrace")
-	FName SocketLocation;		// Æ®·¹ÀÌ½º°¡ ³ª°¥ ¼ÒÄÏÀÇ ½ÃÀÛÁ¡
+	UPROPERTY(EditAnywhere, Category = "AttackTrace")
+	FName SocketLocation;		// íŠ¸ë ˆì´ìŠ¤ê°€ ì´ì§ˆ ì†Œì¼“ì˜ ì‹œì‘ì 
 
 	FTimerHandle detectDelayTimer;
 
 private:
-	TObjectPtr<ARSMonsterAIController> AIController;  // TODO : È¤½Ã³ª Ä³½ÌÇØ¼­ ¾µ ÀÏ »ı±æ±îºÁ ¹Ì¸® ¸¸µé¾îµÒ.
+	TObjectPtr<ARSMonsterAIController> AIController;  // TODO : í˜¹ì‹œë‚˜ ìºì‹±í•´ì„œ ì“¸ ì¼ ìƒê¸¸ê¹Œë´ ë¯¸ë¦¬ ë§Œë“¤ì–´ë‘ .
 
 };

--- a/Source/RogShop/DataTable/MonsterConfigData.cpp
+++ b/Source/RogShop/DataTable/MonsterConfigData.cpp
@@ -1,0 +1,5 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "MonsterConfigData.h"
+

--- a/Source/RogShop/DataTable/MonsterConfigData.h
+++ b/Source/RogShop/DataTable/MonsterConfigData.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Engine/DataTable.h" // 필수 헤더
+#include "MonsterConfigData.generated.h"
+
+USTRUCT(BlueprintType)
+struct ROGSHOP_API FMonsterConfigData : public FTableRowBase
+{
+	GENERATED_BODY()
+
+public:
+	UPROPERTY(VisibleAnywhere)
+	TObjectPtr<UAnimMontage> DeathMontage;
+
+};

--- a/Source/RogShop/DataTable/MonsterSkillData.cpp
+++ b/Source/RogShop/DataTable/MonsterSkillData.cpp
@@ -1,0 +1,5 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "MonsterSkillData.h"
+

--- a/Source/RogShop/DataTable/MonsterSkillData.h
+++ b/Source/RogShop/DataTable/MonsterSkillData.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Engine/DataTable.h" // 필수 헤더
+#include "MonsterSkillData.generated.h"
+
+USTRUCT(BlueprintType)
+struct ROGSHOP_API FMonsterSkillData : public FTableRowBase
+{
+	GENERATED_BODY()
+
+public:
+	UPROPERTY(EditDefaultsOnly)
+	FName SkillName;
+
+	UPROPERTY(EditDefaultsOnly)
+	TObjectPtr<UAnimMontage> SkillMontage;
+
+	UPROPERTY(EditDefaultsOnly)
+	float AttackPower;
+
+	UPROPERTY(EditDefaultsOnly)
+	float PlayRate = 1.0f;		// 각 애니메이션 재생속도를 조절해서 공격 속도를 조절
+
+	/*UPROPERTY(EditAnywhere)
+	float Cooldown = 2.0f;*/    // TODO :: 나중에 전투 시스템 확장되면 쿨타임 추가, 아니면 제거
+
+	UPROPERTY(EditDefaultsOnly)
+	bool bIsBasicAttack;		// 기본 공격과 다른 스킬을 구분하기 위한 변수
+
+	// 트레이스 관련
+	UPROPERTY(EditDefaultsOnly)
+	FVector TraceBoxHalfSize;   // 트레이스 반경 (옆으로 얼만큼 쏠지)
+
+	UPROPERTY(EditDefaultsOnly)
+	float TraceLength;			// 트레이스 길이 (앞으로 얼마만큼 쏠지)
+
+	UPROPERTY(EditDefaultsOnly)
+	float TraceForwardOffset;	// 소켓 시작점 앞뒤 보정
+
+	UPROPERTY(EditDefaultsOnly)
+	float TraceRightOffset;     // 소켓 시작점 좌우 보정
+
+	UPROPERTY(EditDefaultsOnly)
+	float TraceUpOffset;        // 소켓 시작점 높이 보정
+
+	UPROPERTY(EditDefaultsOnly)
+	FName SocketLocation;		// 트레이스가 쏴질 소켓의 시작점
+	
+};

--- a/Source/RogShop/DataTable/MonsterStatData.cpp
+++ b/Source/RogShop/DataTable/MonsterStatData.cpp
@@ -1,0 +1,5 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "MonsterStatData.h"
+

--- a/Source/RogShop/DataTable/MonsterStatData.h
+++ b/Source/RogShop/DataTable/MonsterStatData.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Engine/DataTable.h" // 필수 헤더
+#include "MonsterStatData.generated.h"
+
+USTRUCT(BlueprintType)
+struct ROGSHOP_API FMonsterStatData : public FTableRowBase
+{
+	GENERATED_BODY()
+
+public:
+	UPROPERTY(EditDefaultsOnly)
+	float MaxHP;
+
+	UPROPERTY(EditDefaultsOnly)
+	float MoveSpeed;
+
+	UPROPERTY(EditDefaultsOnly)
+	float AttackPower;
+
+	UPROPERTY(EditDefaultsOnly)
+	float AttackSpeed;
+	
+};


### PR DESCRIPTION
- #194 

## 현재 상태
- 기본적으로 MonsterStatDataTable, MonsterSkillDataTable, MonsterConfigDataTable로 나누었습니다.
- MonsterStatDataTable에서는 몬스터의 스탯(MaxHP, MoveSpeed, AttackPower, AttackSpeed)을 결정합니다.
- MonsterSkillDataTable에서는 몬스터의 스킬(BaseAttackAnimMontage, SkillAnimMontage 등)을 결정합니다.
ㄴ 스킬은 일단 공격 스킬만 넣는 걸로 생각 중이며, 그래서 트레이스 관련 변수도 다 여기에 들어갑니다.
- MonsterConfigDataTable에서는 몬스터의 기타:남는 것들 설정(DeathAnimMontage 등)을 결정합니다.
ㄴ DeathAnimMontage가 스킬이 아닌 이유는 죽음은 공격 스킬이 아니기 때문입니다.
ㄴ 그리고 트레이스 관련 변수에 null이 들어가서 쓸데없는 공간을 차지하게 될 것입니다.

**왜 데이터 테이블을 하나로 만들지 않고 3개로 나누었냐면 
몬스터의 스탯, 스킬, 설정(애니메이션/트레이스 등)은 성격이 명확히 다른 데이터이므로, 
데이터 테이블을 기능별로 분리하여 책임을 나눴습니다.
이를 통해 유지보수성과 확장성이 향상되며, 한 테이블 변경이 전체 로직에 영향을 주는 리스크를 줄일 수 있습니다.**

---

<html>
<body>
<!--StartFragment--><h2>몬스터 관련 정보를 데이터 테이블로 관리하면 좋은 점</h2>
<p>여기 아래에서 말하는 값은 각 몬스터마다 달라야 하는 고유한 체력, 공격력, 스킬, 죽음 애니메이션 같은 값을 말합니다.</p>
<h2>💡 전후 비교</h2>

항목 | Before (수동 설정) | After (DataTable 기반)
-- | -- | --
초기화 위치 | 생성자 내부, 혹은 블루프린트에서 직접 지정 | DataTable의 RowID 기준으로 값을 가져옴
유연성 | 몬스터마다 별도 클래스 필요 or 조건문 많아짐 | 테이블 한 줄로 다양한 몬스터 설정 가능
유지보수 | 변경 시 코드/블루프린트 열어서 직접 수정 | CSV만 바꾸면 전체 반영 가능
확장성 | 수치 추가 시 코드 수정 필요 | 테이블에 열 추가하면 끝


<!-- notionvc: c2e675ec-084a-4cff-b0ee-f60a984c9485 --><!--EndFragment-->
</body>
</html>
