### PR TITLE
[Add] 보스 처치시 스폰되어 상호작용이 가능한 액터 추가

### DIFF
--- a/Content/Blueprints/Actor/Dungeon/BP_DunNextStagePortal.uasset
+++ b/Content/Blueprints/Actor/Dungeon/BP_DunNextStagePortal.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:071bc12e78c026a778b6f27a89dc4fbe05242f50d9a728a63180f9ef3a8bcec2
+size 38928

--- a/Content/Blueprints/Widgets/Dungeon/WBP_SendIngredient.uasset
+++ b/Content/Blueprints/Widgets/Dungeon/WBP_SendIngredient.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2996fe1721ba08b9f353d3aca710d1cc44fd9a1adf46f06bdbfb28e952a94d44
+size 30407

--- a/Source/RogShop/Actor/Dungeon/RSDunNextStagePortal.cpp
+++ b/Source/RogShop/Actor/Dungeon/RSDunNextStagePortal.cpp
@@ -1,0 +1,51 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "RSDunNextStagePortal.h"
+#include "Blueprint/UserWidget.h"
+#include "RSDunPlayerCharacter.h"
+#include "GameFramework/PlayerController.h"
+
+ARSDunNextStagePortal::ARSDunNextStagePortal()
+{
+	PrimaryActorTick.bCanEverTick = false;
+
+	SceneComp = CreateDefaultSubobject<USceneComponent>(TEXT("Scene"));
+	SetRootComponent(SceneComp);
+
+	MeshComp = CreateDefaultSubobject<UStaticMeshComponent>(TEXT("StaticMesh"));
+	MeshComp->SetupAttachment(SceneComp);
+	MeshComp->SetCollisionProfileName("Interactable");
+}
+
+void ARSDunNextStagePortal::BeginPlay()
+{
+	Super::BeginPlay();
+	
+}
+
+void ARSDunNextStagePortal::Interact(ARSDunPlayerCharacter* Interactor)
+{
+	if (SendIngredientWidgetClass && Interactor)
+	{
+		APlayerController* PC = Interactor->GetController<APlayerController>();
+		if (!PC)
+		{
+			return;
+		}
+
+		SendIngredientWidgetInstance = CreateWidget<UUserWidget>(PC, SendIngredientWidgetClass);
+
+		if (!SendIngredientWidgetInstance)
+		{
+			return;
+		}
+
+		SendIngredientWidgetInstance->AddToViewport();
+
+		FInputModeUIOnly InputMode;
+		PC->SetInputMode(InputMode);
+		PC->SetShowMouseCursor(true);
+		PC->FlushPressedKeys();
+	}
+}

--- a/Source/RogShop/Actor/Dungeon/RSDunNextStagePortal.h
+++ b/Source/RogShop/Actor/Dungeon/RSDunNextStagePortal.h
@@ -1,0 +1,39 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GameFramework/Actor.h"
+#include "RSInteractable.h"
+#include "RSDunNextStagePortal.generated.h"
+
+UCLASS()
+class ROGSHOP_API ARSDunNextStagePortal : public AActor, public IRSInteractable
+{
+	GENERATED_BODY()
+	
+public:	
+	ARSDunNextStagePortal();
+
+protected:
+	virtual void BeginPlay() override;
+
+// 컴포넌트
+private:
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Component", meta = (AllowPrivateAccess = true))
+	TObjectPtr<USceneComponent> SceneComp;
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Component", meta = (AllowPrivateAccess = true))
+	TObjectPtr<UStaticMeshComponent> MeshComp;
+
+// 상호작용
+public:
+	virtual void Interact(ARSDunPlayerCharacter* Interactor) override;
+
+// 상호작용시 띄워줄 UI
+private:
+	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "UI", meta = (AllowPrivateAccess = "true"))
+	TSubclassOf<UUserWidget> SendIngredientWidgetClass;
+
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "UI", meta = (AllowPrivateAccess = "true"))
+	TObjectPtr<UUserWidget> SendIngredientWidgetInstance;
+};

--- a/Source/RogShop/GameModeBase/RSDungeonGameModeBase.cpp
+++ b/Source/RogShop/GameModeBase/RSDungeonGameModeBase.cpp
@@ -24,12 +24,12 @@ void ARSDungeonGameModeBase::BeginPlay()// 게임이 시작될 때 호출됨
 
     SpawnMap(CurrentMapType);
 
-
-
     if (MapGeneratorInstance)
     {
         MapGeneratorInstance->OnMapFullyLoaded.AddDynamic(this, &ARSDungeonGameModeBase::OnMapReady);// 맵 로딩 완료 시 콜백 등록
     }
+
+    OnBossDead.AddDynamic(this, &ARSDungeonGameModeBase::SpawnDunNextStagePortal);
 }
 
 
@@ -74,6 +74,19 @@ void ARSDungeonGameModeBase::SpawnMap(EMapType MapType)// 선택된 맵 타입�
             MapGeneratorInstance = GetWorld()->SpawnActor<ARSMapGenerator>(CaveMapGeneratorClass, Location, Rotation, SpawnParams);// 해당 맵 생성기 액터를 월드에 스폰
         }
         break;
+    }
+}
+
+void ARSDungeonGameModeBase::SpawnDunNextStagePortal()
+{
+    if (DunNextStagePortalClass)
+    {
+        FActorSpawnParameters SpawnParameters;
+        SpawnParameters.Owner = this;
+        SpawnParameters.Instigator = nullptr;
+
+        // TODO : 보스 맵의 특정 위치에 생성
+        DunNextStagePortalInstance = GetWorld()->SpawnActor<AActor>(DunNextStagePortalClass, FTransform(), SpawnParameters);
     }
 }
 

