### PR TITLE
[Add] 던전의 스테이지 정보에 대해서 세이브 및 로드 기능 추가

### DIFF
--- a/Source/RogShop/Actor/MapGenerator/RSMapGenerator.cpp
+++ b/Source/RogShop/Actor/MapGenerator/RSMapGenerator.cpp
@@ -17,7 +17,6 @@ ARSMapGenerator::ARSMapGenerator()
     PrimaryActorTick.bCanEverTick = false;
     ShopTilePos = FVector2D::ZeroVector;
     bMapGenerationComplete = false;
-    Seed = 8888;
 }
 
 
@@ -28,7 +27,16 @@ void ARSMapGenerator::BeginPlay()
 // 맵 생성 프로세스 시작
 void ARSMapGenerator::StartMapGenerator()
 {
-    RandomStream.Initialize(Seed);
+    ARSDungeonGameModeBase* DungeonGameMode = GetWorld()->GetAuthGameMode<ARSDungeonGameModeBase>();
+
+    if (!DungeonGameMode)
+    {
+        return;
+    }
+
+    int32 CurSeed = DungeonGameMode->GetSeed();
+
+    RandomStream.Initialize(CurSeed);
 
     GenerateMainPath();
     ChooseShopTile();
@@ -104,12 +112,6 @@ void ARSMapGenerator::GenerateMainPath()
         Current = Next;
         Path.Add(Current);
     }
-}
-
-// 외부에서 시드를 설정할 함수
-void ARSMapGenerator::SetSeed(int32 RandomSeed)
-{
-    Seed = RandomSeed;
 }
 
 // 유효한 위치인지 확인 (그리드 안에 있는지)

--- a/Source/RogShop/Actor/MapGenerator/RSMapGenerator.h
+++ b/Source/RogShop/Actor/MapGenerator/RSMapGenerator.h
@@ -40,8 +40,6 @@ class ROGSHOP_API ARSMapGenerator : public AActor
 public:
 	ARSMapGenerator();
 
-	// 외부함수에서 시드 설정 함수
-	void SetSeed(int32 RandomSeed);
 	void SetTileType(int32 IGridSize, float ITileSize, TSoftObjectPtr<UWorld> ILineTileLevel, TSoftObjectPtr<UWorld> ICornerTileLevel, TSoftObjectPtr<UWorld> ICrossTileLevel, TSoftObjectPtr<UWorld> ITTileLevel, TSoftObjectPtr<UWorld> IDeadEndTileLevel, TSoftObjectPtr<UWorld> IBossArenaLevel, TSoftObjectPtr<UWorld> IEnvLevel);
 	void StartMapGenerator();
 
@@ -77,12 +75,9 @@ protected:
 #pragma region 공개 변수
 public:
 
-	// 타일 크기, 시드 , 그리드 크기
+	// 타일 크기, 그리드 크기
 	UPROPERTY(EditAnywhere, Category = "Room Status") // 타일 크기
 	float TileSize;
-
-	UPROPERTY(EditAnywhere, Category = "Room Status") // 시드
-	int32 Seed;
 
 	UPROPERTY(EditAnywhere, Category = "Room Status") // 그리드 크기
 	int32 GridSize;

--- a/Source/RogShop/GameModeBase/RSDungeonGameModeBase.cpp
+++ b/Source/RogShop/GameModeBase/RSDungeonGameModeBase.cpp
@@ -11,6 +11,7 @@
 #include "Engine/World.h"                             
 #include "TimerManager.h"                             
 #include "RogShop/UtilDefine.h"
