### PR TITLE
[Update] 상호작용 전에 UI로 표시하기위해 이름 반환 및 자동 상호작용 반환 함수 추가

### DIFF
--- a/Source/RogShop/Actor/Dungeon/GroundItem/RSDungeonGroundIngredient.cpp
+++ b/Source/RogShop/Actor/Dungeon/GroundItem/RSDungeonGroundIngredient.cpp
@@ -12,22 +12,6 @@ ARSDungeonGroundIngredient::ARSDungeonGroundIngredient()
 
 }
 
-void ARSDungeonGroundIngredient::InitItemInfo(FName NewDataTableKey, UStaticMesh* NewMesh, int32 NewQuantity)
-{
-	if (!NewMesh)
-	{
-		RS_LOG_C("Invalid StaticMesh Used", FColor::Red);
-	}
-
-	DataTableKey = NewDataTableKey;
-
-	MeshComp->SetStaticMesh(NewMesh);
-
-	MeshComp->SetCollisionEnabled(ECollisionEnabled::QueryAndPhysics);
-
-	Quantity = NewQuantity;
-}
-
 void ARSDungeonGroundIngredient::Interact(ARSDunPlayerCharacter* Interactor)
 {
 	if (!Interactor)
@@ -43,4 +27,9 @@ void ARSDungeonGroundIngredient::Interact(ARSDunPlayerCharacter* Interactor)
 
 		Destroy();
 	}
+}
+
+void ARSDungeonGroundIngredient::SetQuantity(int32 NewQuantity)
+{
+	Quantity = NewQuantity;
 }

--- a/Source/RogShop/Actor/Dungeon/GroundItem/RSDungeonGroundIngredient.h
+++ b/Source/RogShop/Actor/Dungeon/GroundItem/RSDungeonGroundIngredient.h
@@ -17,13 +17,12 @@ class ROGSHOP_API ARSDungeonGroundIngredient : public ARSDungeonGroundItem
 public:
 	ARSDungeonGroundIngredient();
 
-// 해당 엑터의 메시 세팅 및 상호작용에 필요한 변수 세팅
-public:
-	void InitItemInfo(FName NewDataTableKey, UStaticMesh* NewMesh, int32 NewQuantity);
-
 // 상호작용
 public:
 	virtual void Interact(ARSDunPlayerCharacter* Interactor) override;
+
+public:
+	void SetQuantity(int32 NewQuantity);
 
 private:
 	int32 Quantity;

--- a/Source/RogShop/Actor/Dungeon/GroundItem/RSDungeonGroundItem.cpp
+++ b/Source/RogShop/Actor/Dungeon/GroundItem/RSDungeonGroundItem.cpp
@@ -16,6 +16,9 @@ ARSDungeonGroundItem::ARSDungeonGroundItem()
 	MeshComp = CreateDefaultSubobject<UStaticMeshComponent>(TEXT("StaticMesh"));
 	MeshComp->SetupAttachment(SceneComp);
 	MeshComp->SetCollisionProfileName(TEXT("Interactable"));
+
+	InteractName = FText::GetEmpty();
+	bIsAutoInteract = false;
 }
 
 // Called when the game starts or when spawned
@@ -30,6 +33,27 @@ void ARSDungeonGroundItem::BeginPlay()
 void ARSDungeonGroundItem::Interact(ARSDunPlayerCharacter* Interactor)
 {
 
+}
+
+FText ARSDungeonGroundItem::GetInteractName() const
+{
+	return InteractName;
+}
+
+bool ARSDungeonGroundItem::GetIsAutoInteract() const
+{
+	return bIsAutoInteract;
+}
+
+void ARSDungeonGroundItem::InitGroundItemInfo(FText NewInteractName, bool NewbIsAutoInteract, FName NewDataTableKey, UStaticMesh* NewMesh)
+{
+	InteractName = NewInteractName;
+
+	bIsAutoInteract = NewbIsAutoInteract;
+
+	DataTableKey = NewDataTableKey;
+
+	MeshComp->SetStaticMesh(NewMesh);
 }
 
 void ARSDungeonGroundItem::RandImpulse()

--- a/Source/RogShop/Actor/Dungeon/GroundItem/RSDungeonGroundItem.h
+++ b/Source/RogShop/Actor/Dungeon/GroundItem/RSDungeonGroundItem.h
@@ -22,6 +22,22 @@ protected:
 public:
 	virtual void Interact(ARSDunPlayerCharacter* Interactor) override;
 
