### PR TITLE
[Update] 새 게임 클릭시 던전 세이브 파일이 제거되도록 구현

### DIFF
--- a/Source/RogShop/GameInstanceSubsystem/RSSaveGameSubsystem.cpp
+++ b/Source/RogShop/GameInstanceSubsystem/RSSaveGameSubsystem.cpp
@@ -71,3 +71,76 @@ void URSSaveGameSubsystem::AddIngredientDungeonToTycoon(FName IngredientKey, int
 		RS_LOG_C("재료를 추가하지 못했습니다.", FColor::Red);
 	}
 }
+
+void URSSaveGameSubsystem::DeleteAllSaveFile()
+{
+	DeleteDungeonSaveFile();
+
+	if (UGameplayStatics::DoesSaveGameExist(TycoonSaveSlot, 0))
+	{
+		UGameplayStatics::DeleteGameInSlot(TycoonSaveSlot, 0);
+	}
+
+	if (UGameplayStatics::DoesSaveGameExist(TycoonTileMapSaveSlot, 0))
+	{
+		UGameplayStatics::DeleteGameInSlot(TycoonTileMapSaveSlot, 0);
+	}
+}
+
+void URSSaveGameSubsystem::DeleteDungeonSaveFile()
+{
+	if (UGameplayStatics::DoesSaveGameExist(IngredientInventorySaveSlotName, 0))
+	{
+		UGameplayStatics::DeleteGameInSlot(IngredientInventorySaveSlotName, 0);
+	}
+
+	if (UGameplayStatics::DoesSaveGameExist(WeaponSaveSlotName, 0))
+	{
+		UGameplayStatics::DeleteGameInSlot(WeaponSaveSlotName, 0);
+	}
+
+	if (UGameplayStatics::DoesSaveGameExist(RelicSaveSlotName, 0))
+	{
+		UGameplayStatics::DeleteGameInSlot(RelicSaveSlotName, 0);
+	}
+
+	if (UGameplayStatics::DoesSaveGameExist(StatusSaveSlotName, 0))
+	{
+		UGameplayStatics::DeleteGameInSlot(StatusSaveSlotName, 0);
+	}
+
+	if (UGameplayStatics::DoesSaveGameExist(DungeonInfoSaveSlotName, 0))
+	{
+		UGameplayStatics::DeleteGameInSlot(DungeonInfoSaveSlotName, 0);
+	}
+}
+
+bool URSSaveGameSubsystem::DoesDungeonSaveFileExist()
+{
+	if (!UGameplayStatics::DoesSaveGameExist(IngredientInventorySaveSlotName, 0))
+	{
+		return false;
+	}
+
+	if (UGameplayStatics::DoesSaveGameExist(WeaponSaveSlotName, 0))
+	{
+		return false;
+	}
+
+	if (UGameplayStatics::DoesSaveGameExist(RelicSaveSlotName, 0))
+	{
+		return false;
+	}
+
+	if (UGameplayStatics::DoesSaveGameExist(StatusSaveSlotName, 0))
+	{
+		return false;
+	}
+
+	if (UGameplayStatics::DoesSaveGameExist(DungeonInfoSaveSlotName, 0))
+	{
+		return false;
+	}
+
+	return true;
+}

--- a/Source/RogShop/GameInstanceSubsystem/RSSaveGameSubsystem.h
+++ b/Source/RogShop/GameInstanceSubsystem/RSSaveGameSubsystem.h
@@ -16,10 +16,16 @@ class ROGSHOP_API URSSaveGameSubsystem : public UGameInstanceSubsystem
 public:
 	void AddIngredientDungeonToTycoon(FName IngredientKey, int32 Amount);
 	
+	void DeleteAllSaveFile();
+
+	void DeleteDungeonSaveFile();
+
+	bool DoesDungeonSaveFileExist();
+
 public:
 	UPROPERTY(BlueprintAssignable)
 	FOnSaveRequested OnSaveRequested;	// 저장 요청을 의미하는 이벤트 디스패처
