### PR TITLE
[Update] 거점에서 가장 낮은 등급의 무기를 획득할 수 있도록 액터 추가

### DIFF
--- a/Content/Maps/BaseAreaMap.umap
+++ b/Content/Maps/BaseAreaMap.umap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0d0f1612a92e270bd9feb9b48498a69e42ff4796e0b69a4a3a1d35b8ccd0a7e5
-size 51758
+oid sha256:d9cf4b73b7b7a214ccfa6bebb51754f1e7fb61876da2cda3ed9ae1dda91b1db7
+size 51777


### PR DESCRIPTION
기존에 구현한 ARSWeaponSpawnPadActor 클래스를 상속받은 블루프린트 클래스를 거점 레벨에 배치해주었습니다. 