### PR TITLE
[Add] 몽타주 스킵 기능 추가

### DIFF
--- a/Content/Assets/PlayerAnimations/Rolling_Montage.uasset
+++ b/Content/Assets/PlayerAnimations/Rolling_Montage.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f19c46ce4541694d7d910414935440fd1d4facf570091a95f6bb5b9fb927c1a8
-size 11339
+oid sha256:c9fbb4dc735ba3d3a3544c08122e85cbb6083bbd01390bb9755d071f2a3d1a52
+size 13069

--- a/Source/RogShop/ActorComponent/RSPlayerWeaponComponent.cpp
+++ b/Source/RogShop/ActorComponent/RSPlayerWeaponComponent.cpp
@@ -95,6 +95,7 @@ void URSPlayerWeaponComponent::HandleNormalAttackInput()
 
 bool URSPlayerWeaponComponent::ContinueComboAttack()
 {
+	// 공격에 대한 입력 버퍼가 설정된 경우
 	if (bComboInputBuffered)
 	{
 		int8 Index = static_cast<int8>(WeaponSlot) - 1;

--- a/Source/RogShop/AnimNotifyState/RSAttackAnimNotifyState.cpp
+++ b/Source/RogShop/AnimNotifyState/RSAttackAnimNotifyState.cpp
@@ -2,6 +2,7 @@
 
 
 #include "RSAttackAnimNotifyState.h"
+#include "RogShop/UtilDefine.h"
 #include "RSDunPlayerCharacter.h"
 #include "RSPlayerWeaponComponent.h"
 #include "RSBaseWeapon.h"
@@ -9,6 +10,8 @@
 void URSAttackAnimNotifyState::NotifyBegin(USkeletalMeshComponent* MeshComp, UAnimSequenceBase* Animation, float TotalDuration)
 {
 	Super::NotifyBegin(MeshComp, Animation, TotalDuration);
+
+	RS_LOG_C("RSAttackAnimNotifyState Begin", FColor::Blue);
 
 }
 
@@ -32,6 +35,8 @@ void URSAttackAnimNotifyState::NotifyTick(USkeletalMeshComponent* MeshComp, UAni
 void URSAttackAnimNotifyState::NotifyEnd(USkeletalMeshComponent* MeshComp, UAnimSequenceBase* Animation)
 {
 	Super::NotifyEnd(MeshComp, Animation);
+
+	RS_LOG_C("RSAttackAnimNotifyState End", FColor::Orange);
 
 	// 데미지를 가했던 액터들을 저장한 배열 초기화
 	ARSDunPlayerCharacter* PlayerCharacter = MeshComp->GetOwner<ARSDunPlayerCharacter>();

--- a/Source/RogShop/AnimNotifyState/RSAttackBufferAnimNotifyState.cpp
+++ b/Source/RogShop/AnimNotifyState/RSAttackBufferAnimNotifyState.cpp
@@ -4,6 +4,7 @@
 #include "RSAttackBufferAnimNotifyState.h"
 #include "RSDunPlayerCharacter.h"
 #include "RSPlayerWeaponComponent.h"
+#include "RogShop/UtilDefine.h"
 
 URSAttackBufferAnimNotifyState::URSAttackBufferAnimNotifyState()
 {
@@ -13,6 +14,8 @@ URSAttackBufferAnimNotifyState::URSAttackBufferAnimNotifyState()
 void URSAttackBufferAnimNotifyState::NotifyBegin(USkeletalMeshComponent* MeshComp, UAnimSequenceBase* Animation, float TotalDuration)
 {
 	Super::NotifyBegin(MeshComp, Animation, TotalDuration);
+
+	RS_LOG_C("RSAttackBufferAnimNotifyState Begin", FColor::Blue);
 
 	bNextAnimStart = false;
 }
@@ -43,10 +46,7 @@ void URSAttackBufferAnimNotifyState::NotifyEnd(USkeletalMeshComponent* MeshComp,
 {
 	Super::NotifyEnd(MeshComp, Animation);
 
-	if (bNextAnimStart)
-	{
-		return;
-	}
+	RS_LOG_C("RSAttackBufferAnimNotifyState End", FColor::Blue);
 
 	if (!MeshComp)
 	{
@@ -55,6 +55,12 @@ void URSAttackBufferAnimNotifyState::NotifyEnd(USkeletalMeshComponent* MeshComp,
 
 	ARSDunPlayerCharacter* PlayerCharacter = MeshComp->GetOwner<ARSDunPlayerCharacter>();
 	if (!PlayerCharacter)
+	{
+		return;
+	}
+
+	// 다음 콤보 공격을 진행해야하며, 몽타주를 스킵한 상태가 아닌 경우
+	if (bNextAnimStart && !PlayerCharacter->IsSkippingMontage())
 	{
 		return;
 	}

--- a/Source/RogShop/AnimNotifyState/RSBlockMontageSkipAnimNotifyState.cpp
+++ b/Source/RogShop/AnimNotifyState/RSBlockMontageSkipAnimNotifyState.cpp
@@ -1,0 +1,37 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "RSBlockMontageSkipAnimNotifyState.h"
+#include "RSDunPlayerCharacter.h"
+
+URSBlockMontageSkipAnimNotifyState::URSBlockMontageSkipAnimNotifyState()
+{
+
+}
+
+void URSBlockMontageSkipAnimNotifyState::NotifyBegin(USkeletalMeshComponent* MeshComp, UAnimSequenceBase* Animation, float TotalDuration)
+{
+	Super::NotifyBegin(MeshComp, Animation, TotalDuration);
+
+	ARSDunPlayerCharacter* PlayerCharacter = MeshComp->GetOwner<ARSDunPlayerCharacter>();
+	if (PlayerCharacter)
+	{
+		PlayerCharacter->SetIsMontageSkippable(false);
+	}
+}
+
+void URSBlockMontageSkipAnimNotifyState::NotifyTick(USkeletalMeshComponent* MeshComp, UAnimSequenceBase* Animation, float FrameDeltaTime)
+{
+	Super::NotifyTick(MeshComp, Animation, FrameDeltaTime);
+}
+
+void URSBlockMontageSkipAnimNotifyState::NotifyEnd(USkeletalMeshComponent* MeshComp, UAnimSequenceBase* Animation)
+{
+	Super::NotifyEnd(MeshComp, Animation);
+
+	ARSDunPlayerCharacter* PlayerCharacter = MeshComp->GetOwner<ARSDunPlayerCharacter>();
+	if (PlayerCharacter)
+	{
+		PlayerCharacter->SetIsMontageSkippable(true);
+	}
+}

--- a/Source/RogShop/AnimNotifyState/RSBlockMontageSkipAnimNotifyState.h
+++ b/Source/RogShop/AnimNotifyState/RSBlockMontageSkipAnimNotifyState.h
@@ -1,0 +1,28 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Animation/AnimNotifies/AnimNotifyState.h"
+#include "RSBlockMontageSkipAnimNotifyState.generated.h"
+
+/**
+ * 
+ */
+UCLASS()
+class ROGSHOP_API URSBlockMontageSkipAnimNotifyState : public UAnimNotifyState
+{
+	GENERATED_BODY()
+	
+public:
+	URSBlockMontageSkipAnimNotifyState();
+
+private:
+	virtual void NotifyBegin(USkeletalMeshComponent* MeshComp, UAnimSequenceBase* Animation, float TotalDuration) override;
+
+	virtual void NotifyTick(USkeletalMeshComponent* MeshComp, UAnimSequenceBase* Animation, float FrameDeltaTime) override;
+
+	virtual void NotifyEnd(USkeletalMeshComponent* MeshComp, UAnimSequenceBase* Animation) override;
+	
+	
+};

--- a/Source/RogShop/Character/RSDunPlayerCharacter.h
+++ b/Source/RogShop/Character/RSDunPlayerCharacter.h
@@ -81,9 +81,28 @@ private:
 	TObjectPtr<UCameraComponent> CameraComp;
 
 // 애니메이션 몽타주 관련
+public:
+	void SetIsMontageSkippable(bool NewbIsMontageSkippable);
+
+	// 현재 몽타주를 스킵 중인지 반환
+	bool IsSkippingMontage() const;
+
 private:
-	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Anim Montage", meta = (AllowPrivateAccess = true))
+	// 현재 재생 중인 몽타주를 스킵 시도한다.
+	bool TrySkipMontage();
+
+private:
+	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Anim Montage", meta = (AllowPrivateAccess = "true"))
 	TObjectPtr<UAnimMontage> DodgeMontage; // 구르기
+
+	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Anim Montage", meta = (AllowPrivateAccess = "true"))
+	TObjectPtr<UAnimMontage> ChangeWeaponMontage;	// 무기 교체
+
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, category = "Anim Montage", meta = (AllowPrivateAccess = "true"))
+	bool bIsMontageSkippable;	// 몽타주를 스킵 가능한 상태인지 저장
+
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, category = "Anim Montage", meta = (AllowPrivateAccess = "true"))
+	bool bIsSkippingMontage;	// 현재 몽타주를 스킵 중인지 저장
 
 // 던전 재화 관련
 public:


### PR DESCRIPTION
몽타주의 재생을 멈추고 시퀀스가 재생되도록 하거나 다른 몽타주가 재생되게하는 스킵 기능을 추가해주었습니다.

기존 몽타주 재생 중 멈추고 다른 몽타주를 재생할 때, 몽타주 재생 중의 상태가 관리되지 않는 문제가 있었습니다.
이 문제는 기존 몽타주에서 노티파이나 노티파이 스테이트가 제대로 호출되지 않고 넘어가버리기 때문에 발생하는 문제였습니다.

현재 상태에 대한 관리는 노티파이 스테이트에서 이루어지기 때문에, 호출되지 않은 노티파이 스테이트를 직접 호출해주어 상태가 관리되도록 구현해주었습니다.

현재 플레이어가 스킵이 가능한 상태인지 값을 저장하는 변수를 추가해주었고, 해당 값은 노티파이 스테이트를 사용하여 몽타주의 특정 구간에서는 스킵이 불가능하도록 해주었습니다.

현재 해당 기능은 구르기에만 적용을 해두었기 때문에 추후 다른 애니메이션 몽타주들에도 적용해야합니다.