### PR TITLE
[Fix] 거점에서 로딩창이 계속 남아있는 문제 수정

### DIFF
--- a/Content/Blueprints/Controllers/BP_DunPlayerController.uasset
+++ b/Content/Blueprints/Controllers/BP_DunPlayerController.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0c7ea73fe73f74451b06bb0f2be338616535fa8170980fca3184d7b03834d005
-size 23505
+oid sha256:307ceb5b610ad3f02a76da0d4336b75d9c14f614e8c81d07bfe0d91138952540
+size 23502

--- a/Content/Blueprints/Widgets/Dungeon/WBP_LoadingWidget.uasset
+++ b/Content/Blueprints/Widgets/Dungeon/WBP_LoadingWidget.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4e892c8ab15d9398924d6103c18b8535d62d3d8d94bb3cf6390d908b86d1b39d
+size 27345

--- a/Content/Blueprints/Widgets/InGame/WBP_LoadingUIWidget.uasset
+++ b/Content/Blueprints/Widgets/InGame/WBP_LoadingUIWidget.uasset
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3b1cb3d77bd78d942c6c396e02a1ce2faae5b1d3da88cfedc0dcb596f2bc5f26
-size 26885

--- a/Source/RogShop/Controller/RSDunPlayerController.cpp
+++ b/Source/RogShop/Controller/RSDunPlayerController.cpp
@@ -7,6 +7,7 @@
 #include "RSPlayerInventoryWidget.h"
 #include "TimerManager.h"
 #include "RSDunPlayerCharacter.h"
+#include "RSDungeonGameModeBase.h"
 
 ARSDunPlayerController::ARSDunPlayerController()
 {
@@ -92,22 +93,20 @@ void ARSDunPlayerController::ToggleInGameMenuWidget()
 
 void ARSDunPlayerController::ShowLoadingUI()
 {
-    if (LoadingUIWidgetClass)
-    {
-        LoadingUIWidget = CreateWidget<UUserWidget>(this, LoadingUIWidgetClass);
-        if (LoadingUIWidget)
-        {
-            LoadingUIWidget->AddToViewport(999);
-        }
-    }
-}
+    ARSDungeonGameModeBase* DungeonGameModeBase = GetWorld()->GetAuthGameMode<ARSDungeonGameModeBase>();
 
-void ARSDunPlayerController::HideLoadingUI()
-{
-    if (LoadingUIWidget)
+    // 던전 게임모드일 경우에만 로딩창이 그려지도록 구현
+    if (DungeonGameModeBase)
     {
-        LoadingUIWidget->RemoveFromParent();
-        LoadingUIWidget = nullptr;
+        if (LoadingUIWidgetClass)
+        {
+            LoadingUIWidget = CreateWidget<UUserWidget>(this, LoadingUIWidgetClass);
+
+            if (LoadingUIWidget)
+            {
+                LoadingUIWidget->AddToViewport(999);
+            }
+        }
     }
 }
 

--- a/Source/RogShop/Controller/RSDunPlayerController.h
+++ b/Source/RogShop/Controller/RSDunPlayerController.h
@@ -64,7 +64,6 @@ public:
 public:
 	UFUNCTION(BlueprintCallable)
 	void ShowLoadingUI();
-	void HideLoadingUI();
 
 	void InitializeRSDunMainWidget();
 

--- a/Source/RogShop/GameModeBase/RSDungeonGameModeBase.cpp
+++ b/Source/RogShop/GameModeBase/RSDungeonGameModeBase.cpp
@@ -171,30 +171,26 @@ void ARSDungeonGameModeBase::OnMapReady()// 맵 로딩이 완료되었을 때 �
 
     GetWorld()->GetTimerManager().SetTimerForNextTick([WeakThis]()
     {
-        if (!WeakThis.IsValid()) return;
-
-
+        if (!WeakThis.IsValid())
+        {
+            return;
+        }
+        
         ARSDungeonGameModeBase* GameMode = WeakThis.Get();
-
+        
         if (!GameMode->SpawnManager)
         {
             RS_LOG_DEBUG("스폰 매니저 생성");
             GameMode->SpawnManager = NewObject<URSSpawnManager>(GameMode, URSSpawnManager::StaticClass());
             GameMode->SpawnManager->Initialize(GameMode->GetWorld(), GameMode->GetGameInstance(), GameMode->TileIndex);
-
+        
             GameMode->SpawnManager->SpawnPlayerAtStartPoint();
             GameMode->SpawnManager->SpawnMonstersInLevel();
             GameMode->SpawnManager->SpawnShopNPCInLevel();
             GameMode->SpawnManager->SpawnBossPortal(GameMode->MapGeneratorInstance->BossWorldLocation);
             GameMode->SpawnManager->SpawnBossMonster();
-
-            APlayerController* PC = UGameplayStatics::GetPlayerController(GameMode, 0);
-            ARSDunPlayerController* DunPC = Cast<ARSDunPlayerController>(PC);
-
-            if (DunPC)
-            {
-                DunPC->HideLoadingUI();
-            }
+        
+            GameMode->OnGameReady.Broadcast();
         }
     });
 }

