### PR TITLE
[Bugfix] 몬스터 캐릭터에서 사망을 두번 호출하는 문제 수정

### DIFF
--- a/Source/RogShop/Character/RSDunMonsterCharacter.cpp
+++ b/Source/RogShop/Character/RSDunMonsterCharacter.cpp
@@ -154,13 +154,6 @@ float ARSDunMonsterCharacter::TakeDamage(float DamageAmount, FDamageEvent const&
 		GetHP(),
 		GetMaxHP()
 	);
-	
-	// TODO : 해당 로직으로 인해 사망이 2번 호출되므로 제거해야한다.
-	// 체력 감소 함수에서 체크하므로 해당 작업을 할 필요가 없다.
-	if (GetHP() <= 0)
-	{
-		OnDeath();
-	}
 
 	return Damage;
 }


### PR DESCRIPTION
기존에 체력을 변경하는 함수에서 특정 조건이 성립하면 OnDeath를 호출하므로 TakeDamage에서 OnDeath를 호출할 경우 문제가 되므로 제거해주었습니다.