### PR TITLE
[Add] 보스방으로 이동하는 액터 추가

### DIFF
--- a/Content/Blueprints/Actor/Dungeon/BP_BossRoomPortal.uasset
+++ b/Content/Blueprints/Actor/Dungeon/BP_BossRoomPortal.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:58c2d9f4da8f5b4edbec5ad30b190abce1db1a802032ce0b5651ae90b78d314e
+size 35019

--- a/Source/RogShop/Actor/Dungeon/RSDunBossRoomPortal.cpp
+++ b/Source/RogShop/Actor/Dungeon/RSDunBossRoomPortal.cpp
@@ -1,0 +1,32 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "RSDunBossRoomPortal.h"
+#include "RSDunPlayerCharacter.h"
+
+ARSDunBossRoomPortal::ARSDunBossRoomPortal()
+{
+	PrimaryActorTick.bCanEverTick = false;
+
+	SceneComp = CreateDefaultSubobject<USceneComponent>(TEXT("Scene"));
+	SetRootComponent(SceneComp);
+
+	MeshComp = CreateDefaultSubobject<UStaticMeshComponent>(TEXT("StaticMesh"));
+	MeshComp->SetupAttachment(SceneComp);
+	MeshComp->SetCollisionProfileName("Interactable");
+}
+
+void ARSDunBossRoomPortal::BeginPlay()
+{
+	Super::BeginPlay();
+	
+}
+
+void ARSDunBossRoomPortal::Interact(ARSDunPlayerCharacter* Interactor)
+{
+	if (Interactor)
+	{
+		Interactor->SetActorTransform(TargetTransform);
+	}
+}
+

--- a/Source/RogShop/Actor/Dungeon/RSDunBossRoomPortal.h
+++ b/Source/RogShop/Actor/Dungeon/RSDunBossRoomPortal.h
@@ -1,0 +1,39 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GameFramework/Actor.h"
+#include "RSInteractable.h"
+#include "RSDunBossRoomPortal.generated.h"
+
+UCLASS()
+class ROGSHOP_API ARSDunBossRoomPortal : public AActor, public IRSInteractable
+{
+	GENERATED_BODY()
+	
+public:	
+	ARSDunBossRoomPortal();
+
+protected:
+	virtual void BeginPlay() override;
+
+// 컴포넌트
+private:
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Component", meta = (AllowPrivateAccess = true))
+	TObjectPtr<USceneComponent> SceneComp;
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Component", meta = (AllowPrivateAccess = true))
+	TObjectPtr<UStaticMeshComponent> MeshComp;
+
+// 상호작용
+public:
+	virtual void Interact(ARSDunPlayerCharacter* Interactor) override;
+
+// 이동할 위치 정보
+public:
+	void SetTargetTransform(FTransform NewTargetTransform) { TargetTransform = NewTargetTransform; }
+
+private:
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "UI", meta = (AllowPrivateAccess = "true"))
+	FTransform TargetTransform;
+};

--- a/Source/RogShop/Actor/MapGenerator/RSSpawnManager.cpp
+++ b/Source/RogShop/Actor/MapGenerator/RSSpawnManager.cpp
@@ -21,7 +21,7 @@ void URSSpawnManager::Initialize(UWorld* InWorld, UGameInstance* GameInstance, T
 {
 	World = InWorld;
 	ShopNPCClass = ShopNPC;
-
+	
 	if (!GameInstance) return;
 
 	URSDataSubsystem* DataSubsystem = GameInstance->GetSubsystem<URSDataSubsystem>();

--- a/Source/RogShop/Actor/MapGenerator/RSSpawnManager.h
+++ b/Source/RogShop/Actor/MapGenerator/RSSpawnManager.h
@@ -59,4 +59,13 @@ private:
 	TSubclassOf<AActor> ShopNPCClass;
 
 #pragma endregion
+
+#pragma region BossRoomPortal
+private:
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "BossRoomPortal", meta = (AllowPrivateAccess = "true"))
+	TSubclassOf<AActor> DunBossRoomPortalClass;
+
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "BossRoomPortal", meta = (AllowPrivateAccess = "true"))
+	TObjectPtr<AActor> DunBossRoomPortalInstance;
+#pragma endregion
 };


### PR DESCRIPTION
상호작용할 경우 보스방으로 이동할 수 있는 액터 클래스를 구현했습니다.

기존의 상호작용 인터페이스를 사용했습니다.

해당 엑터에 SetTargetTransform함수를 사용하여 이동할 위치를 미리 설정해주어야합니다.
미리 설정할 위치는 보스방에서 플레이어의 위치를 의미할 TargetPoint의 위치를 가져와서 설정해주어야합니다.

상호작용시 Setlocation함수를 호출하여 설정된 TargetTransform으로 이동합니다.

게임모드에서 사용하는 RSSpawnManager에서 해당 액터를 스폰하도록 구현해야합니다.
스폰 위치는 스테이지의 특정 칸에서 보스방으로 이동하는 액터를 스폰합니다.