### PR TITLE
[Bugfix] 기존 로직이 패키징에서 동작하지 않아 로직 수정

### DIFF
--- a/Source/RogShop/Actor/Dungeon/GroundItem/RSDungeonGroundLifeEssence.cpp
+++ b/Source/RogShop/Actor/Dungeon/GroundItem/RSDungeonGroundLifeEssence.cpp
@@ -3,57 +3,79 @@
 
 #include "RSDungeonGroundLifeEssence.h"
 #include "RSDunPlayerCharacter.h"
+#include "Components/CapsuleComponent.h"
 
 ARSDungeonGroundLifeEssence::ARSDungeonGroundLifeEssence()
 {
+	PrimaryActorTick.bCanEverTick = true;
+	PrimaryActorTick.bStartWithTickEnabled = false;
+
 	InteractName = FText::FromString(TEXT("생명의 정수"));
 	bIsAutoInteract = true;
 
-	CharacterFollowTime = 0.1f;
-	InteractDelayTime = 1.f;
-
 	CharacterFollowSpeed = 300.f;
+
+	InteractDelayTime = 1.f;
 
 	Quantity = 1;
 }
 
-void ARSDungeonGroundLifeEssence::Interact(ARSDunPlayerCharacter* Interactor)
+void ARSDungeonGroundLifeEssence::Tick(float DeltaTime)
 {
-	bIsAutoInteract = false;
-
-	MeshComp->SetSimulatePhysics(false);
-	MeshComp->SetEnableGravity(false);
-	MeshComp->SetCollisionEnabled(ECollisionEnabled::NoCollision);
+	Super::Tick(DeltaTime);
 
 	// 상호작용 전까지 플레이어 캐릭터를 따라가도록 설정
-	GetWorld()->GetTimerManager().SetTimer(CharacterFollowTimer, FTimerDelegate::CreateLambda([=, this]()
+	if (TargetActor)
+	{
+		FVector CurrentLocation = GetActorLocation();
+		FVector TargetLocation = TargetActor->GetActorLocation();
+
+		FVector Direction = TargetLocation - CurrentLocation;
+		Direction.Normalize();
+
+		FVector NewLocation = CurrentLocation + Direction * CharacterFollowSpeed * DeltaTime;
+
+		SetActorLocation(NewLocation);
+
+		// 1초에 50퍼센트씩 속도가 점점 빨라지도록 한다.
+		CharacterFollowSpeed += CharacterFollowSpeed * 0.50f * DeltaTime;
+
+		// 플레이어 캐릭터의 캡슐컴포넌트 반경만큼 가까워진 경우
+		float TargetCapsuleRadius = TargetActor->GetCapsuleComponent()->GetScaledCapsuleRadius();
+		float Distance = FVector::Dist(CurrentLocation, TargetLocation);
+
+		if (Distance <= TargetCapsuleRadius)
 		{
-			if (Interactor)
-			{
-				FVector CurrentLocation = GetActorLocation();
-
-				FVector Direction = Interactor->GetActorLocation() - CurrentLocation;
-				Direction.Normalize();
-
-				FVector NewLocation = CurrentLocation + Direction * CharacterFollowSpeed * CharacterFollowTime;
-			}
-		}),
-		CharacterFollowTime,
-		true);
-
-	// 상호작용
-	GetWorld()->GetTimerManager().SetTimer(InteractDelayTimer, FTimerDelegate::CreateLambda([=, this]()
-		{
-			if (Interactor)
-			{
-				Interactor->IncreaseLifeEssence(Quantity);
-			}
-
-			GetWorld()->GetTimerManager().ClearTimer(CharacterFollowTimer);
-			GetWorld()->GetTimerManager().ClearTimer(InteractDelayTimer);
-
+			TargetActor->IncreaseLifeEssence(Quantity);
 			Destroy();
-		}),
+		}
+	}
+}
+
+void ARSDungeonGroundLifeEssence::Interact(ARSDunPlayerCharacter* Interactor)
+{
+	// 더이상 상호작용 함수가 호출되지 않도록 한다.
+	bIsAutoInteract = false;
+
+	GetWorld()->GetTimerManager().SetTimer(InteractDelayTimer, FTimerDelegate::CreateLambda([=, this]()
+	{
+		// 틱 활성화
+		SetActorTickEnabled(true);
+
+		MeshComp->SetSimulatePhysics(false);
+		MeshComp->SetEnableGravity(false);
+		MeshComp->SetCollisionEnabled(ECollisionEnabled::NoCollision);
+
+		// 루트 컴포넌트를 메시 위치로 이동 및 루트 컴포넌트에 다시 부착후 메시 컴포넌트의 위치 및 회전 초기화
+		SceneComp->SetWorldLocationAndRotation(MeshComp->GetComponentLocation(), MeshComp->GetComponentRotation());
+
+		MeshComp->AttachToComponent(GetRootComponent(), FAttachmentTransformRules::KeepRelativeTransform);
+		MeshComp->SetRelativeLocation(FVector::ZeroVector);
+		MeshComp->SetRelativeRotation(FRotator::ZeroRotator);
+
+		// 타겟 액터 저장
+		TargetActor = Interactor;
+	}),
 		InteractDelayTime,
 		false);
 }

--- a/Source/RogShop/Actor/Dungeon/GroundItem/RSDungeonGroundLifeEssence.h
+++ b/Source/RogShop/Actor/Dungeon/GroundItem/RSDungeonGroundLifeEssence.h
@@ -17,6 +17,8 @@ class ROGSHOP_API ARSDungeonGroundLifeEssence : public ARSDungeonGroundItem
 public:
 	ARSDungeonGroundLifeEssence();
 
+	virtual void Tick(float DeltaTime) override;
+
 // 상호작용
 public:
 	virtual void Interact(ARSDunPlayerCharacter* Interactor) override;
@@ -25,11 +27,12 @@ public:
 	void SetQuantity(int32 NewQuantity);
 
 private:
-	// 플레이어 캐릭터 추적 타이머 및 딜레이 타임
-	FTimerHandle CharacterFollowTimer;
+	int32 Quantity;
 
-	float CharacterFollowTime;
-
+private:
+	// 추적 대상
+	TObjectPtr<ARSDunPlayerCharacter> TargetActor;
+	
 	// 추적 속도
 	float CharacterFollowSpeed;
 
@@ -37,6 +40,4 @@ private:
 	FTimerHandle InteractDelayTimer;
 
 	float InteractDelayTime;
-
-	int32 Quantity;
 };


### PR DESCRIPTION
기존 로직은 타이머와 람다함수를 사용해주었는데 Destory함수 호출 시 패키징에서는 프로그램이 터지는 문제가 발생했습니다.

로직을 수정할 겸 자연스러운 액터 이동을 위해서 Tick함수를 사용해주었습니다.
비용은 타이머보다 높지만 자연스러운 움직임이 가능하기 때문에 Tick을 선택했습니다.

처음에는 재화가 땅에 떨어지도록 해주었고, 바닥에서부터 플레이어 캐릭터를 추적하도록 설정해주었습니다.
추적 중에는 점점 추적 속도가 빨라집니다.

획득되는 시점은 플레이어 캐릭터의 캡슐 컴포넌트에 대한 반지름 값을 기준으로 반지름 값보다 가까운 경우 획득 처리가 되도록 해주었습니다.