### PR TITLE
[Add] 유물 클래스 구현

### DIFF
--- a/Source/RogShop/Actor/Dungeon/GroundItem/RSDungeonGroundRelic.cpp
+++ b/Source/RogShop/Actor/Dungeon/GroundItem/RSDungeonGroundRelic.cpp
@@ -33,11 +33,10 @@ void ARSDungeonGroundRelic::Interact(ARSDunPlayerCharacter* Interactor)
 		return;
 	}
 
-	FActorSpawnParameters SpawnParameters;
-	SpawnParameters.Owner = Interactor;
-	SpawnParameters.Instigator = Interactor;
+	FString ObjectString = DataTableKey.ToString() + TEXT("Object");
+	FName ObjectName = FName(*ObjectString);
 
-	URSBaseRelic* SpawnRelic = GetWorld()->SpawnActor<URSBaseRelic>(RelicClass, SpawnParameters);
+	URSBaseRelic* SpawnRelic = NewObject<URSBaseRelic>(Interactor, ObjectName, EObjectFlags::RF_Transient, RelicClass->StaticClass());
 
 	URSRelicInventoryComponent* RSPlayerWeaponComponent = Interactor->GetRSRelicInventoryComponent();
 	if (SpawnRelic && RSPlayerWeaponComponent)

--- a/Source/RogShop/Actor/Dungeon/GroundItem/RSDungeonGroundRelic.cpp
+++ b/Source/RogShop/Actor/Dungeon/GroundItem/RSDungeonGroundRelic.cpp
@@ -1,0 +1,50 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "GroundItem/RSDungeonGroundRelic.h"
+#include "RogShop/UtilDefine.h"
+#include "RSBaseRelic.h"
+#include "RSDunPlayerCharacter.h"
+#include "RSRelicInventoryComponent.h"
+
+void ARSDungeonGroundRelic::InitInteractableRelic(FName NewDataTableKey, UStaticMesh* NewMesh, const TSubclassOf<URSBaseRelic> NewRelicClass)
+{
+	if (!NewMesh)
+	{
+		RS_LOG_C("Invalid StaticMesh Used", FColor::Red);
+	}
+	if (!NewRelicClass)
+	{
+		RS_LOG_C("Invalid Blueprint Class Used", FColor::Red);
+	}
+
+	DataTableKey = NewDataTableKey;
+
+	MeshComp->SetStaticMesh(NewMesh);
+	RelicClass = NewRelicClass;
+
+	MeshComp->SetCollisionEnabled(ECollisionEnabled::QueryAndPhysics);
+}
+
+void ARSDungeonGroundRelic::Interact(ARSDunPlayerCharacter* Interactor)
+{
+	if (!Interactor)
+	{
+		return;
+	}
+
+	FActorSpawnParameters SpawnParameters;
+	SpawnParameters.Owner = Interactor;
+	SpawnParameters.Instigator = Interactor;
+
+	URSBaseRelic* SpawnRelic = GetWorld()->SpawnActor<URSBaseRelic>(RelicClass, SpawnParameters);
+
+	URSRelicInventoryComponent* RSPlayerWeaponComponent = Interactor->GetRSRelicInventoryComponent();
+	if (SpawnRelic && RSPlayerWeaponComponent)
+	{
+		RSPlayerWeaponComponent->AddRelic(DataTableKey);
+		SpawnRelic->ApplyEffect(Interactor);
+
+		Destroy();
+	}
+}

--- a/Source/RogShop/Actor/Dungeon/GroundItem/RSDungeonGroundRelic.h
+++ b/Source/RogShop/Actor/Dungeon/GroundItem/RSDungeonGroundRelic.h
@@ -1,0 +1,27 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "RSDungeonGroundItem.h"
+#include "RSDungeonGroundRelic.generated.h"
+
+class URSBaseRelic;
+
+UCLASS()
+class ROGSHOP_API ARSDungeonGroundRelic : public ARSDungeonGroundItem
+{
+	GENERATED_BODY()
+	
+public:
+	// 해당 엑터의 메시 세팅 및 상호작용에 필요한 변수 세팅
+	void InitInteractableRelic(FName NewDataTableKey, UStaticMesh* NewMesh, const TSubclassOf<URSBaseRelic> NewRelicClass);
+
+// 상호작용
+public:
+	virtual void Interact(ARSDunPlayerCharacter* Interactor) override;
+
+private:
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "TargetClass", meta = (AllowPrivateAccess = true))
+	TSubclassOf<URSBaseRelic> RelicClass;	// 상호작용시 플레이어에게 넘겨줄 무기 블루프린트 클래스
+};

--- a/Source/RogShop/Actor/Dungeon/GroundItem/RSDungeonGroundWeapon.h
+++ b/Source/RogShop/Actor/Dungeon/GroundItem/RSDungeonGroundWeapon.h
@@ -26,6 +26,6 @@ public:
 	virtual void Interact(ARSDunPlayerCharacter* Interactor) override;
 
 private:
-	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Component", meta = (AllowPrivateAccess = true))
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "TargetClass", meta = (AllowPrivateAccess = true))
 	TSubclassOf<ARSDungeonItemBase> WeaponClass;	// 상호작용시 플레이어에게 넘겨줄 무기 블루프린트 클래스
 };

