### PR TITLE
[Update] 보스 잡고 스테이지 이동이 가능하도록 수정

### DIFF
--- a/Content/Blueprints/Widgets/Dungeon/WBP_SendIngredient.uasset
+++ b/Content/Blueprints/Widgets/Dungeon/WBP_SendIngredient.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2996fe1721ba08b9f353d3aca710d1cc44fd9a1adf46f06bdbfb28e952a94d44
-size 30407
+oid sha256:84f7fe3fb5e2a743c19b9a33f1955af95d4405985f879182163907feb0bb5ec9
+size 30393

--- a/Source/RogShop/Actor/RSInteractableLevelTravel.cpp
+++ b/Source/RogShop/Actor/RSInteractableLevelTravel.cpp
@@ -4,6 +4,7 @@
 #include "RSInteractableLevelTravel.h"
 #include "RSDunPlayerCharacter.h"
 #include "RSGameInstance.h"
+#include "RSSaveGameSubsystem.h"
 
 ARSInteractableLevelTravel::ARSInteractableLevelTravel()
 {
@@ -26,7 +27,26 @@ void ARSInteractableLevelTravel::BeginPlay()
 void ARSInteractableLevelTravel::Interact(ARSDunPlayerCharacter* Interactor)
 {
 	// 레벨을 이동하기 전에 세이브 요청을 의미하는 이벤트 디스패처에 바인딩 된 함수를 호출한다.
-	Interactor->OnSaveRequested.Broadcast();
+
+	if (!Interactor)
+	{
+		return;
+	}
+
+	UGameInstance* CurGameInstance = Interactor->GetGameInstance();
+	if (!CurGameInstance)
+	{
+		return;
+	}
+
+	URSSaveGameSubsystem* SaveGameSubsystem = CurGameInstance->GetSubsystem<URSSaveGameSubsystem>();
+	if (!SaveGameSubsystem)
+	{
+		return;
+	}
+
+	SaveGameSubsystem->OnSaveRequested.Broadcast();
+
 
 	// 레벨 이동 함수 호출
 	URSGameInstance* RSGameInstance = Interactor->GetGameInstance<URSGameInstance>();

--- a/Source/RogShop/ActorComponent/RSDungeonIngredientInventoryComponent.h
+++ b/Source/RogShop/ActorComponent/RSDungeonIngredientInventoryComponent.h
@@ -29,4 +29,7 @@ public:
 	UFUNCTION()
 	virtual void SaveItemData() override;
 	virtual void LoadItemData() override;
+
+private:
+	const FString IngredientInventorySaveSlotName = TEXT("IngredientInventorySaveSlot");
 };

--- a/Source/RogShop/ActorComponent/RSPlayerWeaponComponent.cpp
+++ b/Source/RogShop/ActorComponent/RSPlayerWeaponComponent.cpp
@@ -11,6 +11,7 @@
 #include "ItemInfoData.h"
 #include "RSDungeonGroundWeapon.h"
 #include "RSDunPlayerController.h"
+#include "RSSaveGameSubsystem.h"
 #include "RSDungeonWeaponSaveGame.h"
 
 // Sets default values for this component's properties
@@ -34,10 +35,24 @@ void URSPlayerWeaponComponent::BeginPlay()
 	LoadRequested();
 	
 	ARSDunPlayerCharacter* OwnerCharacter = GetOwner<ARSDunPlayerCharacter>();
-	if (OwnerCharacter)
+	if (!OwnerCharacter)
 	{
-		OwnerCharacter->OnSaveRequested.AddDynamic(this, &URSPlayerWeaponComponent::SaveRequested);
+		return;
 	}
+	UGameInstance* CurGameInstance = OwnerCharacter->GetGameInstance();
+	if (!CurGameInstance)
+	{
+		return;
+	}
+
+	URSSaveGameSubsystem* SaveGameSubsystem = CurGameInstance->GetSubsystem<URSSaveGameSubsystem>();
+	if (!SaveGameSubsystem)
+	{
+		return;
+	}
+
+	SaveGameSubsystem->OnSaveRequested.AddDynamic(this, &URSPlayerWeaponComponent::SaveRequested);
+
 }
 
 void URSPlayerWeaponComponent::HandleNormalAttackInput()
@@ -465,13 +480,12 @@ void URSPlayerWeaponComponent::SaveRequested()
 
 void URSPlayerWeaponComponent::LoadRequested()
 {
-	// 널 체크
+	// 세이브가 있는지 확인 후 로드
 	URSDungeonWeaponSaveGame* WeaponLoadGame = Cast<URSDungeonWeaponSaveGame>(UGameplayStatics::LoadGameFromSlot(WeaponSaveSlotName, 0));
 	if (!WeaponLoadGame)
 	{
 		return;
 	}
-
 
 	ARSDunPlayerCharacter* OwnerCharacter = GetOwner<ARSDunPlayerCharacter>();
 	if (!OwnerCharacter)

--- a/Source/RogShop/ActorComponent/RSRelicInventoryComponent.h
+++ b/Source/RogShop/ActorComponent/RSRelicInventoryComponent.h
@@ -38,4 +38,7 @@ public:
 
 private:
 	void LoadRelicData();
+
+private:
+	const FString RelicSaveSlotName = TEXT("RelicSaveSlot");
 };

