### PR TITLE
[Fix] 구르기가 되지 않아도 회전하는 문제 해결

### DIFF
--- a/Source/RogShop/Character/RSDunPlayerCharacter.cpp
+++ b/Source/RogShop/Character/RSDunPlayerCharacter.cpp
@@ -324,14 +324,6 @@ void ARSDunPlayerCharacter::Dodge(const FInputActionValue& value)
         }
     }
 
-    FVector LastInput = GetLastMovementInputVector();
-
-    if (!LastInput.IsNearlyZero())
-    {
-        FRotator DesiredRotation = LastInput.Rotation();
-        SetActorRotation(DesiredRotation);
-    }
-
     // 구르기 전 몬스터 HP바가 플레이어를 바라보도록 하기
     // 1. 모든 몬스터 HP 바 회전
     for (ARSDunMonsterCharacter* Monster : ARSDunMonsterCharacter::GetAllMonsters())
@@ -342,11 +334,17 @@ void ARSDunPlayerCharacter::Dodge(const FInputActionValue& value)
         }
     }
 
-    // TODO : TrySkipMontage을 호출하고 반환값이 true인 경우 구르기 실행
-
     if (TrySkipMontage())
     {
         PlayAnimMontage(DodgeMontage);
+    }
+
+    FVector LastInput = GetLastMovementInputVector();
+
+    if (!LastInput.IsNearlyZero())
+    {
+        FRotator DesiredRotation = LastInput.Rotation();
+        SetActorRotation(DesiredRotation);
     }
 }
 


### PR DESCRIPTION
구르기가 특정 조건에 의해 되지 못해도 캐릭터가 회전하는 문제가 있어서 수정했습니다.

캐릭터를 회전하는 로직이 애니메이션의 재생과 다른 조건식에 위치하여 문제가 됐었는데 이를 수정해주었습니다.