### PR TITLE
[Fix] 이동속도 유물 로직 수정

### DIFF
--- a/Source/RogShop/Actor/Dungeon/Relic/RSStatusRelic.cpp
+++ b/Source/RogShop/Actor/Dungeon/Relic/RSStatusRelic.cpp
@@ -3,6 +3,7 @@
 
 #include "RSStatusRelic.h"
 #include "RSDunPlayerCharacter.h"
+#include "GameFramework/CharacterMovementComponent.h"
 
 void URSStatusRelic::ApplyEffect(ARSDunPlayerCharacter* OwnerCharacter)
 {
@@ -21,8 +22,13 @@ void URSStatusRelic::ApplyEffect(ARSDunPlayerCharacter* OwnerCharacter)
 	}
 	else if (TargetStatus == EStatus::MoveSpeed)
 	{
-		// 해당 이동속도로 고정됨
-		OwnerCharacter->ChangeMoveSpeed(Amount);
+		UCharacterMovementComponent* MovementComp = OwnerCharacter->GetCharacterMovement();
+		if (MovementComp)
+		{
+			float CurrentSpeed = MovementComp->GetMaxSpeed();
+			CurrentSpeed + Amount;
+			OwnerCharacter->ChangeMoveSpeed(CurrentSpeed);
+		}
 	}
 	else if (TargetStatus == EStatus::AttackPower)
 	{

--- a/Source/RogShop/Actor/Dungeon/Relic/RSStatusRelic.cpp
+++ b/Source/RogShop/Actor/Dungeon/Relic/RSStatusRelic.cpp
@@ -26,7 +26,7 @@ void URSStatusRelic::ApplyEffect(ARSDunPlayerCharacter* OwnerCharacter)
 		if (MovementComp)
 		{
 			float CurrentSpeed = MovementComp->GetMaxSpeed();
-			CurrentSpeed + Amount;
+			CurrentSpeed += Amount;
 			OwnerCharacter->ChangeMoveSpeed(CurrentSpeed);
 		}
 	}


### PR DESCRIPTION
기존 로직은 값으로 이동속도를 Set합니다.
이 경우 이동속도가 기존 이동속도에 + 혹은 -되는 로직을 구현하기 힘들어지므로, 기존 이동속도에 값을 추가하거나 줄일 수 있도록 변경했습니다.