### PR TITLE
[Update] 던전 입장전 3개의 무기 스폰 로직 변경 및 내용 추가

### DIFF
--- a/Content/Blueprints/Actor/Dungeon/BP_WeaponSpawnPadActor.uasset
+++ b/Content/Blueprints/Actor/Dungeon/BP_WeaponSpawnPadActor.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3a01b0c0e674fb42adc68389204a539b377c7ea8167a16e0d771f0bda21c41f8
-size 32409
+oid sha256:47954bace51e95197ca2a66cd3df2729fc3aad3c23324ef892effff651d0731c
+size 32364

--- a/Content/Maps/BaseAreaMap.umap
+++ b/Content/Maps/BaseAreaMap.umap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d9cf4b73b7b7a214ccfa6bebb51754f1e7fb61876da2cda3ed9ae1dda91b1db7
-size 51777
+oid sha256:a616c5f2dddbb8a2d049ac38cb2669001f1e85ef1d34d43d0f7f53dd29f1f639
+size 54691

--- a/Source/RogShop/Actor/Dungeon/GroundItem/RSDungeonGroundWeapon.cpp
+++ b/Source/RogShop/Actor/Dungeon/GroundItem/RSDungeonGroundWeapon.cpp
@@ -8,10 +8,12 @@
 #include "RSDunPlayerCharacter.h"
 #include "RSPlayerWeaponComponent.h"
 
+#include "RSDunPlayerController.h"
+#include "Kismet/GameplayStatics.h"
+
 ARSDungeonGroundWeapon::ARSDungeonGroundWeapon()
 {
 	PrimaryActorTick.bCanEverTick = false;
-
 }
 
 void ARSDungeonGroundWeapon::InitInteractableWeapon(FName NewDataTableKey, UStaticMesh* NewMesh, const TSubclassOf<ARSDungeonItemBase> NewWeaponClass)
@@ -51,6 +53,14 @@ void ARSDungeonGroundWeapon::Interact(ARSDunPlayerCharacter* Interactor)
 	{
 		SpawnWeapon->SetDataTableKey(DataTableKey);
 		RSPlayerWeaponComponent->EquipWeaponToSlot(SpawnWeapon);
+
+		ARSDunPlayerController* PC = Cast<ARSDunPlayerController>(Interactor->GetController());
+
+		if (PC)
+		{
+			// 맨 처음에 던전 입장전 3개의 무기중 1개를 먹었을때를 알림
+			PC->OnFirstWeaponPickUp.Broadcast(this);
+		}
 
 		Destroy();
 	}

--- a/Source/RogShop/Actor/Dungeon/Weapon/RSWeaponSpawnPadActor.h
+++ b/Source/RogShop/Actor/Dungeon/Weapon/RSWeaponSpawnPadActor.h
@@ -12,27 +12,15 @@ class ROGSHOP_API ARSWeaponSpawnPadActor : public AActor
 	GENERATED_BODY()
 	
 public:	
-	// Sets default values for this actor's properties
 	ARSWeaponSpawnPadActor();
 
 protected:
-	// Called when the game starts or when spawned
 	virtual void BeginPlay() override;
 
-	UPROPERTY(EditAnywhere, Category = "Weapon")
-	UDataTable* WeaponDataTable;
-
-	UPROPERTY(EditAnywhere, Category = "Weapon")
-	int32 NumberOfWeapons = 3;
-
-	void SpawnWeapons();
-
-public:	
-	// Called every frame
-	virtual void Tick(float DeltaTime) override;
-
-// ƒƒ∆˜≥Õ∆Æ
+// Ïª¥Ìè¨ÎÑåÌä∏
 private:
 	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Component", meta = (AllowPrivateAccess = true))
 	UStaticMeshComponent* PadMesh;
+
+	void SpawnWeapons();
 };

--- a/Source/RogShop/Controller/RSDunPlayerController.h
+++ b/Source/RogShop/Controller/RSDunPlayerController.h
@@ -16,6 +16,7 @@ DECLARE_DYNAMIC_MULTICAST_DELEGATE_TwoParams(FOnWeaponSlotChange, int8, WeaponSl
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_TwoParams(FOnIngredientChange, int32, IngredientSlotIndex, FItemSlot, IngredientItemSlot);
 DECLARE_DYNAMIC_MULTICAST_DELEGATE(FOnHPChange);
 DECLARE_DYNAMIC_MULTICAST_DELEGATE(FOnMaxHPChange);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnFirstWeaponPickUp, ARSDungeonGroundWeapon*, PickUpWeapon);
 
 UCLASS()
 class ROGSHOP_API ARSDunPlayerController : public APlayerController
@@ -85,4 +86,7 @@ public:
 
 	UPROPERTY(BlueprintAssignable)
 	FOnMaxHPChange OnMaxHPChange;