--- a/Source/RogShop/Character/RSDunPlayerCharacter.cpp
+++ b/Source/RogShop/Character/RSDunPlayerCharacter.cpp
@@ -18,6 +18,7 @@
 #include "Perception/AIPerceptionStimuliSourceComponent.h"
 #include "Perception/AISense_Sight.h"
 #include "Engine/OverlapResult.h"
+#include "RSSaveGameSubsystem.h"
 #include "RSDungeonStatusSaveGame.h"
 #include "RogShop/UtilDefine.h"
 
@@ -85,7 +86,19 @@ void ARSDunPlayerCharacter::BeginPlay()
     USkeletalMesh* MergeSkeletalMesh = USkeletalMergingLibrary::MergeMeshes(SkeletalMeshMergeParams);
     GetMesh()->SetSkeletalMeshAsset(MergeSkeletalMesh);
 
-    OnSaveRequested.AddDynamic(this, &ARSDunPlayerCharacter::SaveStatus);
+    UGameInstance* CurGameInstance = GetGameInstance();
+    if (!CurGameInstance)
+    {
+        return;
+    }
+
+    URSSaveGameSubsystem* SaveGameSubsystem = CurGameInstance->GetSubsystem<URSSaveGameSubsystem>();
+    if (!SaveGameSubsystem)
+    {
+        return;
+    }
+
+    SaveGameSubsystem->OnSaveRequested.AddDynamic(this, &ARSDunPlayerCharacter::SaveStatus);
 
     LoadStatus();
 }

--- a/Source/RogShop/Character/RSDunPlayerCharacter.h
+++ b/Source/RogShop/Character/RSDunPlayerCharacter.h
@@ -16,8 +16,6 @@ class UAIPerceptionStimuliSourceComponent;
 
 struct FInputActionValue;
 