+#include "RSDungeonStageSaveGame.h"
 
 ARSDungeonGameModeBase::ARSDungeonGameModeBase()
 {
@@ -21,7 +22,7 @@ void ARSDungeonGameModeBase::BeginPlay()// 게임이 시작될 때 호출됨
 {
     Super::BeginPlay();
     
-    TileIndex = 0; // 저장된 타일 인덱스 값을 불러와 줘야함
+    LoadDungeonInfo();
 
     URSDataSubsystem* DataSubsystem = GetGameInstance()->GetSubsystem<URSDataSubsystem>();
     if (!DataSubsystem) return;
@@ -81,6 +82,61 @@ void ARSDungeonGameModeBase::SpawnMap()// 선택된 맵 타입에 따라 맵 생
     MapGeneratorInstance->StartMapGenerator();
 }
 
+int32 ARSDungeonGameModeBase::GetSeed() const
+{
+    return Seed;
+}
+
+void ARSDungeonGameModeBase::InitRandSeed()
+{
+    Seed = FMath::RandRange(1, INT32_MAX);
+}
+
+int32 ARSDungeonGameModeBase::GetTileIndex() const
+{
+    return TileIndex;
+}
+
+void ARSDungeonGameModeBase::IncrementAtTileIndex()
+{
+    TileIndex += 1;
+}
+
+void ARSDungeonGameModeBase::SaveDungeonInfo()
+{
+    // 다음레벨로 넘어가기전 호출해 레벨 인덱스를 저장해줘야한다
+
+    // SaveGame 오브젝트 생성
+    URSDungeonStageSaveGame* DungeonStageSaveGame = Cast<URSDungeonStageSaveGame>(UGameplayStatics::CreateSaveGameObject(URSDungeonStageSaveGame::StaticClass()));
+    if (!DungeonStageSaveGame)
+    {
+        return;
+    }
+
+    // 세이브
+    DungeonStageSaveGame->TileIndex = TileIndex;
+    DungeonStageSaveGame->Seed = Seed;
+}
+
+void ARSDungeonGameModeBase::LoadDungeonInfo()
+{
+    // SaveGame 오브젝트 생성
+    URSDungeonStageSaveGame* DungeonStageSaveGame = Cast<URSDungeonStageSaveGame>(UGameplayStatics::CreateSaveGameObject(URSDungeonStageSaveGame::StaticClass()));
+    if (!DungeonStageSaveGame)
+    {
+        return;
+    }
+
+    TileIndex = DungeonStageSaveGame->TileIndex;
+    Seed = DungeonStageSaveGame->Seed;
+
+    // 시드 값이 설정되어있지 않은 경우 랜덤한 시드를 설정한다.
+    if (Seed == 0)
+    {
+        InitRandSeed();
+    }
+}
+
 void ARSDungeonGameModeBase::OnMapReady()// 맵 로딩이 완료되었을 때 호출되는 함수
 {
     RS_LOG_DEBUG("맵 로딩 완료, 캐릭터 생성 시작");
@@ -114,9 +170,4 @@ void ARSDungeonGameModeBase::NotifyMapReady()
     RS_LOG_DEBUG("GameMode::NotifyMapReady - 델리게이트 Broadcast");
     OnMapFullyLoaded.Broadcast();
     OnMapReady();
-}
-
-void ARSDungeonGameModeBase::SaveLevelIndex()
-{
-    // 다음레벨로 넘어가기전 호출해 레벨 인덱스를 저장해줘야한다
 }

--- a/Source/RogShop/GameModeBase/RSDungeonGameModeBase.h
+++ b/Source/RogShop/GameModeBase/RSDungeonGameModeBase.h
@@ -25,7 +25,6 @@ public:
 	void OnMapReady(); // 맵이 완전히 로드되었을 때 실행되는 콜백
 	UFUNCTION()
 	void NotifyMapReady(); //MapGenerator가 호출하는 함수
-	void SaveLevelIndex();
 #pragma endregion
 
 #pragma region Delegate
@@ -70,7 +69,6 @@ public:
 
 	UPROPERTY(EditDefaultsOnly, Category = "Player")
 	TSubclassOf<ACharacter> PlayerClass; // 플레이어 캐릭터 클래스
-	int32 TileIndex;
 #pragma endregion
 
 private:
@@ -82,5 +80,31 @@ private:
 private:
 	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "StageClear", meta = (AllowPrivateAccess = "true"))
 	TSubclassOf<AActor> DunNextStagePortalClass;
+#pragma endregion
+
+#pragma region Dungeon Info
+public:
+	int32 GetSeed() const;
+	void InitRandSeed();
+
+	int32 GetTileIndex() const;
+	void IncrementAtTileIndex();
+
+private:
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Dungeon Info", meta = (AllowPrivateAccess = "true"))
+	int32 Seed;	// 해당 값을 기준으로 맵 생성
+
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Dungeon Info", meta = (AllowPrivateAccess = "true"))
+	int32 TileIndex;
+#pragma endregion
+
+
+#pragma region SaveData
+public:
+	UFUNCTION()
+	void SaveDungeonInfo();
+
+private:
+	void LoadDungeonInfo();
 #pragma endregion
 };

--- a/Source/RogShop/SaveGame/Dungeon/RSDungeonStageSaveGame.cpp
+++ b/Source/RogShop/SaveGame/Dungeon/RSDungeonStageSaveGame.cpp
@@ -1,0 +1,5 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "RSDungeonStageSaveGame.h"
+

--- a/Source/RogShop/SaveGame/Dungeon/RSDungeonStageSaveGame.h
+++ b/Source/RogShop/SaveGame/Dungeon/RSDungeonStageSaveGame.h
@@ -1,0 +1,23 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GameFramework/SaveGame.h"
+#include "RSDungeonStageSaveGame.generated.h"
+
+/**
+ * 
+ */
+UCLASS()
+class ROGSHOP_API URSDungeonStageSaveGame : public USaveGame
+{
+	GENERATED_BODY()
+	
+public:
+	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	int32 TileIndex;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	int32 Seed;
+};


### PR DESCRIPTION
던전의 스테이지 정보를 저장하고 불러오는 기능 추가

타일 인덱스와 Seed값을 저장합니다.

로드에서 저장했던 값을 불러오며, Seed값이 0으로 설정되어있는 경우 랜덤한 시드를 불러와 설정하도록 구현했습니다.