### PR TITLE
[Update] 무기를 버리는 기능 추가

### DIFF
--- a/Source/RogShop/ActorComponent/RSPlayerWeaponComponent.cpp
+++ b/Source/RogShop/ActorComponent/RSPlayerWeaponComponent.cpp
@@ -269,10 +269,13 @@ void URSPlayerWeaponComponent::DropWeaponToSlot(EWeaponSlot TargetWeaponSlot)
 		}
 	}
 
-	// 기존에 장착하던 무기 장착 해제
-	UnEquipWeaponToCharacter();
+	// 장착 중이었을 경우 무기 장착 해제
+	if (TargetWeaponSlot == WeaponSlot)
+	{
+		UnEquipWeaponToCharacter();
+	}
 
-	// 기존에 장착하던 무기 제거
+	// 기존에 소유하던 무기 제거
 	WeaponActors[TargetIndex]->Destroy();
 	WeaponActors[TargetIndex] = nullptr;
 

--- a/Source/RogShop/ActorComponent/RSPlayerWeaponComponent.cpp
+++ b/Source/RogShop/ActorComponent/RSPlayerWeaponComponent.cpp
@@ -97,21 +97,21 @@ bool URSPlayerWeaponComponent::ContinueComboAttack()
 				return false;
 			}
 
-			// ÄŞº¸ °ø°İÀÌ ¹è¿­ÀÇ Å©±â¸¦ ³Ñ¾î¼­Áö ¾Ê°Ô ÇØÁØ´Ù.
+			// ì½¤ë³´ ê³µê²©ì´ ë°°ì—´ì˜ í¬ê¸°ë¥¼ ë„˜ì–´ì„œì§€ ì•Šê²Œ í•´ì¤€ë‹¤.
 			const TArray<UAnimMontage*>& CurNormalAttacks = WeaponActors[Index]->GetNormalAttacks();
 			if (CurNormalAttacks.Num() <= ComboIndex)
 			{
 				ComboIndex %= CurNormalAttacks.Num();
 			}
 