+	virtual FText GetInteractName() const override;
+
+	virtual bool GetIsAutoInteract() const override;
+
+protected:
+	FText InteractName;
+
+	bool bIsAutoInteract;
+
+// 기본 정보
+public:
+	void InitGroundItemInfo(FText NewInteractName, bool NewbIsAutoInteract, FName NewDataTableKey, UStaticMesh* NewMesh);
+
+protected:
+	FName DataTableKey;	// 데이터 테이블의 RowName을 ID값으로 사용한다.
+
 // 아이템을 랜덤한 방향으로 날린다.
 public:
 	void RandImpulse();
@@ -32,9 +48,5 @@ protected:
 	TObjectPtr<USceneComponent> SceneComp;
 	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Component", meta = (AllowPrivateAccess = true))
 	TObjectPtr<UStaticMeshComponent> MeshComp;
-
-// 데이터 테이블의 RowName을 ID값으로 사용한다.
-protected:
-	FName DataTableKey;
 
 };

--- a/Source/RogShop/Actor/Dungeon/GroundItem/RSDungeonGroundRelic.cpp
+++ b/Source/RogShop/Actor/Dungeon/GroundItem/RSDungeonGroundRelic.cpp
@@ -7,23 +7,9 @@
 #include "RSDunPlayerCharacter.h"
 #include "RSRelicInventoryComponent.h"
 
-void ARSDungeonGroundRelic::InitInteractableRelic(FName NewDataTableKey, UStaticMesh* NewMesh, const TSubclassOf<URSBaseRelic> NewRelicClass)
+void ARSDungeonGroundRelic::SetRelicClass(const TSubclassOf<URSBaseRelic> NewRelicClass)
 {
-	if (!NewMesh)
-	{
-		RS_LOG_C("Invalid StaticMesh Used", FColor::Red);
-	}
-	if (!NewRelicClass)
-	{
-		RS_LOG_C("Invalid Blueprint Class Used", FColor::Red);
-	}
-
-	DataTableKey = NewDataTableKey;
-
-	MeshComp->SetStaticMesh(NewMesh);
 	RelicClass = NewRelicClass;
-
-	MeshComp->SetCollisionEnabled(ECollisionEnabled::QueryAndPhysics);
 }
 
 void ARSDungeonGroundRelic::Interact(ARSDunPlayerCharacter* Interactor)

--- a/Source/RogShop/Actor/Dungeon/GroundItem/RSDungeonGroundRelic.h
+++ b/Source/RogShop/Actor/Dungeon/GroundItem/RSDungeonGroundRelic.h
@@ -12,14 +12,13 @@ UCLASS()
 class ROGSHOP_API ARSDungeonGroundRelic : public ARSDungeonGroundItem
 {
 	GENERATED_BODY()
-	
-public:
-	// 해당 엑터의 메시 세팅 및 상호작용에 필요한 변수 세팅
-	void InitInteractableRelic(FName NewDataTableKey, UStaticMesh* NewMesh, const TSubclassOf<URSBaseRelic> NewRelicClass);
 
 // 상호작용
 public:
 	virtual void Interact(ARSDunPlayerCharacter* Interactor) override;
+
+public:
+	void SetRelicClass(const TSubclassOf<URSBaseRelic> NewRelicClass);
 
 private:
 	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "TargetClass", meta = (AllowPrivateAccess = true))

--- a/Source/RogShop/Actor/Dungeon/GroundItem/RSDungeonGroundWeapon.cpp
+++ b/Source/RogShop/Actor/Dungeon/GroundItem/RSDungeonGroundWeapon.cpp
@@ -13,25 +13,6 @@ ARSDungeonGroundWeapon::ARSDungeonGroundWeapon()
 	PrimaryActorTick.bCanEverTick = false;
 }
 
-void ARSDungeonGroundWeapon::InitInteractableWeapon(FName NewDataTableKey, UStaticMesh* NewMesh, const TSubclassOf<ARSDungeonItemBase> NewWeaponClass)
-{
-	if (!NewMesh)
-	{
-		RS_LOG_C("Invalid StaticMesh Used", FColor::Red);
-	}
-	if (!NewWeaponClass)
-	{
-		RS_LOG_C("Invalid Blueprint Class Used", FColor::Red);
-	}
-
-	DataTableKey = NewDataTableKey;
-
-	MeshComp->SetStaticMesh(NewMesh);
-	WeaponClass = NewWeaponClass;
-
-	MeshComp->SetCollisionEnabled(ECollisionEnabled::QueryAndPhysics);
-}
-
 void ARSDungeonGroundWeapon::Interact(ARSDunPlayerCharacter* Interactor)
 {
 	if (!Interactor)
@@ -53,5 +34,10 @@ void ARSDungeonGroundWeapon::Interact(ARSDunPlayerCharacter* Interactor)
 
 		Destroy();
 	}
