### PR TITLE
[Feature] 스폰 매니저에 몬스터가 죽으면 아이템 소환하는 함수 추가 및 구현

### DIFF
--- a/Content/Datas/IngredientDataTable.uasset
+++ b/Content/Datas/IngredientDataTable.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:148ef82e2b67d04ffffa97ff1d03e65e9d78920d6687c8cd760b28450c1204b1
-size 7376
+oid sha256:4677e3d6caaf4d9177a3485bf6adddd6e4237b29b324e13d6cb37834dd7af1fa
+size 7799

--- a/Source/RogShop/Actor/MapGenerator/RSSpawnManager.cpp
+++ b/Source/RogShop/Actor/MapGenerator/RSSpawnManager.cpp
@@ -14,7 +14,9 @@
 #include "RSDataSubsystem.h"
 #include "Engine/World.h"
 #include "Components/CapsuleComponent.h"
-
+#include "CookFoodData.h"
+#include "RSDungeonGroundIngredient.h"
+#include "RogShop/UtilDefine.h"
 
 // 외부에서 전달받은 월드 및 테이블 초기화
 void URSSpawnManager::Initialize(UWorld* InWorld, UGameInstance* GameInstance, TSubclassOf<AActor> ShopNPC, TSubclassOf<AActor> DunNextStagePortal)
@@ -367,5 +369,45 @@ void URSSpawnManager::SpawnDunNextStagePortal() // 다음 스테이지 포탈 �
 	if (DunNextStagePortalInstance)
 	{
 		UE_LOG(LogTemp, Log, TEXT("다음 스테이지 포탈 생성 완료"));
+	}
+}
+
+void URSSpawnManager::SpawnMonsterItemDrop(ARSDunMonsterCharacter* SourceMonster, FName MonsterRowName)
+{
+	UWorld* MonsterFromWorld = SourceMonster->GetWorld();
+
+	URSDataSubsystem* DataSubsystem = MonsterFromWorld->GetGameInstance()->GetSubsystem<URSDataSubsystem>();
+	if (!DataSubsystem)
+	{
+		return;
+	}
+
+	const FMonsterData* MonsterData = DataSubsystem->Monster->FindRow<FMonsterData>(MonsterRowName, TEXT(""));
+	if (!MonsterData || MonsterData->Ingredients.Num() <= 0)
+	{
+		return;
+	}
+
+	// TODO : 일단 임의로 재료가 하나 떨어뜨릴거라 인덱스값을 0으로 설정! << 나중에 바꿔야할수도 있음
+	// 몬스터 데이터테이블에서 재료 배열의 특정 인덱스로 그 몬스터의 재료 이름에 접근
+	FName IngredientRowName = MonsterData->Ingredients[0].IngredientName;
+	RS_LOG_F("IngredientRowName이 잘 적용 되었습니다! IngredientRowName : %s", *IngredientRowName.ToString());
+
+	// 위에서 찾은 재료 이름으로 재료 데이터 테이블에 접근
+	const FIngredientData* IngredientData = DataSubsystem->Ingredient->FindRow<FIngredientData>(IngredientRowName, TEXT(""));
+	if (!IngredientData)
+	{
+		return;
+	}
+
+	// 먼저 몬스터 아이템 기본형을 스폰시킴(지금은 공중에 위치) << 나중에 바닥으로 위치바꾸거나 중력 활성화 하는식으로 처리
+	ARSDungeonGroundIngredient* DungeonIngredient = MonsterFromWorld->SpawnActor<ARSDungeonGroundIngredient>(
+		ARSDungeonGroundIngredient::StaticClass(), SourceMonster->GetActorTransform());
+
+	// 스폰된 기본형 아이템에 위에서 찾은 해당 몬스터의 재료 데이터 행의 Mesh 속성을 찾아 적용
+	if (DungeonIngredient)
+	{
+		DungeonIngredient->InitItemInfo(IngredientRowName, IngredientData->Mesh);
+		RS_LOG("IngredientData의 Mesh가 잘 적용 되었습니다!");
 	}
 }

