### PR TITLE
[Add] 무기 교체 애니메이션 구현

### DIFF
--- a/Content/Assets/PlayerAnimations/equip.uasset
+++ b/Content/Assets/PlayerAnimations/equip.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0b961308fc23b72fd391a5e638c3b83d32833840ce384534bf8d5fc0108beb84
+size 710886

--- a/Content/Assets/PlayerAnimations/equip_Montage.uasset
+++ b/Content/Assets/PlayerAnimations/equip_Montage.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f4aff63437aa5ff32ad4e2d661c64984ca6145d78876d9959f26c891f5cbe2b0
+size 12470

--- a/Content/Blueprints/AnimInstance/ABP_DunPlayerAnim.uasset
+++ b/Content/Blueprints/AnimInstance/ABP_DunPlayerAnim.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6fb517a48934190b5d71eebd76730c78a1bf4c0bc34c5d4a444e775e09281b2e
-size 242210
+oid sha256:c9c25e83d6065d3c1829fced5d73cf3c9e8cfd3d6b3256f8aa0343312b6afdcc
+size 300019

--- a/Content/Blueprints/AnimInstance/ABP_SwordDunPlayerAnim.uasset
+++ b/Content/Blueprints/AnimInstance/ABP_SwordDunPlayerAnim.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:aa9b50d4ba97846bf7175f6d9a738be9d5c6e7bec8b8b0041edbf2083fe9e2f9
-size 66278
+oid sha256:727fc2796ec4f36fe3a5d7de3cc879cb5c399830be244896437ae1ad984cc4b4
+size 67018

--- a/Content/Blueprints/Characters/BP_DunPlayerCharacter.uasset
+++ b/Content/Blueprints/Characters/BP_DunPlayerCharacter.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:53f3bad225f1500b0603618e3df3ab60df5f92a5ef56c8729793f7c942cd7b5d
-size 39412
+oid sha256:e73545cdecc42e2a3f20adfdb31e5fe83324be96b297de91a157b5c410273fb2
+size 40187

--- a/Source/RogShop/ActorComponent/RSPlayerWeaponComponent.h
+++ b/Source/RogShop/ActorComponent/RSPlayerWeaponComponent.h
@@ -29,12 +29,6 @@ protected:
 	virtual void BeginPlay() override;
 
 public:
-	void HandleNormalAttackInput();
-
-	bool ContinueComboAttack();
-
-	void ResetCombo();
-
 	// 슬롯에 무기를 추가한다.
 	UFUNCTION(BlueprintCallable)
 	void EquipWeaponToSlot(ARSBaseWeapon* WeaponActor);
@@ -42,11 +36,18 @@ public:
 	// 특정 슬롯의 무기를 버린다.
 	void DropWeaponToSlot(EWeaponSlot TargetWeaponSlot);
 
-	// 특정 슬롯의 무기를 장착한다.
-	void EquipWeaponToCharacter(EWeaponSlot TargetWeaponSlot);
-
 	// 장착 중인 무기를 장착 해제한다.
 	void UnEquipWeaponToCharacter();
+
+	// 무기 교체시 변경할 슬롯을 미리 저장한다.
+	// 교체 애니메이션 재생 중 특정 노티파이에서 교체된다.
+	void SetChangeTargetSlot(EWeaponSlot TargetWeaponSlot);
+
+	// 현재 설정된 슬롯으로 무기 교체가 가능한지 반환
+	bool CanChangeTargetSlot();
+
+	// 특정 슬롯의 무기를 장착한다.
+	void EquipWeaponToCharacter();
 
 private:
 	// 무기
@@ -59,6 +60,18 @@ private:
 	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Weapon", meta = (AllowPrivateAccess = true))
 	int32 WeaponSlotSize;	// 최대 슬롯 수
 
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Weapon", meta = (AllowPrivateAccess = true))
+	EWeaponSlot ChangeTargetSlot;
+
+// 공격 관련
+public:
+	void HandleNormalAttackInput();
+
+	bool ContinueComboAttack();
+
+	void ResetCombo();
+
+private:
 	// 애니메이션을 위한 상태
 	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Weapon", meta = (AllowPrivateAccess = true))
 	bool bIsAttack;	// 공격 중인 상태

--- a/Source/RogShop/AnimNotify/RSWeaponChangeAnimNotify.cpp
+++ b/Source/RogShop/AnimNotify/RSWeaponChangeAnimNotify.cpp
@@ -1,0 +1,28 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "RSWeaponChangeAnimNotify.h"
+#include "RSDunPlayerCharacter.h"
+#include "RSPlayerWeaponComponent.h"
+
+void URSWeaponChangeAnimNotify::Notify(USkeletalMeshComponent* MeshComp, UAnimSequenceBase* Animation)
+{
+	Super::Notify(MeshComp, Animation);
+
+	if (!MeshComp)
+	{
+		return;
+	}
+
+	ARSDunPlayerCharacter* PlayerCharacter = MeshComp->GetOwner<ARSDunPlayerCharacter>();
+	if (!PlayerCharacter)
+	{
+		return;
+	}
+
+	URSPlayerWeaponComponent* WeaponComp = PlayerCharacter->GetRSPlayerWeaponComponent();
+	if (WeaponComp)
+	{
+		WeaponComp->EquipWeaponToCharacter();
+	}
+}

