### PR TITLE
[bugFix] 무기를 장착만 해도 오버랩 이벤트가 발생하던 현상 수정

### DIFF
--- a/Source/RogShop/Actor/Dungeon/Weapon/RSBaseWeapon.cpp
+++ b/Source/RogShop/Actor/Dungeon/Weapon/RSBaseWeapon.cpp
@@ -21,6 +21,9 @@ ARSBaseWeapon::ARSBaseWeapon()
 	BoxComp->SetupAttachment(SceneComp);
 	BoxComp->SetCollisionProfileName("PlayerAttackHitBox");
 	BoxComp->SetCollisionEnabled(ECollisionEnabled::NoCollision);
+	BoxComp->SetGenerateOverlapEvents(false);
+
+	SetActorEnableCollision(false);
 
 	WeaponDamage = 0.f;
 }
@@ -59,14 +62,18 @@ const TArray<UAnimMontage*>& ARSBaseWeapon::GetNormalAttacks() const
 
 void ARSBaseWeapon::StartOverlap()
 {
-	// ÄÝ¸®ÀüÀ» ÄÒ´Ù.
+	// ì½œë¦¬ì „ê³¼ ì˜¤ë²„ëž© ì´ë²¤íŠ¸ë¥¼ ì¼ ë‹¤.
+	SetActorEnableCollision(true);
 	BoxComp->SetCollisionEnabled(ECollisionEnabled::QueryOnly);
+	BoxComp->SetGenerateOverlapEvents(true);
 }
 
 void ARSBaseWeapon::EndOverlap()
 {
-	// ÄÝ¸®ÀüÀ» ²ö´Ù.
+	// ì½œë¦¬ì „ê³¼ ì˜¤ë²„ëž© ì´ë²¤íŠ¸ë¥¼ ëˆë‹¤.
+	SetActorEnableCollision(false);
 	BoxComp->SetCollisionEnabled(ECollisionEnabled::NoCollision);
+	BoxComp->SetGenerateOverlapEvents(false);
 }
 
 float ARSBaseWeapon::GetWeaponDamage() const

--- a/Source/RogShop/ActorComponent/RSPlayerWeaponComponent.cpp
+++ b/Source/RogShop/ActorComponent/RSPlayerWeaponComponent.cpp
@@ -148,9 +148,8 @@ void URSPlayerWeaponComponent::EquipWeaponToSlot(ARSBaseWeapon* NewWeaponActor)
 		WeaponActors.SetNum(WeaponSlotSize);
 	}
 
-	// 슬롯에 포함할 액터를 숨김처리 및 충돌을 끈다.
+	// 슬롯에 포함할 액터를 숨김처리
 	NewWeaponActor->SetActorHiddenInGame(true);
-	NewWeaponActor->SetActorEnableCollision(false);
 
 	// 캐릭터의 손에 무기를 부착한다.
 	ACharacter* CurCharacter = GetOwner<ACharacter>();
@@ -322,9 +321,8 @@ void URSPlayerWeaponComponent::EquipWeaponToCharacter(EWeaponSlot TargetWeaponSl
 		ARSBaseWeapon* TargetEquipWeapon = WeaponActors[TargetIndex];
 		if (TargetEquipWeapon)
 		{
-			// 새로 착용할 무기의 숨김 처리를 끄고, 충돌을 켠다.
+			// 새로 착용할 무기의 숨김 처리를 끈다.
 			TargetEquipWeapon->SetActorHiddenInGame(false);
-			TargetEquipWeapon->SetActorEnableCollision(true);
 			
 			// 오버랩 이벤트 바인딩
 			UBoxComponent* CurWeaponBoxComp = TargetEquipWeapon->GetBoxComp();
@@ -362,12 +360,12 @@ void URSPlayerWeaponComponent::UnEquipWeaponToCharacter()
 
 	int8 CurrentIndex = static_cast<int8>(WeaponSlot) - 1;
 
-	// 현재 착용 중인 무기가 있는 경우 숨김 처리 및 충돌을 끈다.
+	// 현재 착용 중인 무기가 있는 경우
 	ARSBaseWeapon* CurEquipWeapon = WeaponActors[CurrentIndex];
 	if (CurEquipWeapon)
 	{
+		// 숨김 처리
 		CurEquipWeapon->SetActorHiddenInGame(true);
-		CurEquipWeapon->SetActorEnableCollision(false);
 
 		// 오버랩 이벤트 바인딩 해제
 		WeaponActors[CurrentIndex]->GetBoxComp()->OnComponentBeginOverlap.RemoveDynamic(this, &URSPlayerWeaponComponent::OnBeginOverlap);


### PR DESCRIPTION
URSPlayerWeaponComponent에서 콜리전을 관리하던 것을 ARSBaseWeapon의 함수가 호출될 때 직접 관리하도록 변경