### PR TITLE
[bugFix] 라이프 에센스 액터의 에러 수정 및 위젯이 제대로 전환되지 않던 문제 해결

### DIFF
--- a/Source/RogShop/Actor/Dungeon/GroundItem/RSDungeonGroundLifeEssence.cpp
+++ b/Source/RogShop/Actor/Dungeon/GroundItem/RSDungeonGroundLifeEssence.cpp
@@ -49,6 +49,9 @@ void ARSDungeonGroundLifeEssence::Interact(ARSDunPlayerCharacter* Interactor)
 				Interactor->IncreaseLifeEssence(Quantity);
 			}
 
+			GetWorld()->GetTimerManager().ClearTimer(CharacterFollowTimer);
+			GetWorld()->GetTimerManager().ClearTimer(InteractDelayTimer);
+
 			Destroy();
 		}),
 		InteractDelayTime,

--- a/Source/RogShop/Widget/Dungeon/RSPlayerInventoryWidget.cpp
+++ b/Source/RogShop/Widget/Dungeon/RSPlayerInventoryWidget.cpp
@@ -3,6 +3,7 @@
 #include "RSPlayerInventoryWidget.h"
 
 #include "Components/Button.h"
+#include "RSDunPlayerController.h"
 
 void URSPlayerInventoryWidget::NativeConstruct()
 {
@@ -16,9 +17,15 @@ void URSPlayerInventoryWidget::NativeConstruct()
 
 void URSPlayerInventoryWidget::OnExitBtnClicked()
 {
-    SetMouseMode(false);
-
-    SetVisibility(ESlateVisibility::Hidden);
+    // 인벤토리 닫기
+    if (GetWorld())
+    {
+        ARSDunPlayerController* PC = GetOwningPlayer<ARSDunPlayerController>();
+        if (PC)
+        {
+            PC->TogglePlayerInventoryWidget();
+        }
+    }
 }
 
 void URSPlayerInventoryWidget::SetMouseMode(bool bEnable)

--- a/Source/RogShop/Widget/InGame/RSInGameMenuWidget.cpp
+++ b/Source/RogShop/Widget/InGame/RSInGameMenuWidget.cpp
@@ -6,6 +6,7 @@
 #include "RSGameInstance.h"
 #include "RSLevelSubsystem.h"
 #include "RSSaveGameSubsystem.h"
+#include "RSDunPlayerController.h"
 
 void URSInGameMenuWidget::NativeConstruct()
 {
@@ -72,13 +73,10 @@ void URSInGameMenuWidget::OnCloseButtonClicked()
 	// 메뉴 닫기
 	if (GetWorld())
 	{
-		SetVisibility(ESlateVisibility::Hidden);
-
-		if (APlayerController* PC = GetWorld()->GetFirstPlayerController())
+		ARSDunPlayerController* PC = GetOwningPlayer<ARSDunPlayerController>();
+		if (PC)
 		{
-			FInputModeGameOnly InputMode;
-			PC->SetInputMode(InputMode);
-			PC->bShowMouseCursor = false;
+			PC->ToggleInGameMenuWidget();
 		}
 	}
 }


### PR DESCRIPTION
라이프 에센스에서 타이머가 자신의 액터가 사라져도 계속 반복 동작하던 문제가 있어서 특정 상황에서는 ClearTimer을 통해 타이머가 더이상 동작하지 않도록 해주었습니다.

위젯이 제대로 전환되지 않던 문제는 위젯을 닫거나 전환 할 때 단순하게 뷰포트에 제거만 했기 때문에 발생한 문제입니다.
해당 문제는 플레이어 컨트롤러를 참조하여 위젯을 전환하는 함수를 호출하여 해결해주었습니다.