+}
+
+void ARSDungeonGroundWeapon::SetWeaponClass(const TSubclassOf<ARSDungeonItemBase> NewWeaponClass)
+{
+	WeaponClass = NewWeaponClass;
 }
 

--- a/Source/RogShop/Actor/Dungeon/GroundItem/RSDungeonGroundWeapon.h
+++ b/Source/RogShop/Actor/Dungeon/GroundItem/RSDungeonGroundWeapon.h
@@ -17,13 +17,12 @@ class ROGSHOP_API ARSDungeonGroundWeapon : public ARSDungeonGroundItem
 public:	
 	ARSDungeonGroundWeapon();
 
-public:	
-// 해당 엑터의 메시 세팅 및 상호작용에 필요한 변수 세팅
-	void InitInteractableWeapon(FName NewDataTableKey, UStaticMesh* NewMesh, const TSubclassOf<ARSDungeonItemBase> NewWeaponClass);
-
 // 상호작용
 public:
 	virtual void Interact(ARSDunPlayerCharacter* Interactor) override;
+
+public:
+	void SetWeaponClass(const TSubclassOf<ARSDungeonItemBase> NewWeaponClass);
 
 private:
 	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "TargetClass", meta = (AllowPrivateAccess = true))

--- a/Source/RogShop/Actor/Dungeon/RSDunBossRoomPortal.cpp
+++ b/Source/RogShop/Actor/Dungeon/RSDunBossRoomPortal.cpp
@@ -14,6 +14,9 @@ ARSDunBossRoomPortal::ARSDunBossRoomPortal()
 	MeshComp = CreateDefaultSubobject<UStaticMeshComponent>(TEXT("StaticMesh"));
 	MeshComp->SetupAttachment(SceneComp);
 	MeshComp->SetCollisionProfileName("Interactable");
+
+	InteractName = FText::FromString(TEXT("보스 방으로"));
+	bIsAutoInteract = false;
 }
 
 void ARSDunBossRoomPortal::BeginPlay()
@@ -28,5 +31,15 @@ void ARSDunBossRoomPortal::Interact(ARSDunPlayerCharacter* Interactor)
 	{
 		Interactor->SetActorTransform(TargetTransform);
 	}
+}
+
+FText ARSDunBossRoomPortal::GetInteractName() const
+{
+	return InteractName;
+}
+
+bool ARSDunBossRoomPortal::GetIsAutoInteract() const
+{
+	return bIsAutoInteract;
 }
 

--- a/Source/RogShop/Actor/Dungeon/RSDunBossRoomPortal.h
+++ b/Source/RogShop/Actor/Dungeon/RSDunBossRoomPortal.h
@@ -18,16 +18,18 @@ public:
 protected:
 	virtual void BeginPlay() override;
 
-// 컴포넌트
-private:
-	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Component", meta = (AllowPrivateAccess = true))
-	TObjectPtr<USceneComponent> SceneComp;
-	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Component", meta = (AllowPrivateAccess = true))
-	TObjectPtr<UStaticMeshComponent> MeshComp;
-
 // 상호작용
 public:
 	virtual void Interact(ARSDunPlayerCharacter* Interactor) override;
+
+	virtual FText GetInteractName() const override;
+
+	virtual bool GetIsAutoInteract() const override;
+
+protected:
+	FText InteractName;
+
+	bool bIsAutoInteract;
 
 // 이동할 위치 정보
 public:
@@ -36,4 +38,11 @@ public:
 private:
 	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "UI", meta = (AllowPrivateAccess = "true"))
 	FTransform TargetTransform;
+
+// 컴포넌트
+private:
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Component", meta = (AllowPrivateAccess = true))
+	TObjectPtr<USceneComponent> SceneComp;
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Component", meta = (AllowPrivateAccess = true))
+	TObjectPtr<UStaticMeshComponent> MeshComp;
 };

--- a/Source/RogShop/Actor/Dungeon/RSDunNextStagePortal.cpp
+++ b/Source/RogShop/Actor/Dungeon/RSDunNextStagePortal.cpp
@@ -18,6 +18,9 @@ ARSDunNextStagePortal::ARSDunNextStagePortal()
 	MeshComp = CreateDefaultSubobject<UStaticMeshComponent>(TEXT("StaticMesh"));
 	MeshComp->SetupAttachment(SceneComp);
 	MeshComp->SetCollisionProfileName("Interactable");
