### PR TITLE
[Add] 던전 오브젝트 데이터 테이블 생성

### DIFF
--- a/Content/Blueprints/AL_Blueprints.uasset
+++ b/Content/Blueprints/AL_Blueprints.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:472bfd3dd777c85cfbad045207d78b12d05401074b5d734793dc455bab8f3883
-size 50034
+oid sha256:cd14ec2914def88fdef1efbca4caa6ba815ec4d61be67240602692f3bd1ba75c
+size 50318

--- a/Content/Blueprints/Actor/Dungeon/BP_KnightBattleaxe.uasset
+++ b/Content/Blueprints/Actor/Dungeon/BP_KnightBattleaxe.uasset
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b961d57a06a00cb4e3975a7b315457497cde9136abf7b0574d25ea7e2875f090
-size 33497

--- a/Content/Blueprints/Actor/Dungeon/Weapon/BP_KnightBattleaxe.uasset
+++ b/Content/Blueprints/Actor/Dungeon/Weapon/BP_KnightBattleaxe.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:555fbc059b7d7cc8575c079910df8a1db93e7b03c1fdf433c11f55e605cd2d3c
+size 33467

--- a/Content/Datas/DungeonObjectDataTable.uasset
+++ b/Content/Datas/DungeonObjectDataTable.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bcf1832365e94154c2fe619af632b6409ec3c7b1cd4064b5e493edb798955f44
+size 2871

--- a/Content/Datas/WeaponClassDataTable.uasset
+++ b/Content/Datas/WeaponClassDataTable.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b4d17b1c16277ca7ee676cc1344490246e4cf4c3b9cce01e8665a00a921c866f
-size 5054
+oid sha256:ac0cd0572c8f29e66394b22e4795557b2dee8f0dd84d43a12952d2f38dc54e56
+size 5061

--- a/Source/RogShop/DataTable/DungeonObjectData.cpp
+++ b/Source/RogShop/DataTable/DungeonObjectData.cpp
@@ -1,0 +1,4 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "DungeonObjectData.h"

--- a/Source/RogShop/DataTable/DungeonObjectData.h
+++ b/Source/RogShop/DataTable/DungeonObjectData.h
@@ -1,0 +1,20 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Engine/DataTable.h"
+#include "DungeonObjectData.generated.h"
+
+/**
+ * 
+ */
+USTRUCT(BlueprintType)
+struct ROGSHOP_API FDungeonObjectData : public FTableRowBase
+{
+	GENERATED_BODY()
+
+public:
+	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	TSubclassOf<AActor> ObjectClass;
+};

--- a/Source/RogShop/GameInstanceSubsystem/RSDataSubsystem.cpp
+++ b/Source/RogShop/GameInstanceSubsystem/RSDataSubsystem.cpp
@@ -20,6 +20,7 @@ void URSDataSubsystem::Initialize(FSubsystemCollectionBase& Collection)
 	ForestMonsterSpawnGroup = DataSettings->ForestMonsterSpawnGroupDataTable.LoadSynchronous();
 	Monster = DataSettings->MonsterDataTable.LoadSynchronous();
 	DungeonLevel = DataSettings->DungeonLevelDataTable.LoadSynchronous();
+	DungeonObject = DataSettings->DungeonObjectDataTable.LoadSynchronous();
 
 	check(Food)
 	check(Ingredient)

--- a/Source/RogShop/GameInstanceSubsystem/RSDataSubsystem.h
+++ b/Source/RogShop/GameInstanceSubsystem/RSDataSubsystem.h
@@ -44,4 +44,7 @@ public:
 
 	UPROPERTY()
 	TObjectPtr<UDataTable> DungeonLevel;
+
+	UPROPERTY()
+	TObjectPtr<UDataTable> DungeonObject;
 };

--- a/Source/RogShop/RSDataSubsystemSettings.h
+++ b/Source/RogShop/RSDataSubsystemSettings.h
@@ -41,4 +41,7 @@ public:
 
 	UPROPERTY(Config, EditAnywhere)
 	TSoftObjectPtr<UDataTable> DungeonLevelDataTable;
+
+	UPROPERTY(Config, EditAnywhere)
+	TSoftObjectPtr<UDataTable> DungeonObjectDataTable;
 };


### PR DESCRIPTION
던전에서 스폰할 액터에 대한 클래스를 데이터테이블로 관리하도록 데이터 테이블 생성