--- a/Source/RogShop/GameModeBase/RSDungeonGameModeBase.h
+++ b/Source/RogShop/GameModeBase/RSDungeonGameModeBase.h
@@ -17,6 +17,8 @@ enum class EMapType : uint8
 	Cave       UMETA(DisplayName = "동굴")
 };
 
+DECLARE_DYNAMIC_MULTICAST_DELEGATE(FOnBossDead);
+
 // 던전 게임모드 클래스 정의
 UCLASS()
 class ROGSHOP_API ARSDungeonGameModeBase : public AGameModeBase
@@ -72,4 +74,21 @@ public:
 
 private:
 	FTimerHandle WaitForMapHandle; // 맵 로딩 후 딜레이 핸들
+
+#pragma region StageClear
+public:
+	UPROPERTY(BlueprintAssignable)
+	FOnBossDead OnBossDead;
+
+private:
+	UFUNCTION()
+	void SpawnDunNextStagePortal();
+
+private:
+	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "StageClear", meta = (AllowPrivateAccess = "true"))
+	TSubclassOf<AActor> DunNextStagePortalClass;
+
+	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "StageClear", meta = (AllowPrivateAccess = "true"))
+	TObjectPtr<AActor> DunNextStagePortalInstance;
+#pragma endregion
 };

--- a/Source/RogShop/Widget/Dungeon/RSBaseItemSlotWidget.cpp
+++ b/Source/RogShop/Widget/Dungeon/RSBaseItemSlotWidget.cpp
@@ -1,0 +1,5 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "RSBaseItemSlotWidget.h"
+

--- a/Source/RogShop/Widget/Dungeon/RSBaseItemSlotWidget.h
+++ b/Source/RogShop/Widget/Dungeon/RSBaseItemSlotWidget.h
@@ -1,0 +1,17 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Blueprint/UserWidget.h"
+#include "RSBaseItemSlotWidget.generated.h"
+
+/**
+ * 
+ */
+UCLASS()
+class ROGSHOP_API URSBaseItemSlotWidget : public UUserWidget
+{
+	GENERATED_BODY()
+	
+};

--- a/Source/RogShop/Widget/Dungeon/RSSendIngredientWidget.cpp
+++ b/Source/RogShop/Widget/Dungeon/RSSendIngredientWidget.cpp
@@ -1,0 +1,49 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "RSSendIngredientWidget.h"
+#include "Components/Button.h"
+#include "GameFramework/PlayerController.h"
+#include "RSGameInstance.h"
+
+void URSSendIngredientWidget::NativeConstruct()
+{
+	Super::NativeConstruct();
+
+	if (ExitButton)
+	{
+		ExitButton->OnClicked.AddDynamic(this, &URSSendIngredientWidget::ExitWidget);
+	}
+
+	if (OKButton)
+	{
+		OKButton->OnClicked.AddDynamic(this, &URSSendIngredientWidget::NextStageTravel);
+	}
+
+	// TODO : 플레이어의 재료 인벤토리를 띄우고 재료 아이템 일부를 타이쿤으로 보낼 수 있도록 구현한다.
+}
+
+void URSSendIngredientWidget::NextStageTravel()
+{
+	// TODO : 재료를 보낼 수 있는 만큼 골랐는지 확인 후 적게 골랐다면 경고창을 띄운다.
+
+	URSGameInstance* GameInstance = GetGameInstance<URSGameInstance>();
+	if (GameInstance)
+	{
+		GameInstance->TravelToLevel(TargetLevelAsset);
+	}
+}
+
+void URSSendIngredientWidget::ExitWidget()
+{
+	APlayerController* PC = GetOwningPlayer();
+	if (PC)
+	{
+		FInputModeGameOnly InputMode;
+		PC->SetInputMode(InputMode);
+		PC->SetShowMouseCursor(false);
+		PC->FlushPressedKeys();
+	}
+
+	RemoveFromParent();
+}

--- a/Source/RogShop/Widget/Dungeon/RSSendIngredientWidget.h
+++ b/Source/RogShop/Widget/Dungeon/RSSendIngredientWidget.h
@@ -1,0 +1,37 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Blueprint/UserWidget.h"
+#include "RSSendIngredientWidget.generated.h"
+
+class UButton;
+
+UCLASS()
+class ROGSHOP_API URSSendIngredientWidget : public UUserWidget
+{
+	GENERATED_BODY()
+	
+public:
+	virtual void NativeConstruct() override;
+
+private:
+	UFUNCTION()
+	void NextStageTravel();
+
+	UFUNCTION()
+	void ExitWidget();
+
+private:
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Widget", meta = (BindWidget, AllowPrivateAccess = "true"))
+	TObjectPtr<UButton> OKButton;
+
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Widget", meta = (BindWidget, AllowPrivateAccess = "true"))
+	TObjectPtr<UButton> ExitButton;
+
+// 레벨 이동
+private:
+	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Level", meta = (AllowPrivateAccess = "true"))
+	TSoftObjectPtr<UWorld> TargetLevelAsset;
+};


### PR DESCRIPTION
액터와 상호작용 했을 때 재료를 선택하고, 선택한 재료를 타이쿤으로 보낼 수 있게 UI를 그려줍니다.
해당 UI는 액터에서 관리합니다.

현재 UI는 재료를 보내는 기능은 없으며, 확인 버튼을 눌렀을 때 지정된 레벨로 이동합니다.
취소 버튼을 누를 경우 위젯이 꺼지도록 구현했습니다.

게임모드에서 보스가 죽었는지 이벤트를 의미하는 델리게이트 변수를 추가했습니다.
해당 델리게이트가 브로드캐스트 될 때 위에 구현한 액터를 스폰시킵니다.