### PR TITLE
[Add] GameInstance 로그 제어 bool 변수값에 따른 각종 로그 출력 제어 로직 일부 추가

### DIFF
--- a/Source/RogShop/Character/RSDunPlayerCharacter.cpp
+++ b/Source/RogShop/Character/RSDunPlayerCharacter.cpp
@@ -19,6 +19,7 @@
 #include "Perception/AISense_Sight.h"
 #include "Engine/OverlapResult.h"
 #include "RSDungeonStatusSaveGame.h"
+#include "RogShop/UtilDefine.h"
 
 // Sets default values
 ARSDunPlayerCharacter::ARSDunPlayerCharacter()
@@ -165,7 +166,7 @@ float ARSDunPlayerCharacter::TakeDamage(float DamageAmount, FDamageEvent const& 
 
     DecreaseHP(Damage);
 
-    UE_LOG(LogTemp, Warning, TEXT("[%s] took %.1f damage from [%s], Current Hp is %f"),
+    RS_LOG_DEBUG("[%s] took %.1f damage from [%s], Current Hp is %f",
         *GetName(),
         Damage,
         DamageCauser ? *DamageCauser->GetName() : TEXT("Unknown"),
@@ -315,10 +316,7 @@ void ARSDunPlayerCharacter::Dodge(const FInputActionValue& value)
 void ARSDunPlayerCharacter::Interaction(const FInputActionValue& value)
 {
     // 애니메이션과 기획이 아직 준비되지 않았으므로 디버깅용 출력
-    if (GEngine)
-    {
-        GEngine->AddOnScreenDebugMessage(-1, 1.0f, FColor::Green, TEXT("Interaction Activated"));
-    }
+    RS_LOG_DEBUG("Interaction Activated");
 
     IRSInteractable* Interactable = Cast<IRSInteractable>(InteractActor);
     if (Interactable)
@@ -338,20 +336,14 @@ void ARSDunPlayerCharacter::NormalAttack(const FInputActionValue& value)
 void ARSDunPlayerCharacter::StrongAttack(const FInputActionValue& value)
 {
     // 애니메이션이 아직 준비되지 않았으므로 디버깅용 출력
-    if (GEngine)
-    {
-        GEngine->AddOnScreenDebugMessage(-1, 1.0f, FColor::Green, TEXT("StrongAttack Activated"));
-    }
+    RS_LOG_DEBUG("StrongAttack Activated");
 }
 
 void ARSDunPlayerCharacter::FirstWeaponSlot(const FInputActionValue& value)
 {
     // 애니메이션이 아직 준비되지 않았으므로 디버깅용 출력
     // 추후에 해당 무기로 전환되는 기능 구현해야한다.
-    if (GEngine)
-    {
-        GEngine->AddOnScreenDebugMessage(-1, 1.0f, FColor::Green, TEXT("FirstWeaponSlot Activated"));
-    }
+    RS_LOG_DEBUG("FirstWeaponSlot Activated");
 
     WeaponComp->EquipWeaponToCharacter(EWeaponSlot::FirstWeaponSlot);
 }
@@ -360,10 +352,7 @@ void ARSDunPlayerCharacter::SecondWeaponSlot(const FInputActionValue& value)
 {
     // 애니메이션이 아직 준비되지 않았으므로 디버깅용 출력
     // 추후에 해당 무기로 전환되는 기능 구현해야한다.
-    if (GEngine)
-    {
-        GEngine->AddOnScreenDebugMessage(-1, 1.0f, FColor::Green, TEXT("SecondWeaponSlot Activated"));
-    }
+    RS_LOG_DEBUG("SecondWeaponSlot Activated");
 
     WeaponComp->EquipWeaponToCharacter(EWeaponSlot::SecondWeaponSlot);
 }
@@ -377,10 +366,7 @@ void ARSDunPlayerCharacter::ToggleInventoryUI(const FInputActionValue& value)
         PC->TogglePlayerInventoryWidget();
     }
 
-    if (GEngine)
-    {
-        GEngine->AddOnScreenDebugMessage(-1, 1.0f, FColor::Green, TEXT("ToggleInventoryUI Activated"));
-    }
+    RS_LOG_DEBUG("ToggleInventoryUI Activated");
 }
 
 void ARSDunPlayerCharacter::ToggleInGameMenuUI(const FInputActionValue& value)
@@ -392,10 +378,7 @@ void ARSDunPlayerCharacter::ToggleInGameMenuUI(const FInputActionValue& value)
         PC->ToggleInGameMenuWidget();
     }
 
-    if (GEngine)
-    {
-        GEngine->AddOnScreenDebugMessage(-1, 1.0f, FColor::Green, TEXT("ToggleInGameMenuUI Activated"));
-    }
+    RS_LOG_DEBUG("ToggleInGameMenuUI Activated");
 }
 
 void ARSDunPlayerCharacter::SetLifeEssence(int32 Amount)