--- a/Source/RogShop/Actor/Dungeon/Relic/RSBaseRelic.cpp
+++ b/Source/RogShop/Actor/Dungeon/Relic/RSBaseRelic.cpp
@@ -1,0 +1,10 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "RSBaseRelic.h"
+#include "RSDunPlayerCharacter.h"
+
+void URSBaseRelic::ApplyEffect(ARSDunPlayerCharacter* OwnerCharacter)
+{
+
+}

--- a/Source/RogShop/Actor/Dungeon/Relic/RSBaseRelic.h
+++ b/Source/RogShop/Actor/Dungeon/Relic/RSBaseRelic.h
@@ -1,0 +1,18 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "UObject/NoExportTypes.h"
+#include "RSBaseRelic.generated.h"
+
+class ARSDunPlayerCharacter;
+
+UCLASS(Abstract, NotBlueprintable)
+class ROGSHOP_API URSBaseRelic : public UObject
+{
+	GENERATED_BODY()
+	
+public:
+	virtual void ApplyEffect(ARSDunPlayerCharacter* OwnerCharacter);
+};

--- a/Source/RogShop/Actor/Dungeon/Relic/RSStatusRelic.cpp
+++ b/Source/RogShop/Actor/Dungeon/Relic/RSStatusRelic.cpp
@@ -1,0 +1,34 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "RSStatusRelic.h"
+#include "RSDunPlayerCharacter.h"
+
+void URSStatusRelic::ApplyEffect(ARSDunPlayerCharacter* OwnerCharacter)
+{
+	if (!OwnerCharacter)
+	{
+		return;
+	}
+
+	if (TargetStatus == EStatus::HP)
+	{
+		// TODO : 플레이어 캐릭터의 현재 HP 증가
+	}
+	else if (TargetStatus == EStatus::MaxHP)
+	{
+		// TODO : 플레이어 캐릭터의 최대 HP 증가
+	}
+	else if (TargetStatus == EStatus::MoveSpeed)
+	{
+		// TODO : 플레이어 캐릭터의 이동속도 증가
+	}
+	else if (TargetStatus == EStatus::AttackPower)
+	{
+		// TODO : 플레이어 캐릭터의 공격력 증가
+	}
+	else if (TargetStatus == EStatus::AttackSpeed)
+	{
+		// TODO : 플레이어 캐릭터의 공격속도 증가
+	}
+}

--- a/Source/RogShop/Actor/Dungeon/Relic/RSStatusRelic.h
+++ b/Source/RogShop/Actor/Dungeon/Relic/RSStatusRelic.h
@@ -1,0 +1,34 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "RSBaseRelic.h"
+#include "RSStatusRelic.generated.h"
+
+UENUM(BlueprintType)
+enum class EStatus : uint8
+{
+	NONE,
+	HP,
+	MaxHP,
+	MoveSpeed,
+	AttackPower,
+	AttackSpeed,
+};
+
+UCLASS(Blueprintable)
+class ROGSHOP_API URSStatusRelic : public URSBaseRelic
+{
+	GENERATED_BODY()
+	
+public:
+	virtual void ApplyEffect(ARSDunPlayerCharacter* OwnerCharacter) override;
+
+private:
+	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, category = "Status", meta = (AllowPrivateAccess = "true"))
+	EStatus TargetStatus;
+
+	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, category = "Status", meta = (AllowPrivateAccess = "true"))
+	float Amount;
+};

--- a/Source/RogShop/RogShop.Build.cs
+++ b/Source/RogShop/RogShop.Build.cs
@@ -28,6 +28,7 @@ public class RogShop : ModuleRules
             Path.Combine(ModuleDirectory, "Actor", "Dungeon"),
             Path.Combine(ModuleDirectory, "Actor", "Dungeon", "Weapon"),
             Path.Combine(ModuleDirectory, "Actor", "Dungeon", "GroundItem"),
+            Path.Combine(ModuleDirectory, "Actor", "Dungeon", "Relic"),
             Path.Combine(ModuleDirectory, "Interface"),
             Path.Combine(ModuleDirectory, "DataTable"),
             Path.Combine(ModuleDirectory, "Object", "Relic"),


### PR DESCRIPTION
유물의 베이스가 되는 클래스 URSBaseRelic 추가

해당 클래스는 ApplyEffect 함수를 가상 함수로 가집니다.

URSBaseRelic 클래스를 상속받아 각 유물의 동작을 구현합니다.

대표적으로 플레이어 캐릭터의 스탯을 변화하는 경우 URSStatusRelic 클래스처럼 구현하도록 합니다.
이 경우 각 스탯별로 클래스를 추가적으로 생성하지 않기 때문에 스탯에 대해서는 URSStatusRelic가 관리합니다.

이렇게 정의된 클래스를 ARSDungeonGroundRelic 클래스에서 상호작용 된 경우
플레이어 캐릭터의 유물 인벤토리에 저장하고, 상호작용 된 유물에 대해서 발동해야하는 동작은 URSBaseRelic 클래스를 상속받은 클래스에 구현된 로직을 실행시킵니다.