### PR TITLE
[Update] ItemInfoData 내부 ItemIcon 타입 UObject 사용할 수 있도록 변경

### DIFF
--- a/Source/RogShop/DataTable/ItemInfoData.h
+++ b/Source/RogShop/DataTable/ItemInfoData.h
@@ -47,8 +47,9 @@ public:
 	UPROPERTY(EditAnywhere, BlueprintReadWrite)
 	FText Description;
 
-	UPROPERTY(EditAnywhere, BlueprintReadWrite)
-	UTexture2D* ItemIcon;
+	// AllowedClasses 설정값이 있어야 에디터 데이터 테이블에서 해당 ItemIcon 값 설정 가능
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta = (AllowedClasses = "Texture2D, MaterialInstance", DisplayThumbnail = "true"))
+	TObjectPtr<UObject> ItemIcon;
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite)
 	int32 Price;

--- a/Source/RogShop/Widget/DunShop/RSDunItemWidget.cpp
+++ b/Source/RogShop/Widget/DunShop/RSDunItemWidget.cpp
@@ -49,7 +49,7 @@ void URSDunItemWidget::SetItemData(const FItemInfoData& InItemData)
 
     if (ItemImage && ItemData.ItemIcon)
     {
-        ItemImage->SetBrushFromTexture(ItemData.ItemIcon);
+        ItemImage->SetBrushResourceObject(ItemData.ItemIcon);
     }
 }
 

--- a/Source/RogShop/Widget/Dungeon/RSInventorySlotWidget.cpp
+++ b/Source/RogShop/Widget/Dungeon/RSInventorySlotWidget.cpp
@@ -18,7 +18,7 @@ void URSInventorySlotWidget::NativeConstruct()
 
 }
 
-void URSInventorySlotWidget::SetSlotItemInfo(FName NewItemDataTableKey, UTexture2D* NewItemIcon, FString NewItemCount)
+void URSInventorySlotWidget::SetSlotItemInfo(FName NewItemDataTableKey, UObject* NewItemIcon, FString NewItemCount)
 {
     if (NewItemDataTableKey != NAME_None)
     {
@@ -27,7 +27,7 @@ void URSInventorySlotWidget::SetSlotItemInfo(FName NewItemDataTableKey, UTexture
 
     if (ItemIcon)
     {
-        ItemIcon->SetBrushFromTexture(NewItemIcon);
+        ItemIcon->SetBrushResourceObject(NewItemIcon);
     }
 
     if (ItemCount)

--- a/Source/RogShop/Widget/Dungeon/RSInventorySlotWidget.h
+++ b/Source/RogShop/Widget/Dungeon/RSInventorySlotWidget.h
@@ -22,7 +22,7 @@ public:
 
 // 현재 슬롯에 대한 아이템 정보
 public:
-    void SetSlotItemInfo(FName NewItemDataTableKey, UTexture2D* NewItemImage, FString NewItemCount);
+    void SetSlotItemInfo(FName NewItemDataTableKey, UObject* NewItemImage, FString NewItemCount);
 
     FName GetItemDataTableKey() const;
 

--- a/Source/RogShop/Widget/Dungeon/RSPlayerStatusWidget.cpp
+++ b/Source/RogShop/Widget/Dungeon/RSPlayerStatusWidget.cpp
@@ -51,21 +51,21 @@ void URSPlayerStatusWidget::UpdateWeaponSlot(int8 WeaponSlotIndex, FName WeaponK
             {
                 if (WeaponSlot1->Brush.GetResourceObject() == nullptr)
                 {
-                    WeaponSlot1->SetBrushFromTexture(FoundData->ItemIcon);
+                    WeaponSlot1->SetBrushResourceObject(FoundData->ItemIcon);
                 }
                 else if (WeaponSlot2->Brush.GetResourceObject() == nullptr)
                 {
-                    WeaponSlot2->SetBrushFromTexture(FoundData->ItemIcon);
+                    WeaponSlot2->SetBrushResourceObject(FoundData->ItemIcon);
                 }
                 else
                 {
                     if (WeaponSlotIndex == 0 || WeaponSlotIndex == 1)
                     {
-                        WeaponSlot1->SetBrushFromTexture(FoundData->ItemIcon);
+                        WeaponSlot1->SetBrushResourceObject(FoundData->ItemIcon);
                     }
                     else
                     {
-                        WeaponSlot2->SetBrushFromTexture(FoundData->ItemIcon);
+                        WeaponSlot2->SetBrushResourceObject(FoundData->ItemIcon);
                     }
                 }
             }

--- a/Source/RogShop/Widget/Dungeon/RSWeaponInventoryWidget.cpp
+++ b/Source/RogShop/Widget/Dungeon/RSWeaponInventoryWidget.cpp
@@ -97,21 +97,21 @@ void URSWeaponInventoryWidget::UpdateWeaponSlot(int8 WeaponSlotIndex, FName Weap
             {
                 if (WeaponSlot1->Brush.GetResourceObject() == nullptr)
                 {
-                    WeaponSlot1->SetBrushFromTexture(FoundData->ItemIcon);
+                    WeaponSlot1->SetBrushResourceObject(FoundData->ItemIcon);
                 }
                 else if (WeaponSlot2->Brush.GetResourceObject() == nullptr)
                 {
-                    WeaponSlot2->SetBrushFromTexture(FoundData->ItemIcon);
+                    WeaponSlot2->SetBrushResourceObject(FoundData->ItemIcon);
                 }
                 else
                 {
                     if (WeaponSlotIndex == 0 || WeaponSlotIndex == 1)
                     {
-                        WeaponSlot1->SetBrushFromTexture(FoundData->ItemIcon);
+                        WeaponSlot1->SetBrushResourceObject(FoundData->ItemIcon);
                     }
                     else
                     {
-                        WeaponSlot2->SetBrushFromTexture(FoundData->ItemIcon);
+                        WeaponSlot2->SetBrushResourceObject(FoundData->ItemIcon);
                     }
                 }
             }


### PR DESCRIPTION
- 머티리얼 인스턴스 추가 할당을 위하여 기존 UTexture2D 대신에 UObject 타입을 변수에 할당할 수 있도록 변경
- AllowedClasses에 원하는 할당 타입 추가 가능, 현재는 Texture2D, MaterialInstance만 할당 가능하도록 선언해둔 상태
- 각 Texture2D, MaterialInstance 할당 후 해당 데이터 정상 출력되는지 전부 확인 완료