--- a/Source/RogShop/Actor/MapGenerator/RSSpawnManager.h
+++ b/Source/RogShop/Actor/MapGenerator/RSSpawnManager.h
@@ -14,6 +14,7 @@
 class UGameInstance;
 class ATargetPoint;
 class AActor;
+class ARSDunMonsterCharacter;
 
 /**
  * URSSpawnManager
@@ -49,6 +50,8 @@ public:
 	FVector GetNextStageLocation() const;
 	UFUNCTION()
 	void SpawnDunNextStagePortal(); // 던전 다음 스테이지로 가는 포탈을 소환하는 함수
+
+	void SpawnMonsterItemDrop(ARSDunMonsterCharacter* SourceMonster, FName MonsterRowName);	// 몬스터 잡으면 아이템 스폰(드롭)하는 함수
 
 #pragma endregion
 

--- a/Source/RogShop/Character/RSDunMonsterCharacter.cpp
+++ b/Source/RogShop/Character/RSDunMonsterCharacter.cpp
@@ -148,10 +148,11 @@ float ARSDunMonsterCharacter::TakeDamage(float DamageAmount, FDamageEvent const&
 		GetMaxHP()
 	);
 	
-	if (GetHP() <= 0)
+	// TODO : 이미 BaseCharacter에서 OnDeath에 대한 처리를 하고 있어서 죽음이 2번처리 되는것이었다. << 나중에 어떤걸 살릴지 선국님께 묻기
+	/*if (GetHP() <= 0)
 	{
 		OnDeath();
-	}
+	}*/
 
 	return Damage;
 }
@@ -328,24 +329,14 @@ void ARSDunMonsterCharacter::OnDeath()
 				DungeonGameMode->OnBossDead.Broadcast();
 			}
 		}
+
+		URSSpawnManager* SpawnManager = NewObject<URSSpawnManager>(CurGameInstance);
+		SpawnManager->SpawnMonsterItemDrop(this, MonsterRowName);
 	}
 }
 
 void ARSDunMonsterCharacter::InitMonsterData()
 {
-	// TODO : 아래 방법의 초기화가 맘에 안들면 다시 주석 풀거나 삭제할 코드
-	/*static const FString DataTablePath = TEXT("/Game/Datas/MonsterDataTable.MonsterDataTable");
-
-	UDataTable* LoadedTable = Cast<UDataTable>(StaticLoadObject(UDataTable::StaticClass(), nullptr, *DataTablePath));
-
-	if (LoadedTable)
-	{
-		MonsterDataTable = LoadedTable;
-	}
-	else
-
-	}*/
-
 	UGameInstance* CurGameInstance = GetGameInstance();
 	if (!CurGameInstance)
 	{


### PR DESCRIPTION
## 읽으면 좋은 사항
- 몬스터 캐릭터 cpp에서 TakeDamage 함수 내에서 OnDeath() 함수를 호출하고 있었는데
ㄴ 이 부분이 이미 BaseCharacter에 처리된 것으로 확인되어 getHP() < 0일때 OnDeath를 호출하는 부분 코드 삭제
ㄴ OnDeath()가 2번 호출되는 문제를 이것으로 해결

- 스폰 매니저에 로직을 추가하는 것이 맞다고 판단해서 새로운 아이템 스폰 함수를 스폰매니저에 추가/구현 했습니다.
ㄴ 기존꺼 안 건드리고 추가만 한거라 웬만하면 충돌 안 날거라고 생각합니다. 

- 몬스터 캐릭터 클래스에서 스폰 매니저를 들고와서 거기에 스폰 함수를 사용하는 식으로 구현 

- 데이터 테이블은 1번 불러오고 나서 바뀌면 안되는 값이니 const를 붙였습니다.

## 아직 남아 있는 문제
- 몬스터가 죽으면 아이템 스폰이 되긴 하는데 바닥 말고 공중에서 됩니다.
ㄴ 중력을 줘서 몬스터 몸통 가운데에서 떨어지게 하거나 바닥에서 스폰되게 하는 방식 둘 중에 추천 받습니다.

- 재료 테이블에 메시랑 이미지의 값이 아직 다 설정되지 않았습니다. 