-			// ÇöÀç Àç»ıÇØ¾ßÇÏ´Â ¸ùÅ¸ÁÖ¸¦ Ã£´Â´Ù.
+			// í˜„ì¬ ì¬ìƒí•´ì•¼í•˜ëŠ” ëª½íƒ€ì£¼ë¥¼ ì°¾ëŠ”ë‹¤.
 			UAnimMontage* CurAttackMontage = CurNormalAttacks[ComboIndex];
 			UAnimInstance* AnimInstance = SkeletalMeshComp->GetAnimInstance();
 
 			if (CurAttackMontage && AnimInstance)
 			{
-				// ¸ùÅ¸ÁÖ¸¦ Àç»ı½ÃÄÑÁØ´Ù.
-				// ÀÔ·ÂµÈ ¹öÆÛ °ªÀ» ÃÊ±âÈ­ÇÏ°í, ´ÙÀ½ °ø°İÀ» À§ÇØ ÄŞº¸ ÀÎµ¦½º¸¦ Áõ°¡½ÃÅ²´Ù.
+				// ëª½íƒ€ì£¼ë¥¼ ì¬ìƒì‹œì¼œì¤€ë‹¤.
+				// ì…ë ¥ëœ ë²„í¼ ê°’ì„ ì´ˆê¸°í™”í•˜ê³ , ë‹¤ìŒ ê³µê²©ì„ ìœ„í•´ ì½¤ë³´ ì¸ë±ìŠ¤ë¥¼ ì¦ê°€ì‹œí‚¨ë‹¤.
 
 				float AttackSpeed = CurCharacter->GetAttackSpeed();
 
@@ -133,8 +133,8 @@ bool URSPlayerWeaponComponent::ContinueComboAttack()
 
 void URSPlayerWeaponComponent::ResetCombo()
 {
-	// °ø°İ ¾Ö´Ï¸ŞÀÌ¼ÇÀÌ Àç»ıµÈ ÈÄ ´õÀÌ»ó ÀÔ·ÂÀÌ ¾øÀ» ¶§ È£ÃâµÈ´Ù.
-	// °ø°İ¿¡ ´ëÇØ ¸ğµÎ ±âº»°ªÀ¸·Î ¼³Á¤
+	// ê³µê²© ì• ë‹ˆë©”ì´ì…˜ì´ ì¬ìƒëœ í›„ ë”ì´ìƒ ì…ë ¥ì´ ì—†ì„ ë•Œ í˜¸ì¶œëœë‹¤.
+	// ê³µê²©ì— ëŒ€í•´ ëª¨ë‘ ê¸°ë³¸ê°’ìœ¼ë¡œ ì„¤ì •
 	ComboIndex = 0;
 	bComboInputBuffered = false;
 	bIsAttack = false;
@@ -142,17 +142,17 @@ void URSPlayerWeaponComponent::ResetCombo()
 
 void URSPlayerWeaponComponent::EquipWeaponToSlot(ARSBaseWeapon* NewWeaponActor)
 {
-	// ½½·ÔÀÇ Å©±â°¡ Àß¸ø ¼³Á¤µÈ °æ¿ì
+	// ìŠ¬ë¡¯ì˜ í¬ê¸°ê°€ ì˜ëª» ì„¤ì •ëœ ê²½ìš°
 	if (WeaponActors.Num() != WeaponSlotSize)
 	{
 		WeaponActors.SetNum(WeaponSlotSize);
 	}
 
-	// ½½·Ô¿¡ Æ÷ÇÔÇÒ ¾×ÅÍ¸¦ ¼û±èÃ³¸® ¹× Ãæµ¹À» ²ö´Ù.
+	// ìŠ¬ë¡¯ì— í¬í•¨í•  ì•¡í„°ë¥¼ ìˆ¨ê¹€ì²˜ë¦¬ ë° ì¶©ëŒì„ ëˆë‹¤.
 	NewWeaponActor->SetActorHiddenInGame(true);
 	NewWeaponActor->SetActorEnableCollision(false);
 
-	// Ä³¸¯ÅÍÀÇ ¼Õ¿¡ ¹«±â¸¦ ºÎÂøÇÑ´Ù.
+	// ìºë¦­í„°ì˜ ì†ì— ë¬´ê¸°ë¥¼ ë¶€ì°©í•œë‹¤.
 	ACharacter* CurCharacter = GetOwner<ACharacter>();
 	if (CurCharacter)
 	{
@@ -164,12 +164,12 @@ void URSPlayerWeaponComponent::EquipWeaponToSlot(ARSBaseWeapon* NewWeaponActor)
 		}
 	}
 
-	// ÇöÀç ºñ¾îÀÖ´Â ¹«±â ½½·ÔÀÌ ÀÖÀ» °æ¿ì ºñ¾îÀÖ´Â ½½·Ô¿¡ ¿ì¼±ÀûÀ¸·Î Ã¤¿î´Ù.
+	// í˜„ì¬ ë¹„ì–´ìˆëŠ” ë¬´ê¸° ìŠ¬ë¡¯ì´ ìˆì„ ê²½ìš° ë¹„ì–´ìˆëŠ” ìŠ¬ë¡¯ì— ìš°ì„ ì ìœ¼ë¡œ ì±„ìš´ë‹¤.
 	if (WeaponActors[0] == nullptr)
 	{
 		WeaponActors[0] = NewWeaponActor;
 
-		// UI °»½ÅµÇµµ·Ï ÀÌº¥Æ® µğ½ºÆĞÃ³ È£Ãâ
+		// UI ê°±ì‹ ë˜ë„ë¡ ì´ë²¤íŠ¸ ë””ìŠ¤íŒ¨ì²˜ í˜¸ì¶œ
 		FName NewWeaponKey = NewWeaponActor->GetDataTableKey();
 
 		ARSDunPlayerController* PC = Cast<ARSDunPlayerController>(CurCharacter->GetController());
@@ -184,7 +184,7 @@ void URSPlayerWeaponComponent::EquipWeaponToSlot(ARSBaseWeapon* NewWeaponActor)
 	{
 		WeaponActors[1] = NewWeaponActor;
 
-		// UI °»½ÅµÇµµ·Ï ÀÌº¥Æ® µğ½ºÆĞÃ³ È£Ãâ
+		// UI ê°±ì‹ ë˜ë„ë¡ ì´ë²¤íŠ¸ ë””ìŠ¤íŒ¨ì²˜ í˜¸ì¶œ
 		FName NewWeaponKey = NewWeaponActor->GetDataTableKey();
 
 		ARSDunPlayerController* PC = Cast<ARSDunPlayerController>(CurCharacter->GetController());
@@ -197,44 +197,29 @@ void URSPlayerWeaponComponent::EquipWeaponToSlot(ARSBaseWeapon* NewWeaponActor)
 	}
 	else
 	{
-		// ±âÁ¸¿¡ ÀåÂøÇÏ´ø ¹«±â¸¦ ¹ö¸®´Â ·ÎÁ÷
-		// ¸¸¾à, ºñ¾îÀÖ´Â ¹«±â ½½·ÔÀÌ ¾ø´Â °æ¿ì µé°í ÀÖ´Â ¹«±â¿Í ±³Ã¼ÇÑ´Ù.
+		// ê¸°ì¡´ì— ì¥ì°©í•˜ë˜ ë¬´ê¸°ë¥¼ ë²„ë¦¬ëŠ” ë¡œì§
+		// ë§Œì•½, ë¹„ì–´ìˆëŠ” ë¬´ê¸° ìŠ¬ë¡¯ì´ ì—†ëŠ” ê²½ìš° ë“¤ê³  ìˆëŠ” ë¬´ê¸°ì™€ êµì²´í•œë‹¤.
 		
 		int8 Index = static_cast<int8>(WeaponSlot) - 1;
 
-		// ¸¸¾à ¹«±â¸¦ ÀåÂøÁßÀÌÁö ¾ÊÀº °æ¿ì Ã¹ ½½·ÔÀÇ ¹«±â¿Í ±³Ã¼ÇÑ´Ù.
+		// ë§Œì•½ ë¬´ê¸°ë¥¼ ì¥ì°©ì¤‘ì´ì§€ ì•Šì€ ê²½ìš° ì²« ìŠ¬ë¡¯ì˜ ë¬´ê¸°ì™€ êµì²´í•œë‹¤.
 		if (EWeaponSlot::NONE == WeaponSlot)
 		{
 			Index = static_cast<int8>(EWeaponSlot::FirstWeaponSlot) - 1;
+			WeaponSlot = EWeaponSlot::FirstWeaponSlot;
 		}
 
-		ARSDungeonGroundWeapon* GroundWeapon = GetWorld()->SpawnActor<ARSDungeonGroundWeapon>(ARSDungeonGroundWeapon::StaticClass(), CurCharacter->GetActorTransform());
+		// ê¸°ì¡´ ë¬´ê¸°ë¥¼ ë²„ë¦°ë‹¤.
+		DropWeaponToSlot(WeaponSlot);
 
-		FName WeaponKey = WeaponActors[Index]->GetDataTableKey();
-
-		FDungeonItemData* Data = CurCharacter->GetGameInstance()->GetSubsystem<URSDataSubsystem>()->Weapon->FindRow<FDungeonItemData>(WeaponKey, TEXT("Get WeaponData"));
-
-		if (Data)
-		{
-			UStaticMesh* ItemStaticMesh = Data->ItemStaticMesh;
-			TSubclassOf<ARSDungeonItemBase> ItemClass = Data->ItemClass;
-
-			if (GroundWeapon && ItemStaticMesh && ItemClass)
-			{
-				GroundWeapon->InitInteractableWeapon(WeaponKey, ItemStaticMesh, ItemClass);
-			}
-		}
-
-		// ±âÁ¸¿¡ ÀåÂøÇÏ´ø ¹«±â Á¦°Å
-		WeaponActors[Index]->Destroy();
+		// ìƒˆë¡œìš´ ë¬´ê¸°ë¥¼ ì¥ì°©
 		WeaponActors[Index] = NewWeaponActor;
 
-		// »õ·Î¿î ¹«±â¸¦ ÀåÂø
 		EWeaponSlot TempWeaponSlot = WeaponSlot;
 		WeaponSlot = EWeaponSlot::NONE;
 		EquipWeaponToCharacter(TempWeaponSlot);
 
-		// UI °»½ÅµÇµµ·Ï ÀÌº¥Æ® µğ½ºÆĞÃ³ È£Ãâ
+		// UI ê°±ì‹ ë˜ë„ë¡ ì´ë²¤íŠ¸ ë””ìŠ¤íŒ¨ì²˜ í˜¸ì¶œ
 		FName NewWeaponKey = NewWeaponActor->GetDataTableKey();
 
 		ARSDunPlayerController* PC = Cast<ARSDunPlayerController>(CurCharacter->GetController());
@@ -245,74 +230,107 @@ void URSPlayerWeaponComponent::EquipWeaponToSlot(ARSBaseWeapon* NewWeaponActor)
 	}
 }
 
-void URSPlayerWeaponComponent::EquipWeaponToCharacter(EWeaponSlot TargetWeaponSlot)
+void URSPlayerWeaponComponent::DropWeaponToSlot(EWeaponSlot TargetWeaponSlot)
 {
-	// Àß¸øµÈ °ªÀÌ µé¾î¿Ô´ÂÁö È®ÀÎ
+	// ì˜ëª»ëœ ê°’ì´ ë“¤ì–´ì™”ëŠ”ì§€ í™•ì¸
 	if (EWeaponSlot::NONE == TargetWeaponSlot)
 	{
 		return;
 	}
 
-	// ¹Ù²Ù·Á´Â ½½·ÔÀÌ ºñ¾îÀÖ´Â °æ¿ì Ãë¼Ò
+	// ë²„ë¦¬ë ¤ëŠ” ìŠ¬ë¡¯ì´ ë¹„ì–´ìˆëŠ” ê²½ìš° ì·¨ì†Œ
+	int8 TargetIndex = static_cast<int8>(TargetWeaponSlot) - 1;
+	if (!WeaponActors.IsValidIndex(TargetIndex) || !WeaponActors[TargetIndex])
+	{
+		return;
+	}
+
+	ACharacter* CurCharacter = GetOwner<ACharacter>();
+	if (!CurCharacter)
+	{
+		return;
+	}
+
+	// ë•…ì— ë²„ë ¤ì§ˆ ì•¡í„° ìƒì„±
+	ARSDungeonGroundWeapon* GroundWeapon = GetWorld()->SpawnActor<ARSDungeonGroundWeapon>(ARSDungeonGroundWeapon::StaticClass(), CurCharacter->GetActorTransform());
+
+	// ë•…ì— ë²„ë ¤ì§ˆ ì•¡í„°ì— ì„¸íŒ…í•  ê°’ì„ ë°ì´í„° í…Œì´ë¸”ì— ê°€ì ¸ì™€ ì„¸íŒ…í•œë‹¤.
+	FName WeaponKey = WeaponActors[TargetIndex]->GetDataTableKey();
+
+	FDungeonItemData* Data = CurCharacter->GetGameInstance()->GetSubsystem<URSDataSubsystem>()->Weapon->FindRow<FDungeonItemData>(WeaponKey, TEXT("Get WeaponData"));
+	if (Data)
+	{
+		UStaticMesh* ItemStaticMesh = Data->ItemStaticMesh;
+		TSubclassOf<ARSDungeonItemBase> ItemClass = Data->ItemClass;
+
+		if (GroundWeapon && ItemStaticMesh && ItemClass)
+		{
+			GroundWeapon->InitInteractableWeapon(WeaponKey, ItemStaticMesh, ItemClass);
+		}
+	}
+
+	// ê¸°ì¡´ì— ì¥ì°©í•˜ë˜ ë¬´ê¸° ì¥ì°© í•´ì œ
+	UnEquipWeaponToCharacter();
+
+	// ê¸°ì¡´ì— ì¥ì°©í•˜ë˜ ë¬´ê¸° ì œê±°
+	WeaponActors[TargetIndex]->Destroy();
+	WeaponActors[TargetIndex] = nullptr;
+
+	// UI ê°±ì‹ ë˜ë„ë¡ ì´ë²¤íŠ¸ ë””ìŠ¤íŒ¨ì²˜ í˜¸ì¶œ
+	ARSDunPlayerController* PC = Cast<ARSDunPlayerController>(CurCharacter->GetController());
+	if (PC)
+	{
+		PC->OnWeaponSlotChange.Broadcast(static_cast<int8>(TargetWeaponSlot), FName(""));
+	}
+}
+
+void URSPlayerWeaponComponent::EquipWeaponToCharacter(EWeaponSlot TargetWeaponSlot)
+{
+	// ì˜ëª»ëœ ê°’ì´ ë“¤ì–´ì™”ëŠ”ì§€ í™•ì¸
+	if (EWeaponSlot::NONE == TargetWeaponSlot)
+	{
+		return;
+	}
+
+	// ë°”ê¾¸ë ¤ëŠ” ìŠ¬ë¡¯ì´ ë¹„ì–´ìˆëŠ” ê²½ìš° ì·¨ì†Œ
 	int8 TargetIndex = static_cast<int8>(TargetWeaponSlot) - 1;
 	if (!WeaponActors.IsValidIndex(TargetIndex) || !WeaponActors[TargetIndex])
 	{
 		return;
 	}
 	
-	// ¹Ù²Ù·Á´Â ½½·ÔÀÌ ÇöÀç ½½·ÔÀÎ °æ¿ì Ãë¼Ò
+	// ë°”ê¾¸ë ¤ëŠ” ìŠ¬ë¡¯ì´ í˜„ì¬ ìŠ¬ë¡¯ì¸ ê²½ìš° ì·¨ì†Œ
 	int8 CurrentIndex = static_cast<int8>(WeaponSlot) - 1;
 	if (CurrentIndex == TargetIndex)
 	{
 		return;
 	}
 
-	// ±âÁ¸¿¡ Âø¿ëÇÏ°í ÀÖ´ø ¹«±â°¡ À¯È¿ÇÑ °æ¿ì
+	// ê¸°ì¡´ì— ì°©ìš©í•˜ê³  ìˆë˜ ë¬´ê¸°ê°€ ìœ íš¨í•œ ê²½ìš°
 	if (WeaponActors.IsValidIndex(CurrentIndex) && WeaponActors[CurrentIndex])
 	{
-		// ÇöÀç Âø¿ë ÁßÀÎ ¹«±â°¡ ÀÖ´Â °æ¿ì ¼û±è Ã³¸® ¹× Ãæµ¹À» ²ö´Ù.
-		ARSBaseWeapon* CurEquipWeapon = WeaponActors[CurrentIndex];
-		if (CurEquipWeapon)
-		{
-			CurEquipWeapon->SetActorHiddenInGame(true);
-			CurEquipWeapon->SetActorEnableCollision(false);
-
-			// ¿À¹ö·¦ ÀÌº¥Æ® ¹ÙÀÎµù ÇØÁ¦
-			WeaponActors[CurrentIndex]->GetBoxComp()->OnComponentBeginOverlap.RemoveDynamic(this, &URSPlayerWeaponComponent::OnBeginOverlap);
-
-			// ¹«±âÀÇ ¾Ö´Ô ·¹ÀÌ¾î¸¦ ÇØÁ¦ÇÑ´Ù.
-			TSubclassOf<UAnimInstance> CurAnimInstance = CurEquipWeapon->GetWeaponAnimInstnace();
-
-			ACharacter* CurCharacter = GetOwner<ACharacter>();
-			if (CurCharacter)
-			{
-				USkeletalMeshComponent* SkeletalMeshComp = CurCharacter->GetMesh();
-				if (SkeletalMeshComp)
-				{
-					SkeletalMeshComp->UnlinkAnimClassLayers(CurAnimInstance);
-				}
-			}
-		}
+		// ì¥ì°© ì¤‘ì¸ ë¬´ê¸°ë¥¼ ì œê±°í•œë‹¤.
+		UnEquipWeaponToCharacter();
 	}
 
-	// »õ·Î Âø¿ëÇÒ ¹«±â°¡ À¯È¿ÇÑ °æ¿ì
+	// ìƒˆë¡œ ì°©ìš©í•  ë¬´ê¸°ê°€ ìœ íš¨í•œ ê²½ìš°
 	if (WeaponActors.IsValidIndex(TargetIndex) && WeaponActors[TargetIndex])
 	{
-		// »õ·Î Âø¿ëÇÒ ¹«±âÀÇ ¼û±è Ã³¸®¸¦ ²ô°í, Ãæµ¹À» ÄÒ´Ù.
 		ARSBaseWeapon* TargetEquipWeapon = WeaponActors[TargetIndex];
 		if (TargetEquipWeapon)
 		{
+			// ìƒˆë¡œ ì°©ìš©í•  ë¬´ê¸°ì˜ ìˆ¨ê¹€ ì²˜ë¦¬ë¥¼ ë„ê³ , ì¶©ëŒì„ ì¼ ë‹¤.
 			TargetEquipWeapon->SetActorHiddenInGame(false);
 			TargetEquipWeapon->SetActorEnableCollision(true);
 			
-			// ¿À¹ö·¦ ÀÌº¥Æ® ¹ÙÀÎµù
+			// ì˜¤ë²„ë© ì´ë²¤íŠ¸ ë°”ì¸ë”©
 			UBoxComponent* CurWeaponBoxComp = TargetEquipWeapon->GetBoxComp();
 			if (CurWeaponBoxComp)
 			{
 				CurWeaponBoxComp->OnComponentBeginOverlap.AddDynamic(this, &URSPlayerWeaponComponent::OnBeginOverlap);
 			}
 
-			// ¹«±âÀÇ ¾Ö´Ô ·¹ÀÌ¾î¸¦ Àû¿ëÇÑ´Ù.
+			// ë¬´ê¸°ì˜ ì• ë‹˜ ë ˆì´ì–´ë¥¼ ì ìš©í•œë‹¤.
 			TSubclassOf<UAnimInstance> TargetAnimInstance = TargetEquipWeapon->GetWeaponAnimInstnace();
 
 			ACharacter* CurCharacter = GetOwner<ACharacter>();
@@ -325,15 +343,53 @@ void URSPlayerWeaponComponent::EquipWeaponToCharacter(EWeaponSlot TargetWeaponSl
 				}
 			}
 
-			// ÇöÀç ½½·ÔÀ» º¯°æÇÑ´Ù.
+			// í˜„ì¬ ìŠ¬ë¡¯ì„ ë³€ê²½í•œë‹¤.
 			WeaponSlot = TargetWeaponSlot;
 		}
 	}
 }
 
+void URSPlayerWeaponComponent::UnEquipWeaponToCharacter()
+{
+	// ì˜ëª»ëœ ê°’ì´ ë“¤ì–´ì™”ëŠ”ì§€ í™•ì¸
+	if (EWeaponSlot::NONE == WeaponSlot)
+	{
+		return;
+	}
+
+	int8 CurrentIndex = static_cast<int8>(WeaponSlot) - 1;
+
+	// í˜„ì¬ ì°©ìš© ì¤‘ì¸ ë¬´ê¸°ê°€ ìˆëŠ” ê²½ìš° ìˆ¨ê¹€ ì²˜ë¦¬ ë° ì¶©ëŒì„ ëˆë‹¤.
+	ARSBaseWeapon* CurEquipWeapon = WeaponActors[CurrentIndex];
+	if (CurEquipWeapon)
+	{
+		CurEquipWeapon->SetActorHiddenInGame(true);
+		CurEquipWeapon->SetActorEnableCollision(false);
+
+		// ì˜¤ë²„ë© ì´ë²¤íŠ¸ ë°”ì¸ë”© í•´ì œ
+		WeaponActors[CurrentIndex]->GetBoxComp()->OnComponentBeginOverlap.RemoveDynamic(this, &URSPlayerWeaponComponent::OnBeginOverlap);
+
+		// ë¬´ê¸°ì˜ ì• ë‹˜ ë ˆì´ì–´ë¥¼ í•´ì œí•œë‹¤.
+		TSubclassOf<UAnimInstance> CurAnimInstance = CurEquipWeapon->GetWeaponAnimInstnace();
+
+		ACharacter* CurCharacter = GetOwner<ACharacter>();
+		if (CurCharacter)
+		{
+			USkeletalMeshComponent* SkeletalMeshComp = CurCharacter->GetMesh();
+			if (SkeletalMeshComp)
+			{
+				SkeletalMeshComp->UnlinkAnimClassLayers(CurAnimInstance);
+			}
+		}
+
+		// í˜„ì¬ ìŠ¬ë¡¯ì„ ë³€ê²½í•œë‹¤.
+		WeaponSlot = EWeaponSlot::NONE;
+	}
+}
+
 void URSPlayerWeaponComponent::StartAttackOverlap()
 {
-	// Äİ¸®ÀüÀ» ÄÒ´Ù.
+	// ì½œë¦¬ì „ì„ ì¼ ë‹¤.
 	int8 Index = static_cast<int8>(WeaponSlot) - 1;
 	if (WeaponActors.IsValidIndex(Index))
 	{
@@ -343,20 +399,20 @@ void URSPlayerWeaponComponent::StartAttackOverlap()
 
 void URSPlayerWeaponComponent::EndAttackOverlap()
 {
-	// Äİ¸®ÀüÀ» ²ö´Ù.
+	// ì½œë¦¬ì „ì„ ëˆë‹¤.
 	int8 Index = static_cast<int8>(WeaponSlot) - 1;
 	if (WeaponActors.IsValidIndex(Index))
 	{
 		WeaponActors[Index]->EndOverlap();
 	}
 
-	// ÇØ´ç ¹«±â·Î ÇÇÇØ¸¦ ÀÔÀº ¾×ÅÍµéÀÇ ¸ñ·ÏÀ» ÃÊ±âÈ­ÇÑ´Ù.
+	// í•´ë‹¹ ë¬´ê¸°ë¡œ í”¼í•´ë¥¼ ì…ì€ ì•¡í„°ë“¤ì˜ ëª©ë¡ì„ ì´ˆê¸°í™”í•œë‹¤.
 	DamagedActors.Empty();
 }
 
 void URSPlayerWeaponComponent::OnBeginOverlap(UPrimitiveComponent* OverlappedComp, AActor* OtherActor, UPrimitiveComponent* OtherComp, int32 OtherBodyIndex, bool bFromSweep, const FHitResult& SweepResult)
 {
-	// ¿À¹ö·¦ µÈ ¾×ÅÍ¿¡°Ô µ¥¹ÌÁö¸¦ °¡ÇÑ´Ù.
+	// ì˜¤ë²„ë© ëœ ì•¡í„°ì—ê²Œ ë°ë¯¸ì§€ë¥¼ ê°€í•œë‹¤.
 	ARSDunPlayerCharacter* OwnerCharacter = GetOwner<ARSDunPlayerCharacter>();
 
 	AController* OwnerController = nullptr;
@@ -383,11 +439,11 @@ void URSPlayerWeaponComponent::OnBeginOverlap(UPrimitiveComponent* OverlappedCom
 
 void URSPlayerWeaponComponent::SaveRequested()
 {
-	// SaveGame ¿ÀºêÁ§Æ® »ı¼º
+	// SaveGame ì˜¤ë¸Œì íŠ¸ ìƒì„±
 	URSDungeonWeaponSaveGame* WeaponSaveGame = Cast<URSDungeonWeaponSaveGame>(UGameplayStatics::CreateSaveGameObject(URSDungeonWeaponSaveGame::StaticClass()));
 
 	WeaponSaveGame->WeaponActors.SetNum(WeaponSlotSize);
-	// ¹«±â Á¤º¸ ÀúÀå
+	// ë¬´ê¸° ì •ë³´ ì €ì¥
 	for (int i = 0; i < WeaponActors.Num(); ++i)
 	{
 		ARSBaseWeapon* Weapon = WeaponActors[i];
@@ -397,17 +453,17 @@ void URSPlayerWeaponComponent::SaveRequested()
 		}
 	}
 
-	// ÀåÂø ÁßÀÎ ¹«±â ½½·Ô ÀúÀå
+	// ì¥ì°© ì¤‘ì¸ ë¬´ê¸° ìŠ¬ë¡¯ ì €ì¥
 	int8 CurWeaponSlot = static_cast<int8>(WeaponSlot);
 	WeaponSaveGame->WeaponSlot = CurWeaponSlot;
 	
-	// ÀúÀå
+	// ì €ì¥
 	UGameplayStatics::SaveGameToSlot(WeaponSaveGame, WeaponSaveSlotName, 0);
 }
 
 void URSPlayerWeaponComponent::LoadRequested()
 {
-	// ³Î Ã¼Å©
+	// ë„ ì²´í¬
 	URSDungeonWeaponSaveGame* WeaponLoadGame = Cast<URSDungeonWeaponSaveGame>(UGameplayStatics::LoadGameFromSlot(WeaponSaveSlotName, 0));
 	if (!WeaponLoadGame)
 	{
@@ -439,10 +495,10 @@ void URSPlayerWeaponComponent::LoadRequested()
 		return;
 	}
 
-	// ÀúÀåµÈ ¹«±â Á¤º¸¸¦ °¡Á®¿Â´Ù.
+	// ì €ì¥ëœ ë¬´ê¸° ì •ë³´ë¥¼ ê°€ì ¸ì˜¨ë‹¤.
 	TArray<FName> LoadWeaponName = WeaponLoadGame->WeaponActors;
 
-	// ÀúÀåµÈ ¹«±â Á¤º¸¸¦ ±âÁØÀ¸·Î ÀåÂøÇÒ ¹«±â ¾×ÅÍ¸¦ »ı¼ºÇÏ°í ½½·Ô¿¡ ÀúÀåÇÑ´Ù.
+	// ì €ì¥ëœ ë¬´ê¸° ì •ë³´ë¥¼ ê¸°ì¤€ìœ¼ë¡œ ì¥ì°©í•  ë¬´ê¸° ì•¡í„°ë¥¼ ìƒì„±í•˜ê³  ìŠ¬ë¡¯ì— ì €ì¥í•œë‹¤.
 	for (int i = 0; i < LoadWeaponName.Num(); ++i)
 	{
 		if (LoadWeaponName[i].IsNone())
@@ -470,7 +526,7 @@ void URSPlayerWeaponComponent::LoadRequested()
 		}
 	}
 
-	// ÀåÂø ÇØ¾ßÇÏ´Â ½½·ÔÀ» °¡Á®¿À°í ¹«±â¸¦ ÀåÂøÇÑ´Ù.
+	// ì¥ì°© í•´ì•¼í•˜ëŠ” ìŠ¬ë¡¯ì„ ê°€ì ¸ì˜¤ê³  ë¬´ê¸°ë¥¼ ì¥ì°©í•œë‹¤.
 	EWeaponSlot TargetWeaponSlot = static_cast<EWeaponSlot>(WeaponLoadGame->WeaponSlot);
 	EquipWeaponToCharacter(TargetWeaponSlot);
 }

--- a/Source/RogShop/ActorComponent/RSPlayerWeaponComponent.h
+++ b/Source/RogShop/ActorComponent/RSPlayerWeaponComponent.h
@@ -35,33 +35,41 @@ public:
 
 	void ResetCombo();
 
+	// ìŠ¬ë¡¯ì— ë¬´ê¸°ë¥¼ ì¶”ê°€í•œë‹¤.
 	UFUNCTION(BlueprintCallable)
 	void EquipWeaponToSlot(ARSBaseWeapon* WeaponActor);
 
+	// íŠ¹ì • ìŠ¬ë¡¯ì˜ ë¬´ê¸°ë¥¼ ë²„ë¦°ë‹¤.
+	void DropWeaponToSlot(EWeaponSlot TargetWeaponSlot);
+
+	// íŠ¹ì • ìŠ¬ë¡¯ì˜ ë¬´ê¸°ë¥¼ ì¥ì°©í•œë‹¤.
 	void EquipWeaponToCharacter(EWeaponSlot TargetWeaponSlot);
 
+	// ì¥ì°© ì¤‘ì¸ ë¬´ê¸°ë¥¼ ì¥ì°© í•´ì œí•œë‹¤.
+	void UnEquipWeaponToCharacter();
+
 private:
-	// ¹«±â
+	// ë¬´ê¸°
 	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Weapon", meta = (AllowPrivateAccess = true))
-	TArray<TObjectPtr<ARSBaseWeapon>> WeaponActors; // ¹«±â ¾×ÅÍ
+	TArray<TObjectPtr<ARSBaseWeapon>> WeaponActors; // ë¬´ê¸° ì•¡í„°
 
 	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Weapon", meta = (AllowPrivateAccess = true))
-	EWeaponSlot WeaponSlot;	// 1-based, ÇöÀç ÀåÂøÁßÀÎ ¹«±â ½½·ÔÀ» ÀÇ¹ÌÇÑ´Ù.
+	EWeaponSlot WeaponSlot;	// 1-based, í˜„ì¬ ì¥ì°©ì¤‘ì¸ ë¬´ê¸° ìŠ¬ë¡¯ì„ ì˜ë¯¸í•œë‹¤.
 
 	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Weapon", meta = (AllowPrivateAccess = true))
-	int32 WeaponSlotSize;	// ÃÖ´ë ½½·Ô ¼ö
+	int32 WeaponSlotSize;	// ìµœëŒ€ ìŠ¬ë¡¯ ìˆ˜
 
-	// ¾Ö´Ï¸ŞÀÌ¼ÇÀ» À§ÇÑ »óÅÂ
+	// ì• ë‹ˆë©”ì´ì…˜ì„ ìœ„í•œ ìƒíƒœ
 	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Weapon", meta = (AllowPrivateAccess = true))
-	bool bIsAttack;	// °ø°İ ÁßÀÎ »óÅÂ
-
-	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Weapon", meta = (AllowPrivateAccess = true))
-	bool bComboInputBuffered;	// °ø°İ ÁßÀÏ ¶§ µé¾î¿Â ÀÔ·Â ¹öÆÛ
+	bool bIsAttack;	// ê³µê²© ì¤‘ì¸ ìƒíƒœ
 
 	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Weapon", meta = (AllowPrivateAccess = true))
-	int32 ComboIndex;	// ÄŞº¸ °ø°İÀ» À§ÇÑ ÀÎµ¦½º °ª
+	bool bComboInputBuffered;	// ê³µê²© ì¤‘ì¼ ë•Œ ë“¤ì–´ì˜¨ ì…ë ¥ ë²„í¼
 
-// Ãæµ¹ ·ÎÁ÷ °ü¸®
+	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Weapon", meta = (AllowPrivateAccess = true))
+	int32 ComboIndex;	// ì½¤ë³´ ê³µê²©ì„ ìœ„í•œ ì¸ë±ìŠ¤ ê°’
+
+// ì¶©ëŒ ë¡œì§ ê´€ë¦¬
 public:
 	void StartAttackOverlap();
 	void EndAttackOverlap();
@@ -72,9 +80,9 @@ protected:
 
 private:
 	UPROPERTY()
-	TSet<AActor*> DamagedActors;	// µ¥¹ÌÁö ÀÔÀº ¾×ÅÍ ÀúÀå
+	TSet<AActor*> DamagedActors;	// ë°ë¯¸ì§€ ì…ì€ ì•¡í„° ì €ì¥
 
-// ¼¼ÀÌºê/·Îµå
+// ì„¸ì´ë¸Œ/ë¡œë“œ
 private:
 	UFUNCTION()
 	void SaveRequested();

--- a/Source/RogShop/Widget/Dungeon/RSInventoryWeaponSlotWidget.cpp
+++ b/Source/RogShop/Widget/Dungeon/RSInventoryWeaponSlotWidget.cpp
@@ -4,6 +4,8 @@
 #include "RSInventoryWeaponSlotWidget.h"
 
 #include "RSDunPlayerController.h"
+#include "RSDunPlayerCharacter.h"
+#include "RSPlayerWeaponComponent.h"
 #include "RSDataSubsystem.h"
 #include "DungeonItemData.h"
 
@@ -66,6 +68,17 @@ void URSInventoryWeaponSlotWidget::HandleLongPress()
     UE_LOG(LogTemp, Warning, TEXT("Long Press Detected on URSInventoryWeaponSlotWidget Index: %d"), (int32)HeldSlotType);
 
     // 추가 작업 필요
+    ARSDunPlayerCharacter* DunPlayerChar = GetOwningPlayerPawn<ARSDunPlayerCharacter>();
+    if (!DunPlayerChar)
+    {
+        return;
+    }
+
+    URSPlayerWeaponComponent* PlayerWeaponComp = DunPlayerChar->GetRSPlayerWeaponComponent();
+    if (PlayerWeaponComp)
+    {
+        PlayerWeaponComp->DropWeaponToSlot(static_cast<EWeaponSlot>(HeldSlotType));
+    }
 }
 
 void URSInventoryWeaponSlotWidget::UpdateWeaponSlot(uint8 SlotIndex, FName WeaponKey)
@@ -103,7 +116,14 @@ void URSInventoryWeaponSlotWidget::UpdateWeaponSlot(uint8 SlotIndex, FName Weapo
             }
             else
             {
-                UE_LOG(LogTemp, Warning, TEXT("Not FoundData"));
+                if (SlotIndex == 1)
+                {
+                    WeaponSlot1->SetBrushFromTexture(nullptr);
+                }
+                else if (SlotIndex == 2)
+                {
+                    WeaponSlot2->SetBrushFromTexture(nullptr);
+                }
             }
         }
     }

