### PR TITLE
[Update] 자동 상호작용이 되는 액터 구현 및 몬스터가 죽을 때 던전 재화 드랍 구현

### DIFF
--- a/Content/Blueprints/Actor/Dungeon/BP_RSDungeonGroundLifeEssence.uasset
+++ b/Content/Blueprints/Actor/Dungeon/BP_RSDungeonGroundLifeEssence.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dcf6330dec12e1a0385f1aa9d0f5c15ea82a52b8114de5a55a382f05df5adaa6
+size 34220

--- a/Content/Datas/DungeonObjectDataTable.uasset
+++ b/Content/Datas/DungeonObjectDataTable.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bcf1832365e94154c2fe619af632b6409ec3c7b1cd4064b5e493edb798955f44
-size 2871
+oid sha256:0d55bb4b1afab12707ddeb4ed37db0228b9659f21713d9c1e57659197e1ed2a5
+size 3125

--- a/Content/Datas/MonsterDataTable.uasset
+++ b/Content/Datas/MonsterDataTable.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:eb67aafe8ea9c38318a0f7c4b65040ec3232b5a7210f9eaf2d0f7bc8f9bb3757
-size 42869
+oid sha256:f3ca3e2b14108de75ce4e55cf4406963ca35d3e420d61b433ee2d7c8d2416269
+size 43423

--- a/Source/RogShop/Actor/Dungeon/GroundItem/RSDungeonGroundLifeEssence.cpp
+++ b/Source/RogShop/Actor/Dungeon/GroundItem/RSDungeonGroundLifeEssence.cpp
@@ -1,0 +1,61 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "RSDungeonGroundLifeEssence.h"
+#include "RSDunPlayerCharacter.h"
+
+ARSDungeonGroundLifeEssence::ARSDungeonGroundLifeEssence()
+{
+	InteractName = FText::FromString(TEXT("생명의 정수"));
+	bIsAutoInteract = true;
+
+	CharacterFollowTime = 0.1f;
+	InteractDelayTime = 1.f;
+
+	CharacterFollowSpeed = 300.f;
+
+	Quantity = 1;
+}
+
+void ARSDungeonGroundLifeEssence::Interact(ARSDunPlayerCharacter* Interactor)
+{
+	bIsAutoInteract = false;
+
+	MeshComp->SetSimulatePhysics(false);
+	MeshComp->SetEnableGravity(false);
+	MeshComp->SetCollisionEnabled(ECollisionEnabled::NoCollision);
+
+	// 상호작용 전까지 플레이어 캐릭터를 따라가도록 설정
+	GetWorld()->GetTimerManager().SetTimer(CharacterFollowTimer, FTimerDelegate::CreateLambda([=, this]()
+		{
+			if (Interactor)
+			{
+				FVector CurrentLocation = GetActorLocation();
+
+				FVector Direction = Interactor->GetActorLocation() - CurrentLocation;
+				Direction.Normalize();
+
+				FVector NewLocation = CurrentLocation + Direction * CharacterFollowSpeed * CharacterFollowTime;
+			}
+		}),
+		CharacterFollowTime,
+		true);
+
+	// 상호작용
+	GetWorld()->GetTimerManager().SetTimer(InteractDelayTimer, FTimerDelegate::CreateLambda([=, this]()
+		{
+			if (Interactor)
+			{
+				Interactor->IncreaseLifeEssence(Quantity);
+			}
+
+			Destroy();
+		}),
+		InteractDelayTime,
+		false);
+}
+
+void ARSDungeonGroundLifeEssence::SetQuantity(int32 NewQuantity)
+{
+	Quantity = NewQuantity;
+}

--- a/Source/RogShop/Actor/Dungeon/GroundItem/RSDungeonGroundLifeEssence.h
+++ b/Source/RogShop/Actor/Dungeon/GroundItem/RSDungeonGroundLifeEssence.h
@@ -1,0 +1,42 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "RSDungeonGroundItem.h"
+#include "RSDungeonGroundLifeEssence.generated.h"
+
+/**
+ * 
+ */
+UCLASS()
+class ROGSHOP_API ARSDungeonGroundLifeEssence : public ARSDungeonGroundItem
+{
+	GENERATED_BODY()
+	
+public:
+	ARSDungeonGroundLifeEssence();
+
+// 상호작용
+public:
+	virtual void Interact(ARSDunPlayerCharacter* Interactor) override;
+
+public:
+	void SetQuantity(int32 NewQuantity);
+
+private:
+	// 플레이어 캐릭터 추적 타이머 및 딜레이 타임
+	FTimerHandle CharacterFollowTimer;
+
+	float CharacterFollowTime;
+
+	// 추적 속도
+	float CharacterFollowSpeed;
+
+	// 상호작용 타이머 및 딜레이 타임
+	FTimerHandle InteractDelayTimer;
+
+	float InteractDelayTime;
+
+	int32 Quantity;
+};