-	
+
 // 세이브 슬롯 네임
 public:
 	// 던전

--- a/Source/RogShop/Widget/MainMenu/MainMenuWidget.cpp
+++ b/Source/RogShop/Widget/MainMenu/MainMenuWidget.cpp
@@ -6,6 +6,7 @@
 #include "Kismet/GameplayStatics.h"
 #include "GameFramework/PlayerController.h"
 #include "RSGameInstance.h"
+#include "RSSaveGameSubsystem.h"
 
 
 void UMainMenuWidget::NativeConstruct()
@@ -17,6 +18,8 @@ void UMainMenuWidget::NativeConstruct()
 		StartButton->OnClicked.AddDynamic(this, &UMainMenuWidget::OnStartButtonClicked);
 	}
 
+	// TODO : 만약 불러올 세이브 파일이 하나도 없는 경우 해당 버튼이 보이거나 위치하면 안된다.
+	// 해당 버튼을 숨기고 로드 버튼의 위치에 StartButton을 위치하게 한다.
 	if (LoadButton)
 	{
 		LoadButton->OnClicked.AddDynamic(this, &UMainMenuWidget::OnLoadButtonClicked);
@@ -35,19 +38,47 @@ void UMainMenuWidget::NativeConstruct()
 
 void UMainMenuWidget::OnStartButtonClicked()
 {
-	// TODO : 기존 세이브 제거
-
-	// 레벨 이동
 	URSGameInstance* RSGameInstance = Cast<URSGameInstance>(GetWorld()->GetGameInstance());
+	
 	if (RSGameInstance)
 	{
+		// 기존 모든 세이브 제거
+		URSSaveGameSubsystem* SaveGameSubsystem = RSGameInstance->GetSubsystem<URSSaveGameSubsystem>();
+		if (SaveGameSubsystem)
+		{
+			SaveGameSubsystem->DeleteAllSaveFile();
+		}
+
+		// 레벨 이동
 		RSGameInstance->TravelToLevel(NewGameTargetLevelAsset);
 	}
 }
 
 void UMainMenuWidget::OnLoadButtonClicked()
 {
-	//UGameplayStatics::OpenLevel(this, FName("다음레벨 이름"));
+	URSGameInstance* RSGameInstance = Cast<URSGameInstance>(GetWorld()->GetGameInstance());
+	if (RSGameInstance)
+	{
+		// 던전에 대한 모든 세이브 파일이 있는지 확인한다.
+		URSSaveGameSubsystem* SaveGameSubsystem = RSGameInstance->GetSubsystem<URSSaveGameSubsystem>();
+		if (SaveGameSubsystem)
+		{
+			bool bDungeonSaveFileExists = SaveGameSubsystem->DoesDungeonSaveFileExist();
+
+			// 던전에 대한 세이브 파일이 모두 존재 하는 경우
+			if (bDungeonSaveFileExists)
+			{
+				// 던전으로 레벨 이동
+				//RSGameInstance->TravelToLevel(NewGameTargetLevelAsset);
+			}
+			// 존재하지 않는 경우
+			else
+			{
+				// 거점으로 레벨 이동
+				//RSGameInstance->TravelToLevel(NewGameTargetLevelAsset);
+			}
+		}
+	}
 }
 
 void UMainMenuWidget::OnOptionButtonClicked()


### PR DESCRIPTION
URSSaveGameSubsystem에서 던전에서 사용하는 세이브 파일들이 존재하는지 확인하고 제거하는 함수를 추가해주었습니다.\
이외에 모든 세이브 파일들이 존재하는지 확인하고 제거하는 함수를 추가해주었습니다,

UMainMenuWidget에서 새 게임 버튼을 클릭 했을 때 모든 세이브 파일들이 존재하는지 확인하고 제거해줍니다.

불러오기 버튼을 클릭했을 경우 던전 세이브 파일만 제거되도록 구현해주었습니다.