### PR TITLE
[Update] 다음 스테이지로 넘어가기 전 재료를 타이쿤으로 보낼 수 있는 기능 구현

### DIFF
--- a/Content/Blueprints/Widgets/Dungeon/WBP_IngredientInventory.uasset
+++ b/Content/Blueprints/Widgets/Dungeon/WBP_IngredientInventory.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:aec79aff6207acb7d55524a22edf55069fd0c46a1ea8daf673061705b8709b51
-size 28834
+oid sha256:f54bb874894de763bd39b3ff40235f6697106caf326a545da8c2d8523e060861
+size 28808

--- a/Content/Blueprints/Widgets/Dungeon/WBP_InventorySlot.uasset
+++ b/Content/Blueprints/Widgets/Dungeon/WBP_InventorySlot.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:36eb7608d6c2533a4c9e16525434a0f8c185c6597f843ab9e40f00b4e4780c8c
-size 36482
+oid sha256:9905157e25eeeada08ace9cf2d7127c1e5cccf440f585132b3ebcce34c07769f
+size 36603

--- a/Content/Blueprints/Widgets/Dungeon/WBP_PlayerInventoryWidget.uasset
+++ b/Content/Blueprints/Widgets/Dungeon/WBP_PlayerInventoryWidget.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:71feae14152bd9f0fc7352ec3db70f4c0e7f2c0981240b9b5f69ff2d25d55b02
-size 36672
+oid sha256:b8c3c63e7e60e9305ccaf5394f2f767c94019ab3f18a18ede2213154c290b023
+size 39932

--- a/Content/Blueprints/Widgets/Dungeon/WBP_RelicInventory.uasset
+++ b/Content/Blueprints/Widgets/Dungeon/WBP_RelicInventory.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ee816b4916de7708c2bad9aeb6f2363fd9ee6cf085ac93e2e8ecf1e7460c4cc2
-size 28765
+oid sha256:8f9be6797b12db9a8764f503c68c53499487e95e325c62e7038cc1cd63a3bd5f
+size 29100

--- a/Content/Blueprints/Widgets/Dungeon/WBP_SendIngredient.uasset
+++ b/Content/Blueprints/Widgets/Dungeon/WBP_SendIngredient.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:84f7fe3fb5e2a743c19b9a33f1955af95d4405985f879182163907feb0bb5ec9
-size 30393
+oid sha256:204646f0469f9084ce0935dd201fb26df753d5abbbd82d08bbecf05531f03148
+size 40050

--- a/Content/Blueprints/Widgets/Dungeon/WBP_WeaponInventory.uasset
+++ b/Content/Blueprints/Widgets/Dungeon/WBP_WeaponInventory.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f15977a7efdd126a7c5fe244605de92daea32c0d96eb17935ae776b5feeafa8a
-size 34735
+oid sha256:83b657b1fd722921f6ca3aa695a1d5203e46e44d2b963b33b12503eb59b0c4e0
+size 35092

--- a/Source/RogShop/Actor/Dungeon/RSDunNextStagePortal.cpp
+++ b/Source/RogShop/Actor/Dungeon/RSDunNextStagePortal.cpp
@@ -5,6 +5,8 @@
 #include "Blueprint/UserWidget.h"
 #include "RSDunPlayerCharacter.h"
 #include "GameFramework/PlayerController.h"
+#include "RSSendIngredientWidget.h"
+#include "RSDungeonIngredientInventoryComponent.h"
 
 ARSDunNextStagePortal::ARSDunNextStagePortal()
 {
@@ -34,13 +36,22 @@ void ARSDunNextStagePortal::Interact(ARSDunPlayerCharacter* Interactor)
 			return;
 		}
 
-		SendIngredientWidgetInstance = CreateWidget<UUserWidget>(PC, SendIngredientWidgetClass);
-
+		SendIngredientWidgetInstance = CreateWidget<URSSendIngredientWidget>(PC, SendIngredientWidgetClass);
 		if (!SendIngredientWidgetInstance)
 		{
 			return;
 		}
 
+		URSDungeonIngredientInventoryComponent* IngredientInventoryComp = Interactor->GetRSDungeonIngredientInventoryComponent();
+		if (!IngredientInventoryComp)
+		{
+			return;
+		}
+
+		const TArray<FItemSlot>& IngredientItems = IngredientInventoryComp->GetItems();
+
+		SendIngredientWidgetInstance->CreateSendIngredientSlots(2);
+		SendIngredientWidgetInstance->CreatePlayerIngredientSlots(IngredientItems);
 		SendIngredientWidgetInstance->AddToViewport();
 
 		FInputModeUIOnly InputMode;