--- a/Source/RogShop/GameModeBase/RSDungeonGameModeBase.h
+++ b/Source/RogShop/GameModeBase/RSDungeonGameModeBase.h
@@ -9,6 +9,7 @@
 #include "RSDungeonGameModeBase.generated.h"
 
 DECLARE_DYNAMIC_MULTICAST_DELEGATE(FOnBossDead);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE(FOnGameReady);
 DECLARE_DYNAMIC_MULTICAST_DELEGATE(FOnMapFullyLoaded);
 
 // 던전 게임모드 클래스 정의
@@ -31,6 +32,9 @@ public:
 public:
 	UPROPERTY(BlueprintAssignable)
 	FOnBossDead OnBossDead;
+
+	UPROPERTY(BlueprintAssignable)
+	FOnGameReady OnGameReady;
 
 	UPROPERTY(BlueprintAssignable)
 	FOnMapFullyLoaded OnMapFullyLoaded;

--- a/Source/RogShop/Widget/Dungeon/RSLoadingWidget.cpp
+++ b/Source/RogShop/Widget/Dungeon/RSLoadingWidget.cpp
@@ -1,0 +1,28 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "RSLoadingWidget.h"
+#include "RSDungeonGameModeBase.h"
+
+void URSLoadingWidget::NativeConstruct()
+{
+	ARSDungeonGameModeBase* DungeonGameModeBase = GetWorld()->GetAuthGameMode<ARSDungeonGameModeBase>();
+	if (DungeonGameModeBase)
+	{
+		DungeonGameModeBase->OnGameReady.AddDynamic(this, &URSLoadingWidget::HideLoading);
+	}
+}
+
+void URSLoadingWidget::HideLoading()
+{
+	APlayerController* PC = GetOwningPlayer();
+	if (PC)
+	{
+		FInputModeGameOnly InputMode;
+		PC->SetInputMode(InputMode);
+		PC->SetShowMouseCursor(false);
+		PC->FlushPressedKeys();
+	}
+
+	RemoveFromParent();
+}

--- a/Source/RogShop/Widget/Dungeon/RSLoadingWidget.h
+++ b/Source/RogShop/Widget/Dungeon/RSLoadingWidget.h
@@ -1,0 +1,23 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Blueprint/UserWidget.h"
+#include "RSLoadingWidget.generated.h"
+
+/**
+ * 
+ */
+UCLASS()
+class ROGSHOP_API URSLoadingWidget : public UUserWidget
+{
+	GENERATED_BODY()
+
+protected:
+	virtual void NativeConstruct() override;
+
+private:
+	UFUNCTION()
+	void HideLoading();
+};


### PR DESCRIPTION
거점 게임모드에서는 특정 델리게이트가 존재하지 않아 로딩이 완료된 시점을 의미하는 이벤트를 호출할 수 없다는 문제가 있었습니다.

이로 인해서 로딩창이 생성된 후 사라지지 못했습니다.

이 문제를 해결하기 위해서 플레이어 컨트롤러에서는 게임모드가 던전 게임모드일 경우에만 로딩창을 생성하도록 해주었습니다.

로딩 위젯에서 C++클래스를 사용하지 않은 상태였는데, C++클래스를 생성해주었습니다.
위젯의 NativeConstruct에서 던전 게임모드의 델리게이트에 로딩 위젯을 사라지게하는 함수를 바인딩 해주었습니다.

게임모드에서 모든 로딩이 완료됨을 의미하는 델리게이트를 추가해주고 던전의 모든 스폰 로직이 마무리 된 후 브로드캐스트 해주도록 했습니다.