+
+	UPROPERTY()
+	FOnFirstWeaponPickUp OnFirstWeaponPickUp;
 };

--- a/Source/RogShop/GameModeBase/RSBaseAreaGameModeBase.cpp
+++ b/Source/RogShop/GameModeBase/RSBaseAreaGameModeBase.cpp
@@ -2,4 +2,54 @@
 
 
 #include "RSBaseAreaGameModeBase.h"
+#include "RSDungeonGroundWeapon.h"
+#include "RSDunPlayerController.h"
 
+void ARSBaseAreaGameModeBase::BeginPlay()
+{
+    Super::BeginPlay();
+
+    if (APlayerController* PC = GetWorld()->GetFirstPlayerController())
+    {
+        if (ARSDunPlayerController* RSController = Cast<ARSDunPlayerController>(PC))
+        {
+            RSController->OnFirstWeaponPickUp.AddDynamic(this, &ARSBaseAreaGameModeBase::ClearRemainingWeapons);
+        }
+    }
+}
+
+void ARSBaseAreaGameModeBase::ClearRemainingWeapons(ARSDungeonGroundWeapon* PickedUpWeapon)
+{
+    for (ARSDungeonGroundWeapon* Weapon : SpawnedWeaponActors)
+    {
+        if (Weapon && Weapon != PickedUpWeapon)
+        {
+            Weapon->Destroy();
+        }
+    }
+
+    SpawnedWeaponActors.Empty();
+    SpawnedWeaponRowNames.Empty();
+
+    bIsEquipWeapon = true;
+}
+
+const TArray<FName>& ARSBaseAreaGameModeBase::GetSpawnedWeaponRowNames() const
+{
+    return SpawnedWeaponRowNames;
+}
+
+void ARSBaseAreaGameModeBase::AddSpawnedWeaponRowName(const FName& RowName)
+{
+    SpawnedWeaponRowNames.Add(RowName);
+}
+
+void ARSBaseAreaGameModeBase::AddSpawnedWeapon(ARSDungeonGroundWeapon* WeaponActor)
+{
+	SpawnedWeaponActors.Add(WeaponActor);
+}
+
+bool ARSBaseAreaGameModeBase::GetIsEquipWeapon() const
+{
+    return bIsEquipWeapon;
+}

--- a/Source/RogShop/GameModeBase/RSBaseAreaGameModeBase.h
+++ b/Source/RogShop/GameModeBase/RSBaseAreaGameModeBase.h
@@ -6,12 +6,37 @@
 #include "GameFramework/GameModeBase.h"
 #include "RSBaseAreaGameModeBase.generated.h"
 
-/**
- * 
- */
+class ARSDungeonGroundWeapon;
+
 UCLASS()
 class ROGSHOP_API ARSBaseAreaGameModeBase : public AGameModeBase
 {
 	GENERATED_BODY()
 	
+public:
+    const TArray<FName>& GetSpawnedWeaponRowNames() const;
+    void AddSpawnedWeaponRowName(const FName& RowName);
+
+    // 스폰된 무기 저장
+    void AddSpawnedWeapon(ARSDungeonGroundWeapon* WeaponActor);
+
+    bool GetIsEquipWeapon() const;
+
+protected:
+    virtual void BeginPlay() override;
+
+private:
+    // 첫 무기 획득 후 남은 무기 모두 제거
+    UFUNCTION()
+    void ClearRemainingWeapons(ARSDungeonGroundWeapon* PickedUpWeapon);
+
+    UPROPERTY()
+    TArray<FName> SpawnedWeaponRowNames;
+
+    UPROPERTY()
+    TArray<TObjectPtr<ARSDungeonGroundWeapon>> SpawnedWeaponActors;
+
+    // 던전 입장전 첫 번째 무기를 획득했는지의 여부 판별용
+    UPROPERTY()
+    bool bIsEquipWeapon = false;
 };


### PR DESCRIPTION
1. 한 개의 발판에서 3개의 무기를 스폰하던 로직을 1개만 정중앙에 스폰될 수 있도록 변경, 해당 발판을 맵에 3개 설치해둔 상태
2. 각 한 개의 발판들이 서로가 중복 무기를 생성하지 않도록 로직 수정
3. 3개의 무기 발판중 한 개의 무기를 획득하는 순간 나머지 2개의 발판 위에 있는 무기가 사라질 수 있도록 구현
- ARSDungeonGroundWeapon에서 Interact시 ARSDunPlayerController에 있는 OnFirstWeaponPickUp 변수를 이용하여 브로드캐스트로 알림, ARSBaseAreaGameModeBase에서 받아서 처리
4. 던전 입장 전 무기를 획득했는지의 여부를 ARSBaseAreaGameModeBase에서 bool 변수를 통해 확인할 수 있도록 해당 값을 반환하는 GetIsEquipWeapon 함수 추가