--- a/Source/RogShop/Actor/Dungeon/RSDunNextStagePortal.h
+++ b/Source/RogShop/Actor/Dungeon/RSDunNextStagePortal.h
@@ -7,6 +7,8 @@
 #include "RSInteractable.h"
 #include "RSDunNextStagePortal.generated.h"
 
+class URSSendIngredientWidget;
+
 UCLASS()
 class ROGSHOP_API ARSDunNextStagePortal : public AActor, public IRSInteractable
 {
@@ -35,5 +37,5 @@ private:
 	TSubclassOf<UUserWidget> SendIngredientWidgetClass;
 
 	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "UI", meta = (AllowPrivateAccess = "true"))
-	TObjectPtr<UUserWidget> SendIngredientWidgetInstance;
+	TObjectPtr<URSSendIngredientWidget> SendIngredientWidgetInstance;
 };

--- a/Source/RogShop/RogShop.Build.cs
+++ b/Source/RogShop/RogShop.Build.cs
@@ -36,6 +36,7 @@ public class RogShop : ModuleRules
             Path.Combine(ModuleDirectory, "GameInstanceSubsystem"),
             Path.Combine(ModuleDirectory, "SaveGame"),
             Path.Combine(ModuleDirectory, "SaveGame", "Dungeon"),
+            Path.Combine(ModuleDirectory, "SaveGame", "Tycoon"),
             Path.Combine(ModuleDirectory, "Struct"),
         });
 

--- a/Source/RogShop/Widget/Dungeon/RSIngredientInventoryWidget.cpp
+++ b/Source/RogShop/Widget/Dungeon/RSIngredientInventoryWidget.cpp
@@ -22,8 +22,7 @@ void URSIngredientInventoryWidget::NativeConstruct()
 	{
 		RSDunPlayerController->OnIngredientChange.AddDynamic(this, &URSIngredientInventoryWidget::UpdateSlots);
 		
-		// 24개 슬롯, 4열 기준 생성
-		CreateSlots(24, 4);
+		CreateSlots(9, 3);
 	}
 
 	HoldThreshold = 0.5f;
