### PR TITLE
[Update] 몬스터 사망 시 재료 아이템을 드랍하도록 구현

### DIFF
--- a/Source/RogShop/Character/RSDunBaseCharacter.cpp
+++ b/Source/RogShop/Character/RSDunBaseCharacter.cpp
@@ -121,6 +121,8 @@ bool ARSDunBaseCharacter::GetIsDead()
 
 void ARSDunBaseCharacter::OnDeath()
 {
+	OnCharacterDied.Broadcast();
+
 	bIsDead = true;
 
 	// 레벨 오브젝트를 제외한 모든 오브젝트와 충돌하지 않도록 콜리전 설정 변경

--- a/Source/RogShop/Character/RSDunBaseCharacter.h
+++ b/Source/RogShop/Character/RSDunBaseCharacter.h
@@ -6,9 +6,8 @@
 #include "GameFramework/Character.h"
 #include "RSDunBaseCharacter.generated.h"
 
-/**
- * 
- */
+DECLARE_DYNAMIC_MULTICAST_DELEGATE(FOnCharacterDied);
+
 UCLASS()
 class ROGSHOP_API ARSDunBaseCharacter : public ACharacter
 {
@@ -16,6 +15,11 @@ class ROGSHOP_API ARSDunBaseCharacter : public ACharacter
 
 public:
 	ARSDunBaseCharacter();
+
+// 델리게이트
+public:
+	UPROPERTY(BlueprintAssignable)
+	FOnCharacterDied OnCharacterDied;	// 죽었을 때 호출
 
 // 스탯 관련
 public:

--- a/Source/RogShop/Character/RSDunMonsterCharacter.h
+++ b/Source/RogShop/Character/RSDunMonsterCharacter.h
@@ -123,4 +123,8 @@ protected:
 private:
 	TObjectPtr<ARSMonsterAIController> AIController;  // TODO : 혹시나 캐싱해서 쓸 일 생길까봐 미리 만들어둠.
 
+// 사망시 아이템 드롭
+private:
+	UFUNCTION()
+	void MonsterItemDrop();
 };


### PR DESCRIPTION
델리게이트를 사용해 몬스터가 사망했음을 의미하는 이벤트를 생성합니다.

해당 이벤트에 바인딩 될 함수를 구현해주어 재료 아이템을 드랍하도록 해주었습니다.

재료 아이템을 드랍하기 위해서 몬스터 데이터 테이블에서 드랍할 아이템을 찾고, 재료 데이터 테이블의 데이터로 드랍될 재료 액터를 정의합니다.

후에 확률적으로 드랍되도록 변경해주어야 합니다.

던전 재화 또한 드랍되도록 해주어야합니다.