@@ -462,7 +445,7 @@ void ARSDunPlayerCharacter::InteractTrace()
     if (!bHit)
     {
         InteractActor = nullptr;
-        DrawDebugSphere(GetWorld(), Center, InteractRadius, 32, FColor::Red, false, 0.f, 0, 1.0f);
+        RS_DRAW_DEBUG_SPHERE(GetWorld(), Center, InteractRadius, 32, FColor::Red, false, 0.f, 0, 1.0f);
         return;
     }
 
@@ -521,21 +504,21 @@ void ARSDunPlayerCharacter::InteractTrace()
             {
                 InteractActor = TargetActor;
 
-                DrawDebugSphere(GetWorld(), Center, InteractRadius, 32, FColor::Green, false, 0.f, 0, 1.0f);
+                RS_DRAW_DEBUG_SPHERE(GetWorld(), Center, InteractRadius, 32, FColor::Green, false, 0.f, 0, 1.0f);
             }
             else
             {
-                DrawDebugSphere(GetWorld(), Center, InteractRadius, 32, FColor::Red, false, 0.f, 0, 1.0f);
+                RS_DRAW_DEBUG_SPHERE(GetWorld(), Center, InteractRadius, 32, FColor::Red, false, 0.f, 0, 1.0f);
             }
         }
         else
         {
-            DrawDebugSphere(GetWorld(), Center, InteractRadius, 32, FColor::Red, false, 0.f, 0, 1.0f);
+            RS_DRAW_DEBUG_SPHERE(GetWorld(), Center, InteractRadius, 32, FColor::Red, false, 0.f, 0, 1.0f);
         }
     }
     else
     {
-        DrawDebugSphere(GetWorld(), Center, InteractRadius, 32, FColor::Red, false, 0.f, 0, 1.0f);
+        RS_DRAW_DEBUG_SPHERE(GetWorld(), Center, InteractRadius, 32, FColor::Red, false, 0.f, 0, 1.0f);
     }
 }
 

--- a/Source/RogShop/CheatManager/RSCheatManager.cpp
+++ b/Source/RogShop/CheatManager/RSCheatManager.cpp
@@ -4,9 +4,11 @@
 #include "RSCheatManager.h"
 #include "RSDunMonsterCharacter.h"
 #include "RSDunPlayerController.h"
+#include "RSGameInstance.h"
 
 #include "Blueprint/UserWidget.h"
 #include "Kismet/GameplayStatics.h"