@@ -96,8 +95,6 @@ void URSIngredientInventoryWidget::UpdateSlots(int32 IngredientSlotIndex, FItemS
 	FItemInfoData* IngredientInfoDataRow = IngredientDataTable->FindRow<FItemInfoData>(IngredientKey, TEXT("Get IngredientInfo"));
 	if (IngredientInfoDataRow)
 	{
-		// TODO : 현재 데이터에 대한 텍스처 정보를 가져온다.
-		// nullptr 대신에 텍스처 정보를 넘겨야한다.
 		InvecntorySlots[IngredientSlotIndex]->SetSlotItemInfo(IngredientKey, IngredientInfoDataRow->ItemIcon, FString::FromInt(ItemCount));
 	}
 	else
@@ -121,7 +118,6 @@ void URSIngredientInventoryWidget::IngredientSlotRelease()
 
 void URSIngredientInventoryWidget::IngredientDrop()
 {
-	// 추가 작업 필요
 	ARSDunPlayerCharacter* CurCharacter = GetOwningPlayerPawn<ARSDunPlayerCharacter>();
 	if (!CurCharacter)
 	{

--- a/Source/RogShop/Widget/Dungeon/RSIngredientInventoryWidget.h
+++ b/Source/RogShop/Widget/Dungeon/RSIngredientInventoryWidget.h
@@ -22,6 +22,7 @@ protected:
 public:
     void CreateSlots(int32 NumSlots, int32 NumColumns);
 
+    // 슬롯 수, 열을 기준으로 슬롯 생성
     UFUNCTION()
     void UpdateSlots(int32 IngredientSlotIndex, FItemSlot IngredientItemSlot);
 

--- a/Source/RogShop/Widget/Dungeon/RSInventorySlotWidget.cpp
+++ b/Source/RogShop/Widget/Dungeon/RSInventorySlotWidget.cpp
@@ -20,10 +20,7 @@ void URSInventorySlotWidget::NativeConstruct()
 
 void URSInventorySlotWidget::SetSlotItemInfo(FName NewItemDataTableKey, UObject* NewItemIcon, FString NewItemCount)
 {
-    if (NewItemDataTableKey != NAME_None)
-    {
-        ItemDataTableKey = NewItemDataTableKey;
-    }
+    ItemDataTableKey = NewItemDataTableKey;
 
     if (ItemIcon)
     {
@@ -39,6 +36,31 @@ void URSInventorySlotWidget::SetSlotItemInfo(FName NewItemDataTableKey, UObject*
 FName URSInventorySlotWidget::GetItemDataTableKey() const
 {
     return ItemDataTableKey;
+}
+
+UObject* URSInventorySlotWidget::GetItemIcon() const
+{
+    UObject* IconResourceObject = nullptr;
+
+    if (ItemIcon)
+    {
+        const FSlateBrush& ItemIconBrush = ItemIcon->GetBrush();
+        IconResourceObject = ItemIconBrush.GetResourceObject();
+    }
+
+    return IconResourceObject;
+}
+
+FString URSInventorySlotWidget::GetItemQuantity() const
+{
+    FString ItemCountString;
+
+    if (ItemCount)
+    {
+        ItemCountString = ItemCount->GetText().ToString();
+    }
+
+    return ItemCountString;
 }
 
 void URSInventorySlotWidget::HandleSlotClicked()

--- a/Source/RogShop/Widget/Dungeon/RSInventorySlotWidget.h
+++ b/Source/RogShop/Widget/Dungeon/RSInventorySlotWidget.h
@@ -26,6 +26,10 @@ public:
 
     FName GetItemDataTableKey() const;
 
+    UObject* GetItemIcon() const;
+
+    FString GetItemQuantity() const;
+
 private:
     UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "ItemInfo", meta = (AllowPrivateAccess = "true"))
     FName ItemDataTableKey;

--- a/Source/RogShop/Widget/Dungeon/RSRelicInventoryWidget.cpp
+++ b/Source/RogShop/Widget/Dungeon/RSRelicInventoryWidget.cpp
@@ -19,7 +19,7 @@ void URSRelicInventoryWidget::NativeConstruct()
         RSDunPlayerController->OnRelicAdded.AddDynamic(this, &URSRelicInventoryWidget::UpdateSlots);
 
         // 24개 슬롯, 4열 기준 생성
-        CreateSlots(24, 4);
+        CreateSlots(24, 5);
     }
 }
 

--- a/Source/RogShop/Widget/Dungeon/RSSendIngredientWidget.cpp
+++ b/Source/RogShop/Widget/Dungeon/RSSendIngredientWidget.cpp
@@ -2,33 +2,91 @@
 
 
 #include "RSSendIngredientWidget.h"
+#include "RogShop/UtilDefine.h"
 #include "Components/Button.h"
+#include "Components/UniformGridPanel.h"
 #include "GameFramework/PlayerController.h"
 #include "RSDungeonGameModeBase.h"
 #include "RSGameInstance.h"
 #include "RSSaveGameSubsystem.h"
+#include "RSDataSubsystem.h"
+#include "ItemInfoData.h"
+#include "RSInventorySlotWidget.h"
+#include "ItemSlot.h"
+#include "RSTycoonSaveGame.h"
+#include "RSDunPlayerCharacter.h"
+#include "RSDungeonIngredientInventoryComponent.h"
 
 void URSSendIngredientWidget::NativeConstruct()
 {
 	Super::NativeConstruct();
 
+	// 닫기 버튼 바인딩
 	if (ExitButton)
 	{
 		ExitButton->OnClicked.AddDynamic(this, &URSSendIngredientWidget::ExitWidget);
 	}
 
+	// 확인 버튼 바인딩
 	if (OKButton)
 	{
 		OKButton->OnClicked.AddDynamic(this, &URSSendIngredientWidget::NextStageTravel);
 	}
-
-	// TODO : 플레이어의 재료 인벤토리를 띄우고 재료 아이템 일부를 타이쿤으로 보낼 수 있도록 구현한다.
 }
 
 void URSSendIngredientWidget::NextStageTravel()
 {
 	// TODO : 재료를 보낼 수 있는 만큼 골랐는지 확인 후 적게 골랐다면 경고창을 띄운다.
 
+	URSGameInstance* GameInstance = GetGameInstance<URSGameInstance>();
+	if (!GameInstance)
+	{
+		return;
+	}
+
+	// 타이쿤 세이브 게임으로 오브젝트 생성
+	// 아이템을 타이쿤으로 세이브하기 위해서 사용
+	URSTycoonSaveGame* TycoonSaveGame = Cast<URSTycoonSaveGame>(UGameplayStatics::CreateSaveGameObject(URSTycoonSaveGame::StaticClass()));
+	if (!TycoonSaveGame)
+	{
+		return;
+	}
+
+	// 캐릭터를 통해 재료 인벤토리 컴포넌트를 가져옵니다.
+	ARSDunPlayerCharacter* CurCharacter = GetOwningPlayerPawn<ARSDunPlayerCharacter>();
+	if (!CurCharacter)
+	{
+		return;
+	}
+
+	URSDungeonIngredientInventoryComponent* IngredientInventoryComp = CurCharacter->GetRSDungeonIngredientInventoryComponent();
+	if (!IngredientInventoryComp)
+	{
+		return;
+	}
+
+	// 선택한 재료 순회
+	for (const auto & e : SendIngredientSlots)
+	{
+		FName ItemDataTableKey = e->GetItemDataTableKey();
+
+		// 보낼 재료를 선택하지 않은 경우 스킵
+		if (ItemDataTableKey == NAME_None)
+		{
+			continue;
+		}
+
+		// 보낼 재료의 개수를 가져온다.
+		int32 ItemQuantity = IngredientInventoryComp->GetQuantity(ItemDataTableKey);
+
+		// 인벤토리에서 보낼 아이템을 제거한다.
+		IngredientInventoryComp->RemoveItem(ItemDataTableKey, ItemQuantity);
+
+		// 보낼 재료를 타이쿤으로 세이브하도록 보낸다.
+		TycoonSaveGame->AddIngredient(ItemDataTableKey, ItemQuantity);
+	}
+
+	// 게임모드의 값을 다음 스테이지를 위해 변경
 	ARSDungeonGameModeBase* DungeonGameMode = GetWorld()->GetAuthGameMode<ARSDungeonGameModeBase>();
 	if (!DungeonGameMode)
 	{
@@ -37,12 +95,7 @@ void URSSendIngredientWidget::NextStageTravel()
 	DungeonGameMode->IncrementAtTileIndex();
 	DungeonGameMode->InitRandSeed();
 
-	URSGameInstance* GameInstance = GetGameInstance<URSGameInstance>();
-	if (!GameInstance)
-	{
-		return;
-	}
-
+	// 데이터 세이브 이벤트 호출
 	URSSaveGameSubsystem* SaveGameSubsystem = GameInstance->GetSubsystem<URSSaveGameSubsystem>();
 	if (!SaveGameSubsystem)
 	{
@@ -51,11 +104,13 @@ void URSSendIngredientWidget::NextStageTravel()
 
 	SaveGameSubsystem->OnSaveRequested.Broadcast();
 
+	// 다음 스테이지로 레벨 이동
 	GameInstance->TravelToLevel(TargetLevelAsset);
 }
 
 void URSSendIngredientWidget::ExitWidget()
 {
+	// 현재 위젯을 뷰포트에서 제거하며 입력을 변경
 	APlayerController* PC = GetOwningPlayer();
 	if (PC)
 	{
@@ -66,4 +121,192 @@ void URSSendIngredientWidget::ExitWidget()
 	}
 
 	RemoveFromParent();
+}
+
+void URSSendIngredientWidget::CreateSendIngredientSlots(int32 NumSlots)
+{
+	if (!SendIngredientPanel || !InvecntorySlotWidgetClass)
+	{
+		RS_LOG_DEBUG("SlotImageWidgetClass Null");
+		return;
+	}
+
+	// 패널과 슬롯 배열 초기화
+	SendIngredientPanel->ClearChildren();
+	SendIngredientSlots.Empty();
+
+	for (int32 i = 0; i < NumSlots; ++i)
+	{
+		// 새로운 슬롯 위젯 생성
+		URSInventorySlotWidget* NewSlot = CreateWidget<URSInventorySlotWidget>(GetWorld(), InvecntorySlotWidgetClass);
+
+		if (NewSlot)
+		{
+			int32 Row = 0;
+			int32 Col = i;
+
+			// 패널에 위젯을 자식으로 추가한다.
+			SendIngredientPanel->AddChildToUniformGrid(NewSlot, Row, Col);
+			// 슬롯 배열에 위젯을 추가한다.
+			SendIngredientSlots.Add(NewSlot);
+
+			UButton* SlotButton = NewSlot->GetSlotButton();
+			if (SlotButton)
+			{
+				NewSlot->OnSlotClicked.AddDynamic(this, &URSSendIngredientWidget::SetClickIngredientName);
+				SlotButton->OnClicked.AddDynamic(this, &URSSendIngredientWidget::SendIngredientSlotPress);
+			}
+		}
+	}
+}
+
+void URSSendIngredientWidget::CreatePlayerIngredientSlots(const TArray<FItemSlot>& IngredientItems)
+{
+	if (!PlayerIngredientPanel || !InvecntorySlotWidgetClass)
+	{
+		RS_LOG_DEBUG("SlotImageWidgetClass Null");
+		return;
+	}
+
+	PlayerIngredientPanel->ClearChildren();
+	PlayerIngredientSlots.Empty();
+
+	for (int32 i = 0; i < IngredientItems.Num(); ++i)
+	{
+		FItemSlot CurIngredientItemSlot = IngredientItems[i];
+
+		FName IngredientKey = CurIngredientItemSlot.ItemKey;
+		int32 ItemCount = CurIngredientItemSlot.Quantity;
+
+		if (IngredientKey == NAME_None || ItemCount <= 0)
+		{
+			continue;
+		}
+
+		UWorld* CurrentWorld = GetWorld();
+		if (!CurrentWorld)
+		{
+			return;
+		}
+
+		UGameInstance* CurrentGameInstance = CurrentWorld->GetGameInstance();
+		if (!CurrentGameInstance)
+		{
+			return;
+		}
+
+		URSDataSubsystem* DataSubsystem = CurrentGameInstance->GetSubsystem<URSDataSubsystem>();
+		if (!DataSubsystem)
+		{
+			return;
+		}
+
+		UDataTable* IngredientDataTable = DataSubsystem->IngredientInfo;
+		if (!IngredientDataTable)
+		{
+			return;
+		}
+
+		FItemInfoData* IngredientInfoDataRow = IngredientDataTable->FindRow<FItemInfoData>(IngredientKey, TEXT("Get IngredientInfo"));
+		if (IngredientInfoDataRow)
+		{
+			// 새로운 슬롯 위젯 생성
+			URSInventorySlotWidget* NewSlot = CreateWidget<URSInventorySlotWidget>(GetWorld(), InvecntorySlotWidgetClass);
+
+			if (NewSlot)
+			{
+				// 새롭게 생성한 위젯에 인벤토리에서 가지고 있던 재료를 표시하도록 세팅한다.
+				NewSlot->SetSlotItemInfo(IngredientKey, IngredientInfoDataRow->ItemIcon, FString::FromInt(ItemCount));
+
+				int32 Row = 0;
+				int32 Col = i;
+
+				// 패널에 위젯을 자식으로 추가한다.
+				PlayerIngredientPanel->AddChildToUniformGrid(NewSlot, Row, Col);
+				// 슬롯 배열에 위젯을 추가한다.
+				PlayerIngredientSlots.Add(NewSlot);
+
+				UButton* SlotButton = NewSlot->GetSlotButton();
+				if (SlotButton)
+				{
+					NewSlot->OnSlotClicked.AddDynamic(this, &URSSendIngredientWidget::SetClickIngredientName);
+					SlotButton->OnClicked.AddDynamic(this, &URSSendIngredientWidget::PlayerIngredientSlotPress);
+				}
+			}
+		}
+	}
+}
+
+void URSSendIngredientWidget::SetClickIngredientName(FName NewClickIngredientName)
+{
+	ClickIngredientName = NewClickIngredientName;
+}
+
+void URSSendIngredientWidget::SendIngredientSlotPress()
+{
+	// 클릭한 슬롯에 데이터 테이블 키값을 설정된 상태인 경우 값을 초기화한다.
+	if (ClickIngredientName != NAME_None)
+	{
+		for (auto& e : SendIngredientSlots)
+		{
+			if (e->GetItemDataTableKey() == ClickIngredientName)
+			{
+				e->SetSlotItemInfo(NAME_None, nullptr, "");
+
+				break;
+			}
+		}
+	}
+
+	ClickIngredientName = NAME_None;
+}
+
+void URSSendIngredientWidget::PlayerIngredientSlotPress()
+{
+	if (ClickIngredientName != NAME_None)
+	{
+		URSInventorySlotWidget* InventorySlotWidget = nullptr;
+
+		FName CurItemDataTableKey;
+
+		// 같은 키를 가진 슬롯을 찾는다.
+		for (int i = 0; i < PlayerIngredientSlots.Num(); ++i)
+		{
+			InventorySlotWidget = PlayerIngredientSlots[i];
+			if (InventorySlotWidget)
+			{
+				CurItemDataTableKey = InventorySlotWidget->GetItemDataTableKey();
+				if (CurItemDataTableKey == ClickIngredientName)
+				{
+					break;
+				}
+			}
+		}
+
+		// 이미 존재하는지 확인한다.
+		for (auto& e : SendIngredientSlots)
+		{
+			if (e->GetItemDataTableKey() == CurItemDataTableKey)
+			{
+				return;
+			}
+		}
+
+
+		// 찾은 키를 비어있는 슬롯에 설정해줍니다.
+		for (auto& e : SendIngredientSlots)
+		{
+			if (e->GetItemDataTableKey() == NAME_None)
+			{
+				UObject* IconObject = InventorySlotWidget->GetItemIcon();
+				FString ItemQuantity = InventorySlotWidget->GetItemQuantity();
+
+				e->SetSlotItemInfo(CurItemDataTableKey, IconObject, ItemQuantity);
+
+				break;
+			}
+		}
+	}
+
+	ClickIngredientName = NAME_None;
 }

--- a/Source/RogShop/Widget/Dungeon/RSSendIngredientWidget.h
+++ b/Source/RogShop/Widget/Dungeon/RSSendIngredientWidget.h
@@ -7,6 +7,10 @@
 #include "RSSendIngredientWidget.generated.h"
 
 class UButton;
+class UUniformGridPanel;
+class URSInventorySlotWidget;
+
+struct FItemSlot;
 
 UCLASS()
 class ROGSHOP_API URSSendIngredientWidget : public UUserWidget
@@ -29,6 +33,40 @@ private:
 
 	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Widget", meta = (BindWidget, AllowPrivateAccess = "true"))
 	TObjectPtr<UButton> ExitButton;
+
+// 재료 슬롯
+public:
+	void CreateSendIngredientSlots(int32 NumSlots);
+
+	void CreatePlayerIngredientSlots(const TArray<FItemSlot>& IngredientItems);
+
+private:
+	UFUNCTION()
+	void SetClickIngredientName(FName NewClickIngredientName);
+
+	UFUNCTION()
+	void SendIngredientSlotPress();
+
+	UFUNCTION()
+	void PlayerIngredientSlotPress();
+
+private:
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Widget", meta = (BindWidget, AllowPrivateAccess = "true"))
+	TObjectPtr<UUniformGridPanel> SendIngredientPanel;	// 보낼 재료 슬롯을 배치할 패널
+
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Widget", meta = (BindWidget, AllowPrivateAccess = "true"))
+	TObjectPtr<UUniformGridPanel> PlayerIngredientPanel;	// 플레이어가 획득한 재료 슬롯을 배치할 패널
+
+	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Widget", meta = (AllowPrivateAccess = "true"))
+	TSubclassOf<URSInventorySlotWidget> InvecntorySlotWidgetClass;	// 슬롯 클래스
+
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Widget", meta = (AllowPrivateAccess = "true"))
+	TArray<TObjectPtr<URSInventorySlotWidget>> SendIngredientSlots;	// 보낼 재료를 보여줄 슬롯
+
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Widget", meta = (AllowPrivateAccess = "true"))
+	TArray<TObjectPtr<URSInventorySlotWidget>> PlayerIngredientSlots;	// 플레이어 재료를 보여줄 슬롯
+
+	FName ClickIngredientName;  // 클릭한 슬롯의 재료의 데이터 테이블 RowName
 
 // 레벨 이동
 private:


### PR DESCRIPTION
다음 스테이지로 넘어가도록 도와주는 액터에 상호작용하여 UI를 생성할 때 위젯의 슬롯 수에 대한 값을 넘겨주고 생성하도록 구현

인벤토리 슬롯 위젯에서 아이템 아이콘, 아이템 수를 반환할 수 있도록 Get함수 생성

UI에서 인벤토리에 있는 아이템에 대한 슬롯을 클릭하면 보낼 슬롯에 추가되도록 구현
보낼 슬롯을 클릭하면 보낼 슬롯에서 취소하도록 구현

다음 레벨로 이동하기 전에 선택한 재료 아이템을 타이쿤에 저장하도록 구현