--- a/Source/RogShop/Character/RSDunMonsterCharacter.cpp
+++ b/Source/RogShop/Character/RSDunMonsterCharacter.cpp
@@ -8,8 +8,10 @@
 #include "Components/CapsuleComponent.h"
 #include "RSDataSubsystem.h"
 #include "ItemInfoData.h"
+#include "DungeonObjectData.h"
 #include "RSDungeonGameModeBase.h"
 #include "RSDungeonGroundIngredient.h"
+#include "RSDungeonGroundLifeEssence.h"
 
 ARSDunMonsterCharacter::ARSDunMonsterCharacter()
 {
@@ -444,6 +446,21 @@ void ARSDunMonsterCharacter::MonsterItemDrop()
 					DungeonIngredient->RandImpulse();
 				}
 			}
+		}
+	}
+
+	UDataTable* DungeonObjectDataTable = DataSubsystem->DungeonObject;
+	FDungeonObjectData* DungeonObjectDataRow = DungeonObjectDataTable->FindRow<FDungeonObjectData>(FName("LifeEssence"), TEXT("Get DungeonObjectDataTable"));;
+	if (MonsterDataRow && DungeonObjectDataRow && DungeonObjectDataRow->ObjectClass)
+	{
+		ARSDungeonGroundLifeEssence* DungeonLifeEssence = GetWorld()->SpawnActor<ARSDungeonGroundLifeEssence>(DungeonObjectDataRow->ObjectClass, GetActorTransform());
+
+		if (DungeonLifeEssence)
+		{
+			int32 LifeEssenceQuantity = MonsterDataRow->DropLifeEssenceQuantity;
+
+			DungeonLifeEssence->RandImpulse();
+			DungeonLifeEssence->SetQuantity(LifeEssenceQuantity);
 		}
 	}
 }

--- a/Source/RogShop/Character/RSDunPlayerCharacter.cpp
+++ b/Source/RogShop/Character/RSDunPlayerCharacter.cpp
@@ -328,9 +328,6 @@ void ARSDunPlayerCharacter::Dodge(const FInputActionValue& value)
 
 void ARSDunPlayerCharacter::Interaction(const FInputActionValue& value)
 {
-    // 애니메이션과 기획이 아직 준비되지 않았으므로 디버깅용 출력
-    RS_LOG_DEBUG("Interaction Activated");
-
     IRSInteractable* Interactable = Cast<IRSInteractable>(InteractActor);
     if (Interactable)
     {
@@ -512,11 +509,20 @@ void ARSDunPlayerCharacter::InteractTrace()
                 {
                     InteractActor = TargetActor;
 
-                    ARSDunPlayerController* PC = Cast<ARSDunPlayerController>(GetController());
-                    if (PC)
+                    // 바로 상호작용 해야하는 경우
+                    if (Interactable->GetIsAutoInteract() == true)
                     {
-                        PC->ShowInteractWidget();
-                        PC->OnInteractableFound.Broadcast(Interactable->GetInteractName());
+                        Interactable->Interact(this);
+                    }
+                    // 유저가 직접 상호작용 해야하는 경우
+                    else
+                    {
+                        ARSDunPlayerController* PC = Cast<ARSDunPlayerController>(GetController());
+                        if (PC)
+                        {
+                            PC->ShowInteractWidget();
+                            PC->OnInteractableFound.Broadcast(Interactable->GetInteractName());
+                        }
                     }
 
                     RS_DRAW_DEBUG_SPHERE(GetWorld(), Center, InteractRadius, 32, FColor::Green, false, 0.f, 0, 1.0f);

--- a/Source/RogShop/DataTable/MonsterData.h
+++ b/Source/RogShop/DataTable/MonsterData.h
@@ -105,6 +105,9 @@ public:
 	TArray<FMonsterIngredientsData> Ingredients;
 
 	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite)
+	int32 DropLifeEssenceQuantity;
+
+	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite)
 	float MaxHP;
 
 	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite)


### PR DESCRIPTION
IRSInteractable 에서 GetIsAutoInteract함수를 통해 true인 경우 플레이어 캐릭터의 InteractTrace 함수에서 즉시 상호작용 하도록 구현해 자동 상호작용이 되는 액터를 구현해주었습니다.

이렇게 구현한 액터를 사용하여 던전 재화를 드랍할 수 있도록 구현해주었습니다.

던전 재화는 DungeonObject 데이터 테이블에 클래스를 저장해주어 몬스터가 사망했을 때 해당 데이터 클래스를 호출하여 클래스 정보를 가져올 수 있도록 해주었습니다.

몬스터가 사망 했을 때 생명의 정수를 드랍하기 위해서 드랍할 개수를 데이터 테이블에 값을 추가해주었습니다.

이렇게 구현한 기능들을 조합하여 몬스터가 사망했을 때 재화가 드랍되도록 구현해주었습니다.

몬스터가 사망했을 때 재화를 드랍하는 함수는 기존에 재료를 드랍하는 함수인 MonsterItemDrop를 사용하였습니다.