+
+	InteractName = FText::FromString(TEXT("다음 스테이지로"));
+	bIsAutoInteract = false;
 }
 
 void ARSDunNextStagePortal::BeginPlay()
@@ -59,4 +62,14 @@ void ARSDunNextStagePortal::Interact(ARSDunPlayerCharacter* Interactor)
 		PC->SetShowMouseCursor(true);
 		PC->FlushPressedKeys();
 	}
+}
+
+FText ARSDunNextStagePortal::GetInteractName() const
+{
+	return InteractName;
+}
+
+bool ARSDunNextStagePortal::GetIsAutoInteract() const
+{
+	return bIsAutoInteract;
 }

--- a/Source/RogShop/Actor/Dungeon/RSDunNextStagePortal.h
+++ b/Source/RogShop/Actor/Dungeon/RSDunNextStagePortal.h
@@ -31,6 +31,15 @@ private:
 public:
 	virtual void Interact(ARSDunPlayerCharacter* Interactor) override;
 
+	virtual FText GetInteractName() const override;
+
+	virtual bool GetIsAutoInteract() const override;
+
+protected:
+	FText InteractName;
+
+	bool bIsAutoInteract;
+
 // 상호작용시 띄워줄 UI
 private:
 	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "UI", meta = (AllowPrivateAccess = "true"))

--- a/Source/RogShop/Actor/Dungeon/Weapon/RSWeaponSpawnPadActor.cpp
+++ b/Source/RogShop/Actor/Dungeon/Weapon/RSWeaponSpawnPadActor.cpp
@@ -103,9 +103,13 @@ void ARSWeaponSpawnPadActor::SpawnWeapons()
             FRotator::ZeroRotator
         );
 
+        FText ItemName = WeaponData->ItemName;
+        UStaticMesh* ItemStaticMesh = WeaponData->ItemStaticMesh;
+
         if (GroundWeapon)
         {
-            GroundWeapon->InitInteractableWeapon(RandomRowName, WeaponData->ItemStaticMesh, WeaponClassData->WeaponClass);
+            GroundWeapon->InitGroundItemInfo(ItemName, false, RandomRowName, ItemStaticMesh);
+            GroundWeapon->SetWeaponClass(WeaponClassData->WeaponClass);
         }
     }
 }

--- a/Source/RogShop/Actor/NPC/RSDunShopNpcActor.cpp
+++ b/Source/RogShop/Actor/NPC/RSDunShopNpcActor.cpp
@@ -3,26 +3,18 @@
 #include "RSDunPlayerCharacter.h"
 #include "Blueprint/UserWidget.h"
 
-// Sets default values
 ARSDunShopNpcActor::ARSDunShopNpcActor()
 {
- 	// Set this actor to call Tick() every frame.  You can turn this off to improve performance if you don't need it.
 	PrimaryActorTick.bCanEverTick = false;
 
+	InteractName = FText::FromString(TEXT("상점"));
+	bIsAutoInteract = false;
 }
 
-// Called when the game starts or when spawned
 void ARSDunShopNpcActor::BeginPlay()
 {
 	Super::BeginPlay();
 	
-}
-
-// Called every frame
-void ARSDunShopNpcActor::Tick(float DeltaTime)
-{
-	Super::Tick(DeltaTime);
-
 }
 
 void ARSDunShopNpcActor::Interact(ARSDunPlayerCharacter* Interactor)
@@ -36,6 +28,16 @@ void ARSDunShopNpcActor::Interact(ARSDunPlayerCharacter* Interactor)
 	if (!StoreWidget) return;
 
 	StoreWidget->AddToViewport();
+}
+
+FText ARSDunShopNpcActor::GetInteractName() const
+{
+	return InteractName;
+}
+
+bool ARSDunShopNpcActor::GetIsAutoInteract() const
+{
+	return bIsAutoInteract;
 }
 
 

--- a/Source/RogShop/Actor/NPC/RSDunShopNpcActor.h
+++ b/Source/RogShop/Actor/NPC/RSDunShopNpcActor.h
@@ -4,7 +4,7 @@
 
 #include "CoreMinimal.h"
 #include "GameFramework/Actor.h"
