### PR TITLE
[Update] 재료 인벤토리의 아이템 드랍 기능 수정

### DIFF
--- a/Content/Blueprints/Widgets/Dungeon/WBP_InventorySlot.uasset
+++ b/Content/Blueprints/Widgets/Dungeon/WBP_InventorySlot.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ba655de53ac5a435c4ceab29eae1b95a0e6f7263e8ae94a4a577f5624727a47a
-size 33762
+oid sha256:36eb7608d6c2533a4c9e16525434a0f8c185c6597f843ab9e40f00b4e4780c8c
+size 36482

--- a/Source/RogShop/Actor/Dungeon/GroundItem/RSDungeonGroundIngredient.cpp
+++ b/Source/RogShop/Actor/Dungeon/GroundItem/RSDungeonGroundIngredient.cpp
@@ -12,7 +12,7 @@ ARSDungeonGroundIngredient::ARSDungeonGroundIngredient()
 
 }
 
-void ARSDungeonGroundIngredient::InitItemInfo(FName NewDataTableKey, UStaticMesh* NewMesh)
+void ARSDungeonGroundIngredient::InitItemInfo(FName NewDataTableKey, UStaticMesh* NewMesh, int32 NewQuantity)
 {
 	if (!NewMesh)
 	{
@@ -24,6 +24,8 @@ void ARSDungeonGroundIngredient::InitItemInfo(FName NewDataTableKey, UStaticMesh
 	MeshComp->SetStaticMesh(NewMesh);
 
 	MeshComp->SetCollisionEnabled(ECollisionEnabled::QueryAndPhysics);
+
+	Quantity = NewQuantity;
 }
 
 void ARSDungeonGroundIngredient::Interact(ARSDunPlayerCharacter* Interactor)
@@ -37,7 +39,7 @@ void ARSDungeonGroundIngredient::Interact(ARSDunPlayerCharacter* Interactor)
 
 	if (DungeonInventoryComp)
 	{
-		DungeonInventoryComp->AddItem(DataTableKey);
+		DungeonInventoryComp->AddItem(DataTableKey, Quantity);
 
 		Destroy();
 	}

--- a/Source/RogShop/Actor/Dungeon/GroundItem/RSDungeonGroundIngredient.h
+++ b/Source/RogShop/Actor/Dungeon/GroundItem/RSDungeonGroundIngredient.h
@@ -19,9 +19,12 @@ public:
 
 // 해당 엑터의 메시 세팅 및 상호작용에 필요한 변수 세팅
 public:
-	void InitItemInfo(FName NewDataTableKey, UStaticMesh* NewMesh);
+	void InitItemInfo(FName NewDataTableKey, UStaticMesh* NewMesh, int32 NewQuantity);
 
 // 상호작용
 public:
 	virtual void Interact(ARSDunPlayerCharacter* Interactor) override;
+
+private:
+	int32 Quantity;
 };

--- a/Source/RogShop/Character/RSDunMonsterCharacter.cpp
+++ b/Source/RogShop/Character/RSDunMonsterCharacter.cpp
@@ -429,7 +429,7 @@ void ARSDunMonsterCharacter::MonsterItemDrop()
 
 				if (DungeonIngredient && IngredientInfoDataRow->ItemStaticMesh)
 				{
-					DungeonIngredient->InitItemInfo(e.IngredientName, IngredientInfoDataRow->ItemStaticMesh);
+					DungeonIngredient->InitItemInfo(e.IngredientName, IngredientInfoDataRow->ItemStaticMesh, 1);
 				}
 			}
 		}

--- a/Source/RogShop/Widget/Dungeon/RSIngredientInventoryWidget.h
+++ b/Source/RogShop/Widget/Dungeon/RSIngredientInventoryWidget.h
@@ -34,4 +34,25 @@ private:
 
     UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Widget", meta = (AllowPrivateAccess = "true"))
     TArray<TObjectPtr<URSInventorySlotWidget>> InvecntorySlots;
+
+// 슬롯 클릭시 재료 드랍
+private:
+    UFUNCTION()
+    void IngredientSlotPress();
+
+    UFUNCTION()
+    void IngredientSlotRelease();
+
+    UFUNCTION()
+    void IngredientDrop();
+
+    UFUNCTION()
+    void SetClickIngredientName(FName NewClickIngredientName);
+
+private:
+    float HoldThreshold;    // 마우스 좌클릭 키다운 시간
+
+    FTimerHandle HoldTimerHandle;   // 마우스 좌클릭 타이머
+
+    FName ClickIngredientName;  // 클릭한 슬롯의 재료의 데이터 테이블 RowName
 };

--- a/Source/RogShop/Widget/Dungeon/RSInventorySlotWidget.cpp
+++ b/Source/RogShop/Widget/Dungeon/RSInventorySlotWidget.cpp
@@ -5,67 +5,17 @@
 #include "RogShop/UtilDefine.h"
 #include "Components/TextBlock.h"
 #include "Components/Image.h"
