### PR TITLE
[Fix] 기존 유물 인벤토리 위젯 코드 리팩토링

### DIFF
--- a/Content/Blueprints/Widgets/Dungeon/WBP_RelicInventory.uasset
+++ b/Content/Blueprints/Widgets/Dungeon/WBP_RelicInventory.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:247b26a07d7f91105ddbb4478f14c5a44d0fb6f548a09b92a99ee6bd307fd4a3
-size 28705
+oid sha256:ee816b4916de7708c2bad9aeb6f2363fd9ee6cf085ac93e2e8ecf1e7460c4cc2
+size 28765

--- a/Source/RogShop/Widget/Dungeon/RSRelicInventoryWidget.cpp
+++ b/Source/RogShop/Widget/Dungeon/RSRelicInventoryWidget.cpp
@@ -15,26 +15,26 @@ void URSRelicInventoryWidget::NativeConstruct()
 
 void URSRelicInventoryWidget::CreateSlots(int32 NumSlots, int32 NumColumns)
 {
-    if (!UniformGridPanel_RelicSlots || !SlotImageWidgetClass)
+    if (!RelicSlots || !InvecntorySlotWidgetClass)
     {
         UE_LOG(LogTemp, Warning, TEXT("SlotImageWidgetClass Null"));
         return;
     }
 
-    UniformGridPanel_RelicSlots->ClearChildren();
-    SlotImages.Empty();
+    RelicSlots->ClearChildren();
+    InvecntorySlots.Empty();
 
     for (int32 i = 0; i < NumSlots; ++i)
     {
-        URSInventorySlotWidget* NewSlotImage = CreateWidget<URSInventorySlotWidget>(GetWorld(), SlotImageWidgetClass);
+        URSInventorySlotWidget* NewSlotImage = CreateWidget<URSInventorySlotWidget>(GetWorld(), InvecntorySlotWidgetClass);
 
         if (NewSlotImage)
         {
             int32 Row = i / NumColumns;
             int32 Col = i % NumColumns;
 
-            UniformGridPanel_RelicSlots->AddChildToUniformGrid(NewSlotImage, Row, Col);
-            SlotImages.Add(NewSlotImage);
+            RelicSlots->AddChildToUniformGrid(NewSlotImage, Row, Col);
+            InvecntorySlots.Add(NewSlotImage);
         }
     }
 }

--- a/Source/RogShop/Widget/Dungeon/RSRelicInventoryWidget.h
+++ b/Source/RogShop/Widget/Dungeon/RSRelicInventoryWidget.h
@@ -14,19 +14,19 @@ class ROGSHOP_API URSRelicInventoryWidget : public UUserWidget
 {
 	GENERATED_BODY()
 	
-public:
-    UPROPERTY(EditAnywhere, Category = "Relic Slots")
-    TSubclassOf<URSInventorySlotWidget> SlotImageWidgetClass;
-
 protected:
     virtual void NativeConstruct() override;
 
-private:
-    UPROPERTY(meta = (BindWidget))
-    UUniformGridPanel* UniformGridPanel_RelicSlots;
-
-    UPROPERTY()
-    TArray<URSInventorySlotWidget*> SlotImages;
-
+public:
     void CreateSlots(int32 NumSlots, int32 NumColumns);
+
+private:
+    UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Widget", meta = (BindWidget, AllowPrivateAccess = "true"))
+    TObjectPtr<UUniformGridPanel> RelicSlots;
+
+    UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Widget", meta = (AllowPrivateAccess = "true"))
+    TSubclassOf<URSInventorySlotWidget> InvecntorySlotWidgetClass;
+
+    UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Widget", meta = (AllowPrivateAccess = "true"))
+    TArray<URSInventorySlotWidget*> InvecntorySlots;
 };


### PR DESCRIPTION
기존 유물 인벤토리 위젯에서 멤버 변수의 이름이 모호하던 문제로 변수명 수정

멤버 함수와 변수가 무작위로 작성되어있어 해당 문제 수정

멤버 변수의 접근제어지정자가 public으로 되어있는 문제 수정
Private로 변경하면서 UPROPERTY를 구체적으로 사용

멤버변수의 이름이 변경됨에 따라 소스코드의 변수명 또한 수정했습니다.

WBP에서 참조가 해제되었기 때문에 다시 참조설정을 해주었습니다.
WBP에서 위젯이 바인드 되어있지 않은 것을 바인드해주었습니다.