### PR TITLE
[Update] 플레이어 스테이터스 일부 세이브 및 로드

### DIFF
--- a/Source/RogShop/Character/RSDunPlayerCharacter.h
+++ b/Source/RogShop/Character/RSDunPlayerCharacter.h
@@ -92,14 +92,14 @@ private:
 
 // 던전 재화 관련
 public:
-	float GetLifeEssence() const { return LifeEssence; }
-	void SetLifeEssence(float Amount);
-	void IncreaseLifeEssence(float Amount);
-	void DecreaseLifeEssence(float Amount);
+	int32 GetLifeEssence() const { return LifeEssence; }
+	void SetLifeEssence(int32 Amount);
+	void IncreaseLifeEssence(int32 Amount);
+	void DecreaseLifeEssence(int32 Amount);
 
 private:
 	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, category = "Money", meta = (AllowPrivateAccess = "true"))
-	float LifeEssence;
+	int32 LifeEssence;
 
 // 무기 관련
 public:
@@ -160,4 +160,12 @@ private:
 public:
 	UPROPERTY(BlueprintAssignable)
 	FOnSaveRequested OnSaveRequested;	// 저장 요청을 의미하는 이벤트 디스패처
+
+	UFUNCTION()
+	void SaveStatus();
+
+	void LoadStatus();
+
+private:
+	const FString StatusSaveSlotName = TEXT("StatusSaveSlot");
 };

--- a/Source/RogShop/SaveGame/Dungeon/RSDungeonStatusSaveGame.cpp
+++ b/Source/RogShop/SaveGame/Dungeon/RSDungeonStatusSaveGame.cpp
@@ -1,0 +1,8 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "RSDungeonStatusSaveGame.h"
+
+
+
+

--- a/Source/RogShop/SaveGame/Dungeon/RSDungeonStatusSaveGame.h
+++ b/Source/RogShop/SaveGame/Dungeon/RSDungeonStatusSaveGame.h
@@ -1,0 +1,24 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GameFramework/SaveGame.h"
+#include "RSDungeonStatusSaveGame.generated.h"
+
+/**
+ * 
+ */
+UCLASS()
+class ROGSHOP_API URSDungeonStatusSaveGame : public USaveGame
+{
+	GENERATED_BODY()
+	
+public:
+	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	float HP; // 플레이어 캐릭터의 체력
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	int32 LifeEssence;	// 던전 재화
+	
+};


### PR DESCRIPTION
플레이어의 체력과 던전 재화를 저장합니다.

공격력, 최대 체력, 공격속도, 이동속도 등 다른 스탯은 유물에 의해 변화될 예정이다.
이 경우 유물을 저장한 것을 불러올 때 유물을 다시 적용시키는 개념으로 접근한다면 스탯이 중첩해서 늘어난다는 문제가 발생할 것이다.
그래서 체력을 제외한 다른 스탯은 저장하지 않는다.