-#include "RSInteractable.h" // ÀÎÅÍÆäÀÌ½º Çì´õ
+#include "RSInteractable.h" // ì¸í„°í˜ì´ìŠ¤ í—¤ë”
 #include "RSDunShopNpcActor.generated.h"
 
 UCLASS()
@@ -13,19 +13,26 @@ class ROGSHOP_API ARSDunShopNpcActor : public AActor, public IRSInteractable
 	GENERATED_BODY()
 	
 public:	
-	// Sets default values for this actor's properties
 	ARSDunShopNpcActor();
 
 protected:
-	// Called when the game starts or when spawned
 	virtual void BeginPlay() override;
 
-public:	
-	// Called every frame
-	virtual void Tick(float DeltaTime) override;
-
+// ìƒí˜¸ì‘ìš©
+public:
 	virtual void Interact(ARSDunPlayerCharacter* Interactor) override;
 
-	UPROPERTY(EditDefaultsOnly, Category = "UI")
+	virtual FText GetInteractName() const override;
+
+	virtual bool GetIsAutoInteract() const override;
+
+protected:
+	FText InteractName;
+
+	bool bIsAutoInteract;
+
+// ìƒí˜¸ì‘ìš©ì‹œ ê·¸ë ¤ë‚¼ UI
+private:
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "UI", meta = (AllowPrivateAccess = "true"))
 	TSubclassOf<UUserWidget> StoreWidgetClass;
 };

--- a/Source/RogShop/Actor/RSInteractableLevelTravel.cpp
+++ b/Source/RogShop/Actor/RSInteractableLevelTravel.cpp
@@ -16,6 +16,9 @@ ARSInteractableLevelTravel::ARSInteractableLevelTravel()
 	MeshComp = CreateDefaultSubobject<UStaticMeshComponent>(TEXT("StaticMesh"));
 	MeshComp->SetupAttachment(SceneComp);
 	MeshComp->SetCollisionProfileName("Interactable");
+
+	InteractName = FText::GetEmpty();
+	bIsAutoInteract = false;
 }
 
 void ARSInteractableLevelTravel::BeginPlay()
@@ -54,4 +57,14 @@ void ARSInteractableLevelTravel::Interact(ARSDunPlayerCharacter* Interactor)
 	{
 		RSGameInstance->TravelToLevel(TargetLevelAsset);
 	}
+}
+
+FText ARSInteractableLevelTravel::GetInteractName() const
+{
+	return InteractName;
+}
+
+bool ARSInteractableLevelTravel::GetIsAutoInteract() const
+{
+	return bIsAutoInteract;
 }

--- a/Source/RogShop/Actor/RSInteractableLevelTravel.h
+++ b/Source/RogShop/Actor/RSInteractableLevelTravel.h
@@ -22,6 +22,17 @@ protected:
 public:
 	virtual void Interact(ARSDunPlayerCharacter* Interactor) override;
 
+	virtual FText GetInteractName() const override;
+
+	virtual bool GetIsAutoInteract() const override;
+
+protected:
+	UPROPERTY(EditInstanceOnly, BlueprintReadOnly, Category = "Interact")
+	FText InteractName;
+
+	UPROPERTY(EditInstanceOnly, BlueprintReadOnly, Category = "Interact")
+	bool bIsAutoInteract;
+
 // 레벨 이동
 private:
 	UPROPERTY(EditInstanceOnly, BlueprintReadOnly, Category = "Level", meta = (AllowPrivateAccess = true))