-#include "RSDunPlayerCharacter.h"
-#include "RSDungeonIngredientInventoryComponent.h"
+#include "Components/Button.h"
 
 void URSInventorySlotWidget::NativeConstruct()
 {
     Super::NativeConstruct();
 
-    bIsPressable = false;
-    HoldThreshold = 0.5f;
-}
-
-FReply URSInventorySlotWidget::NativeOnMouseButtonDown(const FGeometry& InGeometry, const FPointerEvent& InMouseEvent)
-{
-    // 좌클릭 키다운
-    if (InMouseEvent.GetEffectingButton() == EKeys::LeftMouseButton)
+    if (SlotButton)
     {
-        GetWorld()->GetTimerManager().SetTimer(HoldTimerHandle, this, &URSInventorySlotWidget::HandleLongPress, HoldThreshold, false);
-        return FReply::Handled();
+        SlotButton->OnPressed.AddDynamic(this, &URSInventorySlotWidget::HandleSlotClicked);
     }
 
-    return FReply::Unhandled();
-}
-
-FReply URSInventorySlotWidget::NativeOnMouseButtonUp(const FGeometry& InGeometry, const FPointerEvent& InMouseEvent)
-{
-    if (InMouseEvent.GetEffectingButton() == EKeys::LeftMouseButton)
-    {
-        GetWorld()->GetTimerManager().ClearTimer(HoldTimerHandle);
-        return FReply::Handled();
-    }
-
-    return FReply::Unhandled();
-}
-
-void URSInventorySlotWidget::SetIsPressable(bool bNewIsPressable)
-{
-    bIsPressable = bNewIsPressable;
-}
-
-void URSInventorySlotWidget::HandleLongPress()
-{
-    // 유물 슬롯이 아닐때만 처리
-    if (bIsPressable)
-    {
-        // 추가 작업 필요
-        ARSDunPlayerCharacter* CurCharacter = GetOwningPlayerPawn<ARSDunPlayerCharacter>();
-        if (!CurCharacter)
-        {
-            return;
-        }
-
-        URSDungeonIngredientInventoryComponent* IngredientInventoryComp = CurCharacter->GetRSDungeonIngredientInventoryComponent();
-        if (!IngredientInventoryComp)
-        {
-            return;
-        }
-
-        IngredientInventoryComp->DropItem(ItemDataTableKey);
-
-        RS_LOG("UI 클릭");
-    }
 }
 
 void URSInventorySlotWidget::SetSlotItemInfo(FName NewItemDataTableKey, UTexture2D* NewItemIcon, FString NewItemCount)
@@ -89,4 +39,14 @@ void URSInventorySlotWidget::SetSlotItemInfo(FName NewItemDataTableKey, UTexture
 FName URSInventorySlotWidget::GetItemDataTableKey() const
 {
     return ItemDataTableKey;
+}
+
+void URSInventorySlotWidget::HandleSlotClicked()
+{
+    OnSlotClicked.Broadcast(ItemDataTableKey);
+}
+
+UButton* URSInventorySlotWidget::GetSlotButton()
+{
+    return SlotButton;
 }

--- a/Source/RogShop/Widget/Dungeon/RSInventorySlotWidget.h
+++ b/Source/RogShop/Widget/Dungeon/RSInventorySlotWidget.h
@@ -8,6 +8,9 @@
 
 class UImage;
 class UTextBlock;
+class UButton;
+
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnSlotClicked, FName, SlotItemDataTableKey);
 
 UCLASS()
 class ROGSHOP_API URSInventorySlotWidget : public UUserWidget
@@ -17,26 +20,6 @@ class ROGSHOP_API URSInventorySlotWidget : public UUserWidget
 public:
     virtual void NativeConstruct() override;
 
-
-// 위젯 클릭
-protected:
-    virtual FReply NativeOnMouseButtonDown(const FGeometry& InGeometry, const FPointerEvent& InMouseEvent) override;
-    virtual FReply NativeOnMouseButtonUp(const FGeometry& InGeometry, const FPointerEvent& InMouseEvent) override;
-
-public:
-    void SetIsPressable(bool bNewIsPressable);
-
-private:
-    void HandleLongPress();
-
-private:
-    UPROPERTY()
-    bool bIsPressable;  // 해당 값이 true인 경우 버튼 입력을 받습니다.
-
-    float HoldThreshold;    // 마우스 좌클릭 키다운 시간
-
-    FTimerHandle HoldTimerHandle;
-
 // 현재 슬롯에 대한 아이템 정보
 public:
     void SetSlotItemInfo(FName NewItemDataTableKey, UTexture2D* NewItemImage, FString NewItemCount);
@@ -44,12 +27,27 @@ public:
     FName GetItemDataTableKey() const;
 
 private:
-    UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "ItemInfo", meta = (BindWidget, AllowPrivateAccess = "true"))
+    UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "ItemInfo", meta = (AllowPrivateAccess = "true"))
     FName ItemDataTableKey;
 
+public:
+    FOnSlotClicked OnSlotClicked;
+
+private:
+    UFUNCTION()
+    void HandleSlotClicked();
+
+// 위젯
+public:
+    UButton* GetSlotButton();
+
+private:
     UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "ItemInfo", meta = (BindWidget, AllowPrivateAccess = "true"))
     TObjectPtr<UImage> ItemIcon;
 
     UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "ItemInfo", meta = (BindWidget, AllowPrivateAccess = "true"))
     TObjectPtr<UTextBlock> ItemCount;
+
+    UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "ItemInfo", meta = (BindWidget, AllowPrivateAccess = "true"))
+    TObjectPtr<UButton> SlotButton;
 };


### PR DESCRIPTION
URSInventorySlotWidget에서 마우스 클릭 입력은 버튼으로 수행하도록 변경

해당 슬롯을 클릭했을 때 바인딩된 함수로 저장된 데이터 테이블 키를 반환하도록 구현

재료 인벤토리에서 슬롯이 클릭된 경우 클릭된 슬롯의 아이템이 드랍되도록 구현

플로우는 다음과 같습니다.

슬롯 위젯의 클릭 이벤트(저장된 데이터 테이블 키 반환) -> 클릭된 슬롯의 아이템 키 값 저장 ->재료 인벤토리에서 타이머 시작 -> 타이머 완료 -> 저장됐던 아이템 키 값을 기준으로 아이템 드랍 -> UI 갱신