### PR TITLE
[Update] 메인 메뉴의 불러오기 버튼 구현

### DIFF
--- a/Source/RogShop/Widget/MainMenu/MainMenuWidget.cpp
+++ b/Source/RogShop/Widget/MainMenu/MainMenuWidget.cpp
@@ -3,6 +3,7 @@
 
 #include "MainMenuWidget.h"
 #include "Components/Button.h"
+#include "Components/CanvasPanelSlot.h"
 #include "Kismet/GameplayStatics.h"
 #include "GameFramework/PlayerController.h"
 #include "RSGameInstance.h"
@@ -19,10 +20,9 @@ void UMainMenuWidget::NativeConstruct()
 		StartButton->OnClicked.AddDynamic(this, &UMainMenuWidget::OnStartButtonClicked);
 	}
 
-	// TODO : 만약 불러올 세이브 파일이 하나도 없는 경우 해당 버튼이 보이거나 위치하면 안된다.
-	// 해당 버튼을 숨기고 로드 버튼의 위치에 StartButton을 위치하게 한다.
+	// 불러올 세이브 파일이 하나도 없는 경우 불러오기 버튼을 숨기고 해당 버튼의 위치에 StartButton을 위치하게 한다.
 	URSGameInstance* RSGameInstance = Cast<URSGameInstance>(GetWorld()->GetGameInstance());
-	if (LoadButton && RSGameInstance)
+	if (LoadButton && StartButton && RSGameInstance)
 	{
 		// 던전에 대한 모든 세이브 파일이 있는지 확인한다.
 		URSSaveGameSubsystem* SaveGameSubsystem = RSGameInstance->GetSubsystem<URSSaveGameSubsystem>();
@@ -39,7 +39,18 @@ void UMainMenuWidget::NativeConstruct()
 			else
 			{
 				LoadButton->SetVisibility(ESlateVisibility::Hidden);
-				
+
+				UCanvasPanelSlot* LoadButtonSlot = Cast<UCanvasPanelSlot>(LoadButton->Slot);
+				if (LoadButtonSlot)
+				{
+					FVector2D LoadButtonPosition = LoadButtonSlot->GetPosition();
+
+					UCanvasPanelSlot* StartButtonSlot = Cast<UCanvasPanelSlot>(StartButton->Slot);
+					if (StartButtonSlot)
+					{
+						StartButtonSlot->SetPosition(LoadButtonPosition);
+					}
+				}
 			}
 		}
 	}

--- a/Source/RogShop/Widget/MainMenu/MainMenuWidget.h
+++ b/Source/RogShop/Widget/MainMenu/MainMenuWidget.h
@@ -36,21 +36,17 @@ public:
 protected:
 
 	UPROPERTY(meta= (BindWidget))
-	class UButton* StartButton;
+	TObjectPtr<UButton> StartButton;
 
 	UPROPERTY(meta = (BindWidget))
-	class UButton* LoadButton;
+	TObjectPtr<UButton> LoadButton;
 
 	UPROPERTY(meta = (BindWidget))
-	class UButton* OptionButton;
+	TObjectPtr<UButton> OptionButton;
+
+	UPROPERTY(meta = (BindWidget))
+	TObjectPtr<UButton> ExitButton;
 
 	UPROPERTY(EditAnywhere, BlueprintReadOnly)
 	TSubclassOf<UUserWidget> OptionMenuWidgetClass;
-
-	UPROPERTY(meta = (BindWidget))
-	class UButton* ExitButton;
-
-private:
-	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Level", meta = (AllowPrivateAccess = true))
-	TSoftObjectPtr<UWorld> NewGameTargetLevelAsset;
 };


### PR DESCRIPTION
불러오기 버튼을 클릭 했을 때 던전에 대한 세이브 파일이 있을 경우 던전으로 이동하고, 없는 경우 거점으로 이동하도록 구현해주었습니다.

만약 모든 세이브 파일이 없을 경우 불러오기 버튼을 숨기고, 불러오기 버튼에 새 게임 버튼이 위치하도록 수정해주었습니다.

기존 헤더에서 바인딩한 위젯들을 스마트 포인터를 사용하도록 변경해주었습니다.