--- a/Source/RogShop/AnimNotify/RSWeaponChangeAnimNotify.h
+++ b/Source/RogShop/AnimNotify/RSWeaponChangeAnimNotify.h
@@ -1,0 +1,19 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Animation/AnimNotifies/AnimNotify.h"
+#include "RSWeaponChangeAnimNotify.generated.h"
+
+/**
+ * 
+ */
+UCLASS()
+class ROGSHOP_API URSWeaponChangeAnimNotify : public UAnimNotify
+{
+	GENERATED_BODY()
+	
+public:
+	virtual void Notify(USkeletalMeshComponent* MeshComp, UAnimSequenceBase* Animation) override;
+};

--- a/Source/RogShop/Character/RSDunPlayerCharacter.cpp
+++ b/Source/RogShop/Character/RSDunPlayerCharacter.cpp
@@ -379,7 +379,25 @@ void ARSDunPlayerCharacter::FirstWeaponSlot(const FInputActionValue& value)
     // 추후에 해당 무기로 전환되는 기능 구현해야한다.
     RS_LOG_DEBUG("FirstWeaponSlot Activated");
 
-    WeaponComp->EquipWeaponToCharacter(EWeaponSlot::FirstWeaponSlot);
+    UAnimInstance* AnimInstance = GetMesh()->GetAnimInstance();
+    if (!AnimInstance)
+    {
+        return;
+    }
+
+    // 무기 교체 애니메이션을 재생 중이지 않으며, 스킵이 가능한 경우
+    if (!AnimInstance->Montage_IsPlaying(ChangeWeaponMontage) && TrySkipMontage())
+    {
+        // 타겟 슬롯을 변경
+        WeaponComp->SetChangeTargetSlot(EWeaponSlot::FirstWeaponSlot);
+
+        // 변경한 타겟 슬롯으로 무기 교체가 가능한지 확인
+        if (WeaponComp->CanChangeTargetSlot())
+        {
+            // 무기 교체 몽타주 재생
+            PlayAnimMontage(ChangeWeaponMontage);
+        }
+    }
 }
 
 void ARSDunPlayerCharacter::SecondWeaponSlot(const FInputActionValue& value)
@@ -388,7 +406,25 @@ void ARSDunPlayerCharacter::SecondWeaponSlot(const FInputActionValue& value)
     // 추후에 해당 무기로 전환되는 기능 구현해야한다.
     RS_LOG_DEBUG("SecondWeaponSlot Activated");
 
-    WeaponComp->EquipWeaponToCharacter(EWeaponSlot::SecondWeaponSlot);
+    UAnimInstance* AnimInstance = GetMesh()->GetAnimInstance();
+    if (!AnimInstance)
+    {
+        return;
+    }
+
+    // 무기 교체 애니메이션을 재생 중이지 않으며, 스킵이 가능한 경우
+    if (!AnimInstance->Montage_IsPlaying(ChangeWeaponMontage) && TrySkipMontage())
+    {
+        // 타겟 슬롯을 변경
+        WeaponComp->SetChangeTargetSlot(EWeaponSlot::SecondWeaponSlot);
+
+        // 변경한 타겟 슬롯으로 무기 교체가 가능한지 확인
+        if (WeaponComp->CanChangeTargetSlot())
+        {
+            // 무기 교체 몽타주 재생
+            PlayAnimMontage(ChangeWeaponMontage);
+        }
+    }
 }
 
 void ARSDunPlayerCharacter::ToggleInventoryUI(const FInputActionValue& value)


### PR DESCRIPTION
무기 교체 애니메이션 시퀀스 및 몽타주 임포트

플레이어 캐릭터에 무기 교체 애니메이션 몽타주를 참조하도록 변수 추가

플레이어 캐릭터의 애님인스턴스 블루프린트에서 상속받은 인터페이스의 애니메이션 출력에 블렌드 타임 추가
플레이어 캐릭터의 애님인스턴스 블루프린트에서 로코모션 부분들에 애니메이션이 자연스러운 전환이 되도록 inertialization 추가

애니메이션 노티파이를 사용하여 몽타주 재생 중 특정 시점에 무기가 교체되도록 해주었습니다.
이때, 노티파이는 매개변수를 가질 수 없으므로, 무기 컴포넌트에 변경할 무기 슬롯에 대한 부분을 멤버변수로 저장해주어 해결했습니다.
기존 무기 변경 로직을 수정해주었습니다.