-DECLARE_DYNAMIC_MULTICAST_DELEGATE(FOnSaveRequested);
-
 UCLASS()
 class ROGSHOP_API ARSDunPlayerCharacter : public ARSDunBaseCharacter
 {
@@ -154,10 +152,8 @@ private:
 	float AttackSpeed;
 
 // 세이브 및 로드
-public:
-	UPROPERTY(BlueprintAssignable)
-	FOnSaveRequested OnSaveRequested;	// 저장 요청을 의미하는 이벤트 디스패처
 
+public:
 	UFUNCTION()
 	void SaveStatus();
 

--- a/Source/RogShop/GameInstanceSubsystem/RSSaveGameSubsystem.cpp
+++ b/Source/RogShop/GameInstanceSubsystem/RSSaveGameSubsystem.cpp
@@ -1,0 +1,5 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "RSSaveGameSubsystem.h"
+

--- a/Source/RogShop/GameInstanceSubsystem/RSSaveGameSubsystem.h
+++ b/Source/RogShop/GameInstanceSubsystem/RSSaveGameSubsystem.h
@@ -1,0 +1,21 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Subsystems/GameInstanceSubsystem.h"
+#include "RSSaveGameSubsystem.generated.h"
+
+DECLARE_DYNAMIC_MULTICAST_DELEGATE(FOnSaveRequested);
+
+UCLASS()
+class ROGSHOP_API URSSaveGameSubsystem : public UGameInstanceSubsystem
+{
+	GENERATED_BODY()
+
+public:
+	UPROPERTY(BlueprintAssignable)
+	FOnSaveRequested OnSaveRequested;	// 저장 요청을 의미하는 이벤트 디스패처
+
+
+};

--- a/Source/RogShop/GameModeBase/RSDungeonGameModeBase.cpp
+++ b/Source/RogShop/GameModeBase/RSDungeonGameModeBase.cpp
@@ -11,6 +11,7 @@
 #include "Engine/World.h"                             
 #include "TimerManager.h"                             
 #include "RogShop/UtilDefine.h"
+#include "RSSaveGameSubsystem.h"
 #include "RSDungeonStageSaveGame.h"
 
 ARSDungeonGameModeBase::ARSDungeonGameModeBase()
@@ -22,6 +23,16 @@ void ARSDungeonGameModeBase::BeginPlay()// 게임이 시작될 때 호출됨
 {
     Super::BeginPlay();
     
+    UGameInstance* CurGameInstance = GetGameInstance();
+    if (CurGameInstance)
+    {
+        URSSaveGameSubsystem* SaveGameSubsystem = CurGameInstance->GetSubsystem<URSSaveGameSubsystem>();
+        if (SaveGameSubsystem)
+        {
+            SaveGameSubsystem->OnSaveRequested.AddDynamic(this, &ARSDungeonGameModeBase::SaveDungeonInfo);
+        }
+    }
+
     LoadDungeonInfo();
 
     URSDataSubsystem* DataSubsystem = GetGameInstance()->GetSubsystem<URSDataSubsystem>();
@@ -114,19 +125,20 @@ void ARSDungeonGameModeBase::SaveDungeonInfo()
     // 세이브
     DungeonStageSaveGame->TileIndex = TileIndex;
     DungeonStageSaveGame->Seed = Seed;
+
+    // 저장
+    UGameplayStatics::SaveGameToSlot(DungeonStageSaveGame, DungeonInfoSaveSlotName, 0);
 }
 
 void ARSDungeonGameModeBase::LoadDungeonInfo()
 {
-    // SaveGame 오브젝트 생성
-    URSDungeonStageSaveGame* DungeonStageSaveGame = Cast<URSDungeonStageSaveGame>(UGameplayStatics::CreateSaveGameObject(URSDungeonStageSaveGame::StaticClass()));
-    if (!DungeonStageSaveGame)
+    // 저장된 세이브 로드
+    URSDungeonStageSaveGame* DungeonInfoLoadGame = Cast<URSDungeonStageSaveGame>(UGameplayStatics::LoadGameFromSlot(DungeonInfoSaveSlotName, 0));
+    if (DungeonInfoLoadGame)
     {
-        return;
+        TileIndex = DungeonInfoLoadGame->TileIndex;
+        Seed = DungeonInfoLoadGame->Seed;
     }
-
-    TileIndex = DungeonStageSaveGame->TileIndex;
-    Seed = DungeonStageSaveGame->Seed;
 
     // 시드 값이 설정되어있지 않은 경우 랜덤한 시드를 설정한다.
     if (Seed == 0)

--- a/Source/RogShop/GameModeBase/RSDungeonGameModeBase.h
+++ b/Source/RogShop/GameModeBase/RSDungeonGameModeBase.h
@@ -106,5 +106,8 @@ public:
 
 private:
 	void LoadDungeonInfo();
+
+private:
+	const FString DungeonInfoSaveSlotName = TEXT("DungeonInfoSaveSlot");
 #pragma endregion
 };

--- a/Source/RogShop/Widget/Dungeon/RSSendIngredientWidget.cpp
+++ b/Source/RogShop/Widget/Dungeon/RSSendIngredientWidget.cpp
@@ -4,7 +4,9 @@
 #include "RSSendIngredientWidget.h"
 #include "Components/Button.h"
 #include "GameFramework/PlayerController.h"
+#include "RSDungeonGameModeBase.h"
 #include "RSGameInstance.h"
+#include "RSSaveGameSubsystem.h"
 
 void URSSendIngredientWidget::NativeConstruct()
 {
@@ -27,11 +29,29 @@ void URSSendIngredientWidget::NextStageTravel()
 {
 	// TODO : 재료를 보낼 수 있는 만큼 골랐는지 확인 후 적게 골랐다면 경고창을 띄운다.
 
-	URSGameInstance* GameInstance = GetGameInstance<URSGameInstance>();
-	if (GameInstance)
+	ARSDungeonGameModeBase* DungeonGameMode = GetWorld()->GetAuthGameMode<ARSDungeonGameModeBase>();
+	if (!DungeonGameMode)
 	{
-		GameInstance->TravelToLevel(TargetLevelAsset);
+		return;
 	}
+	DungeonGameMode->IncrementAtTileIndex();
+	DungeonGameMode->InitRandSeed();
+
+	URSGameInstance* GameInstance = GetGameInstance<URSGameInstance>();
+	if (!GameInstance)
+	{
+		return;
+	}
+
+	URSSaveGameSubsystem* SaveGameSubsystem = GameInstance->GetSubsystem<URSSaveGameSubsystem>();
+	if (!SaveGameSubsystem)
+	{
+		return;
+	}
+
+	SaveGameSubsystem->OnSaveRequested.Broadcast();
+
+	GameInstance->TravelToLevel(TargetLevelAsset);
 }
 
 void URSSendIngredientWidget::ExitWidget()


### PR DESCRIPTION
보스를 잡고 스테이지 이동이 가능하도록 던전에 대한 데이터를 저장 및 로드하도록 구현

재료, 유물의 잘못된 로드 로직 수정

세이브 시점을 의미하는 델리게이트를 플레이어 캐릭터에서 게임 인스턴스 서브시스템을 생성하여 해당 서브시스템으로 옮겨주었습니다.
그에 따라 기존에 바인딩 하던 로직에 수정을 주었습니다.

보스 잡고 재료를 보내는 UI에서 확인 버튼을 누를 경우 다음 스테이지로 이동되도록 해주었습니다.