### PR TITLE
[Fix] 클래스가 널 값인 문제 해결

### DIFF
--- a/Content/Blueprints/Actor/Dungeon/BP_DunNextStagePortal.uasset
+++ b/Content/Blueprints/Actor/Dungeon/BP_DunNextStagePortal.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:071bc12e78c026a778b6f27a89dc4fbe05242f50d9a728a63180f9ef3a8bcec2
-size 38928
+oid sha256:b671bbc0ba65efd2449016befc2bbb61fb494f7e3710ba21f738fc4ad4fd5dca
+size 38909


### PR DESCRIPTION
다음 스테이지로 넘어가기 위해 위젯을 띄워야 하는데 상호작용시 클래스가 널이기 때문에 위젯이 띄워지지 않는 문제가 있었습니다.

해당 클래스 참조를 다시 설정해주어 문제를 해결했습니다.