### PR TITLE
[Add] 숲 데이터 테이블 생성 및 서브시스템 등록

### DIFF
--- a/Config/DefaultGame.ini
+++ b/Config/DefaultGame.ini
@@ -8,6 +8,7 @@ IngredientDataTable=/Game/Datas/IngredientDataTable.IngredientDataTable
 FoodDataTable=/Game/Datas/CookFoodDataTable.CookFoodDataTable
 WeaponDataTable=/Game/Datas/DungeonWeaponDataTable.DungeonWeaponDataTable
 RelicDataTable=/Game/Datas/DungeonRelicDataTable.DungeonRelicDataTable
+ForestMonsterSpawnGroupDataTable=/Game/Datas/ForestMonsterSpawnGroupDataTable.ForestMonsterSpawnGroupDataTable
 
 [/Script/UnrealEd.ProjectPackagingSettings]
 Build=IfProjectHasCode

--- a/Content/Datas/ForestMonsterSpawnGroupDataTable.uasset
+++ b/Content/Datas/ForestMonsterSpawnGroupDataTable.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b2b10f4ca99ab5755e3dc43d8fad18a9c617dec71ece41460ac21455496b22ab
+size 2171

--- a/Content/Datas/MonsterSpawnGroupDataTable.uasset
+++ b/Content/Datas/MonsterSpawnGroupDataTable.uasset
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:883e87f0800b83a90752d3852ec05dafb51d6fe248d083503703f23d9d445485
-size 2141

--- a/Source/RogShop/GameInstanceSubsystem/RSDataSubsystem.cpp
+++ b/Source/RogShop/GameInstanceSubsystem/RSDataSubsystem.cpp
@@ -15,9 +15,11 @@ void URSDataSubsystem::Initialize(FSubsystemCollectionBase& Collection)
 	Ingredient = DataSettings->IngredientDataTable.LoadSynchronous();
 	Weapon = DataSettings->WeaponDataTable.LoadSynchronous();
 	Relic = DataSettings->RelicDataTable.LoadSynchronous();
+	ForestMonsterSpawnGroup = DataSettings->ForestMonsterSpawnGroupDataTable.LoadSynchronous();
 
 	check(Food)
 	check(Ingredient)
 	check(Weapon)
 	check(Relic)
+	check(ForestMonsterSpawnGroup)
 }

--- a/Source/RogShop/GameInstanceSubsystem/RSDataSubsystem.h
+++ b/Source/RogShop/GameInstanceSubsystem/RSDataSubsystem.h
@@ -29,4 +29,7 @@ public:
 
 	UPROPERTY()
 	TObjectPtr<UDataTable> Relic;
+
+	UPROPERTY()
+	TObjectPtr<UDataTable> ForestMonsterSpawnGroup;
 };

--- a/Source/RogShop/RSDataSubsystemSettings.h
+++ b/Source/RogShop/RSDataSubsystemSettings.h
@@ -26,4 +26,7 @@ public:
 
 	UPROPERTY(Config, EditAnywhere)
 	TSoftObjectPtr<UDataTable> RelicDataTable;
+
+	UPROPERTY(Config, EditAnywhere)
+	TSoftObjectPtr<UDataTable> ForestMonsterSpawnGroupDataTable;
 };


### PR DESCRIPTION
숲 몬스터 스폰 그룹 데이터 테이블을 생성하고 서브시스템에 등록해주었습니다.

후에 다른 맵의 몬스터 스폰 그룹을 추가할 때 같은 식으로 데이터 테이블 애셋을 생성하고, 서브시스템에 추가로 등록 해주어야합니다.