+#include "RogShop/UtilDefine.h"
 
 URSCheatManager::URSCheatManager()
 {
@@ -50,22 +52,22 @@ void URSCheatManager::TestDunMonsterAttack()
 
 void URSCheatManager::TestDunMonsterDeath()
 {
-    UE_LOG(LogTemp, Warning, TEXT("1"));
+    RS_LOG_DEBUG("1");
     UWorld* World = GetWorld();
     if (!World)
     {
-        UE_LOG(LogTemp, Warning, TEXT("2"));
+        RS_LOG_DEBUG("2");
         return;
     }
 
-    UE_LOG(LogTemp, Warning, TEXT("3"));
+    RS_LOG_DEBUG("3");
     ARSDunMonsterCharacter* Monster = Cast<ARSDunMonsterCharacter>(
         UGameplayStatics::GetActorOfClass(World, ARSDunMonsterCharacter::StaticClass())
     );
 
     if (Monster)
     {
-        UE_LOG(LogTemp, Warning, TEXT("4"));
+        RS_LOG_DEBUG("4");
         //Monster->PlayDeathAnim();
         Monster->OnDeath();
     }
@@ -74,7 +76,10 @@ void URSCheatManager::TestDunMonsterDeath()
 void URSCheatManager::SpawnMonster(FString MonsterName)
 {
     UWorld* World = GetWorld();
-    if (!World) return;
+    if (!World)
+    {
+        return;
+    }
 
     FVector PlayerLocation = GetOuterAPlayerController()->GetPawn()->GetActorLocation();
     FVector Forward = GetOuterAPlayerController()->GetPawn()->GetActorForwardVector(); // �÷��̾ �ٶ󺸴� ����
@@ -83,30 +88,36 @@ void URSCheatManager::SpawnMonster(FString MonsterName)
     FVector DirectionToPlayer = (PlayerLocation - SpawnLocation).GetSafeNormal();
     FRotator SpawnRotation = FRotationMatrix::MakeFromX(DirectionToPlayer).Rotator();
 
-
     FString Key = MonsterName.ToLower();
     if (TSubclassOf<AActor>* FoundClass = MonsterMap.Find(Key))
     {
         World->SpawnActor<AActor>(*FoundClass, SpawnLocation, SpawnRotation);
-        UE_LOG(LogTemp, Warning, TEXT("Spawned monster: %s"), *Key);
+        RS_LOG_DEBUG("Spawned monster: %s", *Key);
     }
     else
     {
-        UE_LOG(LogTemp, Warning, TEXT("Monster not found for key: %s"), *Key);
+        RS_LOG_DEBUG("Monster not found for key: %s", *Key);
     }
 }
 
 void URSCheatManager::SpawnDunShopNPC()
 {
     UWorld* World = GetWorld();
-    if (!World) return;
+
+    if (!World)
+    {
+        return;
+    }
 
     APlayerController* PC = GetOuterAPlayerController();
-    if (!PC) return;
+
+    if (!PC)
+    {
+        return;
+    }
 
     if (!DunShopNPCClass)
     {
-        UE_LOG(LogTemp, Warning, TEXT("DunShopNPCClass is not set!"));
         return;
     }
 
@@ -121,21 +132,18 @@ void URSCheatManager::SpawnWeaponPad()
 {
     if (!GetWorld() || !WeaponSpawnPadBPClass)
     {
-        UE_LOG(LogTemp, Warning, TEXT("GetWorld or WeaponSpawnPadBPClass Is Null !"));
         return;
     }
 
     APlayerController* PC = GetOuterAPlayerController();
     if (!PC)
     {
-        UE_LOG(LogTemp, Warning, TEXT("APlayerController Is Null !"));
         return;
     }
 
     APawn* PlayerPawn = PC->GetPawn();
     if (!PlayerPawn)
     {
-        UE_LOG(LogTemp, Warning, TEXT("APawn Is Null !"));
         return;
     }
 
@@ -151,6 +159,25 @@ void URSCheatManager::SpawnWeaponPad()
     FRotator SpawnRotation = FRotator::ZeroRotator;
 
     GetWorld()->SpawnActor<AActor>(WeaponSpawnPadBPClass, SpawnLocation, SpawnRotation);
+}
+
+void URSCheatManager::ToggleDebugLog() const
+{
+    if (!GetWorld())
+    {
+        return;
+    }
+
+    URSGameInstance* RSGameInstance = Cast<URSGameInstance>(UGameplayStatics::GetGameInstance(GetWorld()));
+
+    if (!RSGameInstance)
+    {
+        return;
+    }
+
+    RSGameInstance->SetDebugLogEnabled(!RSGameInstance->GetDebugLogEnabled());
+
+    RS_LOG_DEBUG("DebugLog is now: Enabled");
 }
 
 void URSCheatManager::OpenTycoonLevel()

--- a/Source/RogShop/CheatManager/RSCheatManager.h
+++ b/Source/RogShop/CheatManager/RSCheatManager.h
@@ -38,6 +38,9 @@ public:
 	UFUNCTION(exec)
 	void SpawnWeaponPad();
 
+	UFUNCTION(exec)
+	void ToggleDebugLog() const;
+
 	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "SpawnMonster")
 	TMap<FString, TSubclassOf<AActor>> MonsterMap;
 

--- a/Source/RogShop/GameInstance/RSGameInstance.cpp
+++ b/Source/RogShop/GameInstance/RSGameInstance.cpp
@@ -9,7 +9,11 @@ void URSGameInstance::TravelToLevel(const TSoftObjectPtr<UWorld>& TargetLevelAss
 {
 	if (TargetLevelAsset.IsNull())
 	{
-		RS_LOG_C("TargetLevelAsset is Null", FColor::Red)
+		if (bEnableDebugLog)
+		{
+			RS_LOG_C("TargetLevelAsset is Null", FColor::Red)
+		}
+		
 		return;
 	}
 
@@ -19,4 +23,14 @@ void URSGameInstance::TravelToLevel(const TSoftObjectPtr<UWorld>& TargetLevelAss
 	// 레벨 이름만 추출하고 이동
 	FName LevelName = FName(*FPackageName::GetShortName(LevelPath));
 	UGameplayStatics::OpenLevel(GetWorld(), LevelName);
+}
+
+bool URSGameInstance::GetDebugLogEnabled() const
+{
+	return bEnableDebugLog;
+}
+
+void URSGameInstance::SetDebugLogEnabled(bool bEnable)
+{
+	bEnableDebugLog = bEnable;
 }

--- a/Source/RogShop/GameInstance/RSGameInstance.h
+++ b/Source/RogShop/GameInstance/RSGameInstance.h
@@ -18,5 +18,12 @@ public:
 	void TravelToLevel(const TSoftObjectPtr<UWorld>& TargetLevelAsset) const;
 
 public:
+	bool GetDebugLogEnabled() const;
+
+	void SetDebugLogEnabled(bool bEnable);
+
 	TArray<FName> PurchasedItemIDs;
+
+private:
+	bool bEnableDebugLog = false;
 };

--- a/Source/RogShop/UtilDefine.h
+++ b/Source/RogShop/UtilDefine.h
@@ -1,6 +1,19 @@
 #pragma once
-#include "Engine/Engine.h"
 
+#include "Engine/Engine.h"
+#include "RSGameInstance.h"
+#include "Kismet/GameplayStatics.h"
+
+inline bool IsDebugLogEnabled(UWorld* World)
+{
+	if (!World)
+	{
+		return false;
+	}
+
+	const URSGameInstance* GI = Cast<URSGameInstance>(UGameplayStatics::GetGameInstance(World));
+	return GI && GI->GetDebugLogEnabled();
+}
 
 //기본
 #define RS_LOG(Str) \
@@ -34,7 +47,6 @@
 		GEngine->AddOnScreenDebugMessage(-1, 5.f, FColor::Cyan, FString::Printf(TEXT(FormatString), ##__VA_ARGS__)); \
 	}
 
-
 //Format, Color 버전
 #define RS_LOG_F_C(FormatString, Color, ...) \
 	UE_LOG(LogTemp, Warning, TEXT(FormatString), ##__VA_ARGS__) \
@@ -42,3 +54,20 @@
 	{	\
 		GEngine->AddOnScreenDebugMessage(-1, 5.f, Color, FString::Printf(TEXT(FormatString), ##__VA_ARGS__)); \
 	}
+
+// 위에 로그 찍는 부분들 IsDebugLogEnabled 값 사용해서 찍을 수 있도록 수정 필요
+#define RS_LOG_DEBUG(Format, ...) \
+do { \
+	if (IsDebugLogEnabled(GWorld)) \
+	{ \
+		UE_LOG(LogTemp, Warning, TEXT(Format), ##__VA_ARGS__); \
+	} \
+} while(0)
+
+#define RS_DRAW_DEBUG_SPHERE(World, Center, Radius, Segments, Color, bPersistent, LifeTime, DepthPriority, Thickness) \
+do { \
+	if (IsDebugLogEnabled(World)) \
+	{ \
+		DrawDebugSphere(World, Center, Radius, Segments, Color, bPersistent, LifeTime, DepthPriority, Thickness); \
+	} \
+} while (0)


### PR DESCRIPTION
1. RSGameInstance 내부에 로그 출력을 제어할 수 있는 bool 변수 추가 (기본값 false, true일때 각종 로그 출력 가능)
2. CheatManager에 ToggleDebugLog 함수 등록, 게임 내 콘솔창에서 해당 함수로 로그 출력 제어 bool 변수 Toggle 가능
3. 모든 로그 출력 부분을 로그 출력 제어 변수값을 이용해서 if문으로 처리하면 너무 복잡할 것 같아서 UtilDefine 파일 내부에 로그 출력 제어 변수값을 이용하여 해당 값이 true 일때만 로그를 찍을 수 있는 매크로 함수 추가
-  해당 함수를 이용하여 캐릭터 주변 디버그 라인 제어 및 일부 함수 내부 로그 출력 부분 리팩토링
- 기존에 사용했었던 매크로 함수들 전부 로그 출력 제어 변수를 이용하여 로그 출력이 제어될 수 있도록 변경 예정