### PR TITLE
[Fix]  제거된 PadMesh 대신 새로 생긴 MeshComp 변수에 큐브 메시 추가

### DIFF
--- a/Content/Blueprints/Actor/Dungeon/BP_WeaponSpawnPadActor.uasset
+++ b/Content/Blueprints/Actor/Dungeon/BP_WeaponSpawnPadActor.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:47954bace51e95197ca2a66cd3df2729fc3aad3c23324ef892effff651d0731c
-size 32364
+oid sha256:9830f3f6b0eb9be87b1f5d3718326047b3f5deb5dec76772aa6170116c21235b
+size 32413


### PR DESCRIPTION
- 기존에 PadMesh에 입혀져 있던 큐브 메시 그대로 적용
- 해당 발판을 기준으로 재테스트 필요, 로컬에선 정상 동작