--- a/Source/RogShop/Widget/Dungeon/RSPlayerStatusWidget.cpp
+++ b/Source/RogShop/Widget/Dungeon/RSPlayerStatusWidget.cpp
@@ -66,7 +66,14 @@ void URSPlayerStatusWidget::UpdateWeaponSlot(uint8 SlotIndex, FName WeaponKey)
             }
             else
             {
-                UE_LOG(LogTemp, Warning, TEXT("Not FoundData"));
+                if (SlotIndex == 0 || SlotIndex == 1)
+                {
+                    WeaponSlot1->SetBrushFromTexture(nullptr);
+                }
+                else
+                {
+                    WeaponSlot2->SetBrushFromTexture(nullptr);
+                }
             }
         }
     }


### PR DESCRIPTION
무기를 버리는 함수를 추가했습니다.
해당 함수는 UI에서 특정 슬롯을 특정 시간동안 클릭하고 있을 때, 호출됩니다.

무기를 버릴 때 드랍된 액터를 의미하는 ARSDungeonGroundWeapon 클래스를 생성하고 버려지는 무기의 값을 설정해주었습니다.
기존에 장착 중인 무기를 버리는 경우 장착이 해제되도록 했습니다.

기존에 무기를 장착 해제하던 로직을 2곳 이상에서 호출하므로, 함수화 했습니다.

무기를 버릴 때 UI가 갱신되도록 이벤트 디스패처를 호출합니다.
이때, WeaponKey에 빈 값을 넘겨주어 UI를 빈칸으로 만들어줍니다.