### PR TITLE
[BugFix] static 수정

### DIFF
--- a/Source/RogShop/BehaviorTree/Tycoon/Task/BTT_RSWaiterMoveCookingTile.cpp
+++ b/Source/RogShop/BehaviorTree/Tycoon/Task/BTT_RSWaiterMoveCookingTile.cpp
@@ -13,8 +13,8 @@
 #include "Tycoon/NPC/RSTycoonWaiterCharacter.h"
 
 
-const static FName TileKey = TEXT("TargetTile");
-const static FName CustomerKey = TEXT("TargetCustomer");
+static const FName TileKey = TEXT("TargetTile");
+static const FName CustomerKey = TEXT("TargetCustomer");
 		
 UBTT_RSWaiterMoveCookingTile::UBTT_RSWaiterMoveCookingTile()
 {


### PR DESCRIPTION
const static을 static const으로 수정 C++의 기본 문법에서는 같은 의미이지만, 언리얼 엔진에서는 빌드에 문제가 생겨 수정했습니다.