### PR TITLE
폰 콜리전이 카메라 스프링암에 영향을 주지 않도록 수정

### DIFF
--- a/Config/DefaultEngine.ini
+++ b/Config/DefaultEngine.ini
@@ -305,6 +305,7 @@ ManualIPAddress=
 +DefaultChannelResponses=(Channel=ECC_GameTraceChannel5,DefaultResponse=ECR_Ignore,bTraceType=False,bStaticObject=False,Name="MonsterAttack")
 +DefaultChannelResponses=(Channel=ECC_GameTraceChannel6,DefaultResponse=ECR_Ignore,bTraceType=True,bStaticObject=False,Name="PatrolPoint")
 +DefaultChannelResponses=(Channel=ECC_GameTraceChannel7,DefaultResponse=ECR_Ignore,bTraceType=True,bStaticObject=False,Name="MonsterAttackTrace")
++EditProfiles=(Name="Pawn",CustomResponses=((Channel="Camera",Response=ECR_Ignore),(Channel="PlayerPawn",Response=ECR_Ignore),(Channel="MonsterPawn",Response=ECR_Ignore)))
 -ProfileRedirects=(OldName="BlockingVolume",NewName="InvisibleWall")
 -ProfileRedirects=(OldName="InterpActor",NewName="IgnoreOnlyPawn")
 -ProfileRedirects=(OldName="StaticMeshComponent",NewName="BlockAllDynamic")


### PR DESCRIPTION
Pawn 프리셋에서 Camera 채널을 Block에서 Ingnore로 변경하여 카메라 스프링 암에 영향을 주지 않도록 변경했습니다.