--- a/Source/RogShop/ActorComponent/RSDungeonIngredientInventoryComponent.cpp
+++ b/Source/RogShop/ActorComponent/RSDungeonIngredientInventoryComponent.cpp
@@ -120,11 +120,13 @@ void URSDungeonIngredientInventoryComponent::DropItem(FName ItemKey)
 
 	if (Data)
 	{
+		FText ItemName = Data->ItemName;
 		UStaticMesh* ItemStaticMesh = Data->ItemStaticMesh;
 
 		if (DungeonGroundItem && ItemStaticMesh)
 		{
-			DungeonGroundItem->InitItemInfo(ItemKey, ItemStaticMesh, CurItemQuantity);
+			DungeonGroundItem->InitGroundItemInfo(ItemName, false, ItemKey, ItemStaticMesh);
+			DungeonGroundItem->SetQuantity(CurItemQuantity);
 			DungeonGroundItem->RandImpulse();
 
 			ItemIndex = RemoveItem(ItemKey, INT32_MAX);

--- a/Source/RogShop/ActorComponent/RSPlayerWeaponComponent.cpp
+++ b/Source/RogShop/ActorComponent/RSPlayerWeaponComponent.cpp
@@ -275,12 +275,14 @@ void URSPlayerWeaponComponent::DropWeaponToSlot(EWeaponSlot TargetWeaponSlot)
 	FDungeonWeaponData* WeaponData = GetWorld()->GetGameInstance()->GetSubsystem<URSDataSubsystem>()->WeaponDetail->FindRow<FDungeonWeaponData>(WeaponKey, TEXT("Get WeaponData"));
 	if (ItemInfoData && WeaponData)
 	{
+		FText ItemName = ItemInfoData->ItemName;
 		UStaticMesh* ItemStaticMesh = ItemInfoData->ItemStaticMesh;
 		TSubclassOf<ARSDungeonItemBase> WeaponClass = WeaponData->WeaponClass;
 
 		if (GroundWeapon && ItemStaticMesh && WeaponClass)
 		{
-			GroundWeapon->InitInteractableWeapon(WeaponKey, ItemStaticMesh, WeaponClass);
+			GroundWeapon->InitGroundItemInfo(ItemName, false, WeaponKey, ItemStaticMesh);
+			GroundWeapon->SetWeaponClass(WeaponClass);
 			GroundWeapon->RandImpulse();
 		}
 	}

--- a/Source/RogShop/Character/RSDunMonsterCharacter.cpp
+++ b/Source/RogShop/Character/RSDunMonsterCharacter.cpp
@@ -434,9 +434,13 @@ void ARSDunMonsterCharacter::MonsterItemDrop()
 			{
 				ARSDungeonGroundIngredient* DungeonIngredient = GetWorld()->SpawnActor<ARSDungeonGroundIngredient>(ARSDungeonGroundIngredient::StaticClass(), GetActorTransform());
 
-				if (DungeonIngredient && IngredientInfoDataRow->ItemStaticMesh)
+				if (DungeonIngredient)
 				{
-					DungeonIngredient->InitItemInfo(e.IngredientName, IngredientInfoDataRow->ItemStaticMesh, 1);
+					FText ItemName = IngredientInfoDataRow->ItemName;
+					UStaticMesh* ItemStaticMesh = IngredientInfoDataRow->ItemStaticMesh;
+
+					DungeonIngredient->InitGroundItemInfo(ItemName, false, e.IngredientName, ItemStaticMesh);
+					DungeonIngredient->SetQuantity(1);
 					DungeonIngredient->RandImpulse();
 				}
 			}

--- a/Source/RogShop/DataTable/ItemInfoData.h
+++ b/Source/RogShop/DataTable/ItemInfoData.h
@@ -42,7 +42,7 @@ public:
 	EItemRarity ItemRarity;
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite)
-	FString ItemName;
+	FText ItemName;
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite)
 	FText Description;

--- a/Source/RogShop/Interface/RSInteractable.h
+++ b/Source/RogShop/Interface/RSInteractable.h
@@ -25,4 +25,8 @@ class ROGSHOP_API IRSInteractable
 	// Add interface functions to this class. This is the class that will be inherited to implement this interface.
 public:
 	virtual void Interact(ARSDunPlayerCharacter* Interactor) = 0;
+
+	virtual FText GetInteractName() const = 0;
+
+	virtual bool GetIsAutoInteract() const = 0;
 };

--- a/Source/RogShop/Widget/DunShop/RSDunItemWidget.cpp
+++ b/Source/RogShop/Widget/DunShop/RSDunItemWidget.cpp
@@ -34,7 +34,7 @@ void URSDunItemWidget::SetItemData(const FItemInfoData& InItemData)
 
     if (ItemNameText)
     {
-        ItemNameText->SetText(FText::FromString(ItemData.ItemName));
+        ItemNameText->SetText(ItemData.ItemName);
     }
 
     if (ItemDesText)


### PR DESCRIPTION
상호작용 인터페이스에 이름과 자동 상호작용을 하는지 값을 반환할 순수 가상 함수를 추가했습니다.

이름은 상호작용 전에 UI로 상호작용 할 대상의 이름을 표시하기 위해 사용됩니다.

자동 상호작용 하는지 저장한 값은 몬스터가 드랍하는 재화를 자동으로 줍기 위해 추가한 함수입니다.

해당 가상함수를 추가하면서 기존에 인터페이스를 사용하던 로직에서 오버라이드 해주었습니다.

레벨 이동 액터의 경우 인스턴스 액터에서 이름 값을 설정해주어야 합니다.