### PR TITLE
[Update] 강공격 및 콤보별 데미지 구현

### DIFF
--- a/Content/Assets/AdventurersKit/BodyA/Armor_01/SK_BodyA_Armor_01.uasset
+++ b/Content/Assets/AdventurersKit/BodyA/Armor_01/SK_BodyA_Armor_01.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:650e14475496eb0bd8292abf31ee034d2e8755b77353ad732339d5fee30d0259
+oid sha256:16653037871c4d2e0ae031cae4e70ababb007dad4f8a0d9c5f55f0b5d1739957
 size 53042

--- a/Content/Assets/Characters/Mannequins/Meshes/SK_Mannequin.uasset
+++ b/Content/Assets/Characters/Mannequins/Meshes/SK_Mannequin.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:980e88b67375de1aeb3ba3863abcbcb13e6a505b58c81f0014a519b13adb12b4
+oid sha256:b5343e76622ba96c7b058ca9d83a9891203cd15e2a46c6066d9bb80e897a31ed
 size 191526

--- a/Content/Assets/CombatMasterAnimBundle/Animations/HandsomeSwordAndShieldAnims/SwordAnimations/Attack/Anim_HSAS_Jump_Attack.uasset
+++ b/Content/Assets/CombatMasterAnimBundle/Animations/HandsomeSwordAndShieldAnims/SwordAnimations/Attack/Anim_HSAS_Jump_Attack.uasset
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bcb064169346e9c753c8bfd37b8ac3fe53c9d0e72e5a782eab03d43b00daa028
-size 790453

--- a/Content/Assets/CombatMasterAnimBundle/Animations/PowerfulSwordAnims/RM/Attack/NormalAttack/Anim_PS_NormalAttack_RM.uasset
+++ b/Content/Assets/CombatMasterAnimBundle/Animations/PowerfulSwordAnims/RM/Attack/NormalAttack/Anim_PS_NormalAttack_RM.uasset
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ba5cfef2d6c6d306726428205a0bfb84a87a8be3a294b81334788733db35a6d6
-size 827500

--- a/Content/Assets/PlayerAnimations/KnightBattleaxe/StrongAttack/Anim_Sword_Attack_Slash01_Root.uasset
+++ b/Content/Assets/PlayerAnimations/KnightBattleaxe/StrongAttack/Anim_Sword_Attack_Slash01_Root.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f04a27f596452dcea62d4cf57d180497e012c509f9bcce370ec14f67b92a8db2
-size 837182
+oid sha256:8eea175ccd963f9f71866f7b110d0d7eeae3130fa8bf7cde66e06338a5ef5732
+size 837185

--- a/Content/Assets/PlayerAnimations/KnightBattleaxe/StrongAttack/Anim_Sword_Attack_Slash01_Root_Montage.uasset
+++ b/Content/Assets/PlayerAnimations/KnightBattleaxe/StrongAttack/Anim_Sword_Attack_Slash01_Root_Montage.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e4bff19bead3a5b1bfb916ea74a4037f5f42981698a0ade300556b9f1cf6beb5
+size 9168

--- a/Content/Assets/PlayerAnimations/KnightGreatsword/StrongAttack/Upper_Swing.uasset
+++ b/Content/Assets/PlayerAnimations/KnightGreatsword/StrongAttack/Upper_Swing.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:939e91a6b0ff7d5326415b0cdcc0861a22cef9f9e079c9a02263f543e38b68d2
-size 790965
+oid sha256:f48803f8e5dededff52411b42cdbd7024ebf3c66fa0b599aeb2ffd867da021f2
+size 791121

--- a/Content/Assets/PlayerAnimations/KnightGreatsword/StrongAttack/Upper_Swing_Montage.uasset
+++ b/Content/Assets/PlayerAnimations/KnightGreatsword/StrongAttack/Upper_Swing_Montage.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9a0252e869503fbf7562e7a536dbfdc7139089516d95fb05b9c8b27eb4105f17
+size 9681

--- a/Content/Assets/PlayerAnimations/KnightHammer/StrongAttack/Anim_HSAS_Jump_Attack.uasset
+++ b/Content/Assets/PlayerAnimations/KnightHammer/StrongAttack/Anim_HSAS_Jump_Attack.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:69a92556b30ffcd3889a4fc8543321a7aed515116a9cd69afec832dbb0f8bb3f
+size 790349

--- a/Content/Assets/PlayerAnimations/KnightHammer/StrongAttack/Anim_HSAS_Jump_Attack_Montage.uasset
+++ b/Content/Assets/PlayerAnimations/KnightHammer/StrongAttack/Anim_HSAS_Jump_Attack_Montage.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:82f502c85da839e5d073f7ffe9c3b8ad662dee387c7c142f5ed0aa4175235d89
+size 9476

--- a/Content/Assets/PlayerAnimations/KnightHatchet/StrongAttack/Anim_HSAS_Slash_Combo.uasset
+++ b/Content/Assets/PlayerAnimations/KnightHatchet/StrongAttack/Anim_HSAS_Slash_Combo.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0edf28ea0321dedbf541c3e258013d41e62667697acadeeaa2b786ef773453be
-size 506274
+oid sha256:9bd7622ba84d8a98c4db11f8fa7656b62abc35449993f9b8f22fef5d9719a392
+size 506079

--- a/Content/Assets/PlayerAnimations/KnightHatchet/StrongAttack/Anim_HSAS_Slash_Combo_Montage.uasset
+++ b/Content/Assets/PlayerAnimations/KnightHatchet/StrongAttack/Anim_HSAS_Slash_Combo_Montage.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:76e6882117820c16a97140fba922337c99f15df38bc3037e4c8fe7244ec91f21
+size 9601

--- a/Content/Assets/PlayerAnimations/KnightMace/StrongAttack/Anim_PS_NormalAttack_RM.uasset
+++ b/Content/Assets/PlayerAnimations/KnightMace/StrongAttack/Anim_PS_NormalAttack_RM.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0e4e44772f8ecedce114aa768973ab981030514ba6a3cf449441fc3184d55b86
+size 902984

--- a/Content/Assets/PlayerAnimations/KnightMace/StrongAttack/Anim_PS_NormalAttack_RM_Montage.uasset
+++ b/Content/Assets/PlayerAnimations/KnightMace/StrongAttack/Anim_PS_NormalAttack_RM_Montage.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:95f33e43e4b8122ecb21f6398b5c42f860d18c82274a28fe5bbf08089d3f3df6
+size 8563

--- a/Content/Assets/PlayerAnimations/KnightSword/StrongAttack/Anim_CS3_Attack_JumpAttack_RM.uasset
+++ b/Content/Assets/PlayerAnimations/KnightSword/StrongAttack/Anim_CS3_Attack_JumpAttack_RM.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3e0c1d7882d5fb603f44b6f6c81ab42ad328f50f0b47c32ea55b530b15b99af8
-size 1381718
+oid sha256:61c955648b15101a0bfc4224383758bbb4b1c6b5072f3d9acbafa900047438f3
+size 1381752

--- a/Content/Assets/PlayerAnimations/KnightSword/StrongAttack/Anim_CS3_Attack_JumpAttack_RM_Montage.uasset
+++ b/Content/Assets/PlayerAnimations/KnightSword/StrongAttack/Anim_CS3_Attack_JumpAttack_RM_Montage.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b926889b520e2f4131fb536329beffc1438b415ec903956e65d2a4f9ddd10f2c
+oid sha256:2fe7839997e689aa9ed2fef10f7727849e012255adc0d9b3640aa4bcf624c9dc
 size 12719

--- a/Content/Blueprints/AL_Blueprints.uasset
+++ b/Content/Blueprints/AL_Blueprints.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c96f3640251cbdcbc2fbee650fb3152a95f3c8f3aee9f8aa54d960b239f1020d
-size 66824
+oid sha256:02feba204944df2060fa7d267a67c5991f839bd7dd668e5ebd5476b753d83d45
+size 67582

--- a/Content/Blueprints/Actor/Dungeon/Weapon/BP_BlackSwordWeapon.uasset
+++ b/Content/Blueprints/Actor/Dungeon/Weapon/BP_BlackSwordWeapon.uasset
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:57b347a0a1b7736ac9b4520bba3f0472784f057903854e664840eee9b2783e9d
-size 28854

--- a/Content/Blueprints/Actor/Dungeon/Weapon/BP_KnightSword.uasset
+++ b/Content/Blueprints/Actor/Dungeon/Weapon/BP_KnightSword.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3aca5a9249bd90868989a8209f1fe17374cc83960f180c559c047ccd1143733b
+size 28287

--- a/Content/Datas/DungeonWeaponDataTable.uasset
+++ b/Content/Datas/DungeonWeaponDataTable.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:18b80f4bfbbf7e7427d59ad84c940fa83a39bd8a9e0be1ca472410101ace69e5
-size 9978
+oid sha256:1e51bb37efec7bde692bb07389b9033766e1acce8764a230144ea02068b5fd17
+size 9901

--- a/Content/Datas/WeaponDetailDataTable.uasset
+++ b/Content/Datas/WeaponDetailDataTable.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8d02559f110c7d3766f0d2f6d622b6208bbfb3ab13cdff4d31bc75ebb3b9ba40
-size 5066
+oid sha256:d87ab6f9adff88720479f65094d0d42b3ac3ce530f23bbf535d4d45546d5d082
+size 10121

--- a/Source/RogShop/Actor/Dungeon/GroundItem/RSDungeonGroundWeapon.cpp
+++ b/Source/RogShop/Actor/Dungeon/GroundItem/RSDungeonGroundWeapon.cpp
@@ -7,6 +7,8 @@
 #include "RSBaseWeapon.h"
 #include "RSDunPlayerCharacter.h"
 #include "RSPlayerWeaponComponent.h"
+#include "RSDataSubsystem.h"
+#include "ItemInfoData.h"
 
 ARSDungeonGroundWeapon::ARSDungeonGroundWeapon()
 {
@@ -20,6 +22,24 @@ void ARSDungeonGroundWeapon::Interact(ARSDunPlayerCharacter* Interactor)
 		return;
 	}
 
+	UGameInstance* CurGameInstance = Interactor->GetGameInstance();
+	if (!CurGameInstance)
+	{
+		return;
+	}
+
+	URSDataSubsystem* DataSubsystem = CurGameInstance->GetSubsystem<URSDataSubsystem>();
+	if (!DataSubsystem)
+	{
+		return;
+	}
+
+	UDataTable* WeaponDetailDataTable = DataSubsystem->WeaponDetail;
+	if (!WeaponDetailDataTable)
+	{
+		return;
+	}
+
 	FActorSpawnParameters SpawnParameters;
 	SpawnParameters.Owner = Interactor;
 	SpawnParameters.Instigator = Interactor;
@@ -29,6 +49,11 @@ void ARSDungeonGroundWeapon::Interact(ARSDunPlayerCharacter* Interactor)
 	URSPlayerWeaponComponent* RSPlayerWeaponComponent = Interactor->GetRSPlayerWeaponComponent();
 	if (SpawnWeapon && RSPlayerWeaponComponent)
 	{
+		FDungeonWeaponData* WeaponData = WeaponDetailDataTable->FindRow<FDungeonWeaponData>(DataTableKey, TEXT("Get WeaponData"));
+
+		SpawnWeapon->SetNormalAttackDatas(WeaponData->NormalAttackData);
+		SpawnWeapon->SetStrongAttackDatas(WeaponData->StrongAttackData);
+
 		SpawnWeapon->SetDataTableKey(DataTableKey);
 		RSPlayerWeaponComponent->EquipWeaponToSlot(SpawnWeapon);
 

--- a/Source/RogShop/Actor/Dungeon/Weapon/RSBaseWeapon.cpp
+++ b/Source/RogShop/Actor/Dungeon/Weapon/RSBaseWeapon.cpp
@@ -4,6 +4,7 @@
 #include "RSBaseWeapon.h"
 #include "GameFramework/Character.h"
 #include "Components/BoxComponent.h"
+#include "WeaponAttackData.h"
 
 // Sets default values
 ARSBaseWeapon::ARSBaseWeapon()
@@ -45,19 +46,58 @@ TSubclassOf<UAnimInstance> ARSBaseWeapon::GetWeaponAnimInstnace() const
 	return WeaponAnimInstnace;
 }
 
-UAnimMontage* ARSBaseWeapon::GetNormalAttack(int32 Index) const
+UAnimMontage* ARSBaseWeapon::GetNormalAttackMontage(int32 Index) const
 {
-	if (NormalAttacks.Num() > Index)
+	if (NormalAttackDatas.Num() > Index)
 	{
-		return NormalAttacks[Index];
+		return NormalAttackDatas[Index].AttackMontage;
 	}
 
 	return nullptr;
 }
 
-const TArray<UAnimMontage*>& ARSBaseWeapon::GetNormalAttacks() const
+const TArray<UAnimMontage*> ARSBaseWeapon::GetNormalAttackMontages() const
 {
-	return NormalAttacks;
+	TArray<UAnimMontage*> NormalAttackMontages;
+
+	for (const auto& e : NormalAttackDatas)
+	{
+		NormalAttackMontages.Add(e.AttackMontage);
+	}
+
+	return NormalAttackMontages;
+}
+
+void ARSBaseWeapon::SetNormalAttackDatas(TArray<FWeaponAttackData> NewNormalAttackDatas)
+{
+	NormalAttackDatas = NewNormalAttackDatas;
+}
+
+UAnimMontage* ARSBaseWeapon::GetStrongAttackMontage(int32 Index) const
+{
+	if (StrongAttackDatas.Num() > Index)
+	{
+		return StrongAttackDatas[Index].AttackMontage;
+	}
+
+	return nullptr;
+}
+
+const TArray<UAnimMontage*> ARSBaseWeapon::GetStrongAttackMontages() const
+{
+	TArray<UAnimMontage*> StrongAttackMontages;
+
+	for (const auto& e : StrongAttackDatas)
+	{
+		StrongAttackMontages.Add(e.AttackMontage);
+	}
+
+	return StrongAttackMontages;
+}
+
+void ARSBaseWeapon::SetStrongAttackDatas(TArray<FWeaponAttackData> NewStrongAttackDatas)
+{
+	StrongAttackDatas = NewStrongAttackDatas;
 }
 
 void ARSBaseWeapon::StartOverlap()

--- a/Source/RogShop/Actor/Dungeon/Weapon/RSBaseWeapon.cpp
+++ b/Source/RogShop/Actor/Dungeon/Weapon/RSBaseWeapon.cpp
@@ -120,9 +120,24 @@ void ARSBaseWeapon::EndOverlap()
 	BoxComp->SetGenerateOverlapEvents(false);
 }
 
-float ARSBaseWeapon::GetWeaponDamage() const
+float ARSBaseWeapon::GetNormalAttackMontageDamage(int32 MontageIndex) const
 {
-	return WeaponDamage;
+	if (NormalAttackDatas.IsValidIndex(MontageIndex))
+	{
+		return NormalAttackDatas[MontageIndex].WeaponDamage;
+	}
+
+	return 0.f;
+}
+
+float ARSBaseWeapon::GetStrongAttackMontageDamage(int32 MontageIndex) const
+{
+	if (StrongAttackDatas.IsValidIndex(MontageIndex))
+	{
+		return StrongAttackDatas[MontageIndex].WeaponDamage;
+	}
+
+	return 0.0f;
 }
 
 FName ARSBaseWeapon::GetDataTableKey() const

--- a/Source/RogShop/Actor/Dungeon/Weapon/RSBaseWeapon.h
+++ b/Source/RogShop/Actor/Dungeon/Weapon/RSBaseWeapon.h
@@ -70,11 +70,9 @@ public:
 	// 트레이스 채널을 사용하기 때문에 더이상 사용하지 않는 기능
 	void EndOverlap();
 
-	float GetWeaponDamage() const;
+	float GetNormalAttackMontageDamage(int32 MontageIndex) const;
 
-private:
-	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Status", meta = (AllowPrivateAccess = "true"))
-	float WeaponDamage;	// 오버랩 시 가할 무기 데미지
+	float GetStrongAttackMontageDamage(int32 MontageIndex) const;
 
 // 데이터 테이블의 RowName을 ID값으로 사용한다.
 public:

--- a/Source/RogShop/Actor/Dungeon/Weapon/RSBaseWeapon.h
+++ b/Source/RogShop/Actor/Dungeon/Weapon/RSBaseWeapon.h
@@ -9,6 +9,8 @@
 
 class UBoxComponent;
 
+struct FWeaponAttackData;
+
 UCLASS()
 class ROGSHOP_API ARSBaseWeapon : public ARSDungeonItemBase
 {
@@ -27,27 +29,39 @@ public:
 	UBoxComponent* GetBoxComp() const;
 
 private:
-	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Component", meta = (AllowPrivateAccess = true))
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Component", meta = (AllowPrivateAccess = "true"))
 	TObjectPtr<USceneComponent> SceneComp;
-	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Component", meta = (AllowPrivateAccess = true))
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Component", meta = (AllowPrivateAccess = "true"))
 	TObjectPtr<USkeletalMeshComponent> MeshComp;
-	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Component", meta = (AllowPrivateAccess = true))
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Component", meta = (AllowPrivateAccess = "true"))
 	TObjectPtr<UBoxComponent> BoxComp;	// 데미지 로직을 위한 콜리전 용도의 컴포넌트
 
 // 애니메이션
 public:
 	TSubclassOf<UAnimInstance> GetWeaponAnimInstnace() const;
-	UAnimMontage* GetNormalAttack(int32 Index) const;
-	const TArray<UAnimMontage*>& GetNormalAttacks() const;
+	
+	UAnimMontage* GetNormalAttackMontage(int32 Index) const;
+
+	const TArray<UAnimMontage*> GetNormalAttackMontages() const;
+
+	void SetNormalAttackDatas(TArray<FWeaponAttackData> NewNormalAttackDatas);
+
+	UAnimMontage* GetStrongAttackMontage(int32 Index) const;
+
+	const TArray<UAnimMontage*> GetStrongAttackMontages() const;
+
+	void SetStrongAttackDatas(TArray<FWeaponAttackData> NewStrongAttackDatas);
 		
 private:
-	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Anim", meta = (AllowPrivateAccess = true))
+	// 애니메이션들을 캐싱한다.
+	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Anim", meta = (AllowPrivateAccess = "true"))
 	TSubclassOf<UAnimInstance> WeaponAnimInstnace; // 무기의 기본 이동 애님 인스턴스
 
-	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Anim", meta = (AllowPrivateAccess = true))
-	TArray<TObjectPtr<UAnimMontage>> NormalAttacks; // 무기의 기본 공격 몽타주
-	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Anim", meta = (AllowPrivateAccess = true))
-	TArray<TObjectPtr<UAnimMontage>> StrongAttacks; // 무기의 강 공격 몽타주
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Anim", meta = (AllowPrivateAccess = "true"))
+	TArray<FWeaponAttackData> NormalAttackDatas; // 무기의 기본 공격 몽타주
+
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Anim", meta = (AllowPrivateAccess = "true"))
+	TArray<FWeaponAttackData> StrongAttackDatas; // 무기의 강 공격 몽타주
 
 // 충돌
 public:
@@ -59,7 +73,7 @@ public:
 	float GetWeaponDamage() const;
 
 private:
-	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Status", meta = (AllowPrivateAccess = true))
+	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Status", meta = (AllowPrivateAccess = "true"))
 	float WeaponDamage;	// 오버랩 시 가할 무기 데미지
 
 // 데이터 테이블의 RowName을 ID값으로 사용한다.
@@ -68,6 +82,6 @@ public:
 	void SetDataTableKey(FName NewDataTableKey);
 
 private:
-	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Info", meta = (AllowPrivateAccess = true))
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Info", meta = (AllowPrivateAccess = "true"))
 	FName DataTableKey;
 };

--- a/Source/RogShop/ActorComponent/RSPlayerWeaponComponent.cpp
+++ b/Source/RogShop/ActorComponent/RSPlayerWeaponComponent.cpp
@@ -485,7 +485,7 @@ void URSPlayerWeaponComponent::PerformBoxSweepAttack()
 	{
 		AController* OwnerController = OwnerCharacter->GetInstigatorController();
 
-		if (WeaponActors.IsValidIndex(Index))
+		if (WeaponActors.IsValidIndex(Index) && WeaponActors[Index] != nullptr)
 		{
 			ARSBaseWeapon* CurWeapon = WeaponActors[Index];
 
@@ -522,7 +522,20 @@ void URSPlayerWeaponComponent::PerformBoxSweepAttack()
 							// 총 데미지를 구합니다.
 							float TotalDamage = 0.f;
 
-							float WeaponDamage = WeaponActors[Index]->GetWeaponDamage();
+							// 무기 공격력
+							float WeaponDamage = 0.f;
+
+							// 일반 공격
+							if (AttackType == EAttackType::NormalAttack)
+							{
+								WeaponDamage = WeaponActors[Index]->GetNormalAttackMontageDamage(Index);
+							}
+							// 강 공격
+							else if (AttackType == EAttackType::StrongAttack)
+							{
+								WeaponDamage = WeaponActors[Index]->GetStrongAttackMontageDamage(Index);
+							}
+
 							float AttackPower = OwnerCharacter->GetAttackPower();
 							TotalDamage = WeaponDamage + AttackPower;
 

--- a/Source/RogShop/ActorComponent/RSPlayerWeaponComponent.h
+++ b/Source/RogShop/ActorComponent/RSPlayerWeaponComponent.h
@@ -17,6 +17,14 @@ enum class EWeaponSlot : uint8
 	SecondWeaponSlot,
 };
 
+UENUM(BlueprintType)
+enum class EAttackType : uint8
+{
+	NONE,
+	NormalAttack,
+	StrongAttack,
+};
+
 UCLASS( ClassGroup=(Custom), meta=(BlueprintSpawnableComponent) )
 class ROGSHOP_API URSPlayerWeaponComponent : public UActorComponent
 {
@@ -65,7 +73,7 @@ private:
 
 // 공격 관련
 public:
-	void HandleNormalAttackInput();
+	void HandleAttackInput(EAttackType TargetAttackType);
 
 	bool ContinueComboAttack();
 
@@ -73,13 +81,16 @@ public:
 
 private:
 	// 애니메이션을 위한 상태
-	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Weapon", meta = (AllowPrivateAccess = true))
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Weapon", meta = (AllowPrivateAccess = "true"))
+	EAttackType AttackType;	// 현재 공격 종류
+
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Weapon", meta = (AllowPrivateAccess = "true"))
 	bool bIsAttack;	// 공격 중인 상태
 
-	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Weapon", meta = (AllowPrivateAccess = true))
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Weapon", meta = (AllowPrivateAccess = "true"))
 	bool bComboInputBuffered;	// 공격 중일 때 들어온 입력 버퍼
 
-	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Weapon", meta = (AllowPrivateAccess = true))
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Weapon", meta = (AllowPrivateAccess = "true"))
 	int32 ComboIndex;	// 콤보 공격을 위한 인덱스 값
 
 // 충돌 로직 관리

--- a/Source/RogShop/Character/RSDunPlayerCharacter.cpp
+++ b/Source/RogShop/Character/RSDunPlayerCharacter.cpp
@@ -370,14 +370,16 @@ void ARSDunPlayerCharacter::NormalAttack(const FInputActionValue& value)
 {
     if (WeaponComp)
     {
-        WeaponComp->HandleNormalAttackInput();
+        WeaponComp->HandleAttackInput(EAttackType::NormalAttack);
     }
 }
 
 void ARSDunPlayerCharacter::StrongAttack(const FInputActionValue& value)
 {
-    // 애니메이션이 아직 준비되지 않았으므로 디버깅용 출력
-    RS_LOG_DEBUG("StrongAttack Activated");
+    if (WeaponComp)
+    {
+        WeaponComp->HandleAttackInput(EAttackType::StrongAttack);
+    }
 }
 
 void ARSDunPlayerCharacter::FirstWeaponSlot(const FInputActionValue& value)

--- a/Source/RogShop/DataTable/ItemInfoData.h
+++ b/Source/RogShop/DataTable/ItemInfoData.h
@@ -5,6 +5,7 @@
 #include "CoreMinimal.h"
 #include "Engine/DataTable.h"
 #include "RSDungeonItemBase.h"
+#include "WeaponAttackData.h"
 #include "ItemInfoData.generated.h"
 
 class URSBaseRelic;
@@ -66,6 +67,12 @@ struct ROGSHOP_API FDungeonWeaponData : public FTableRowBase
 public:
 	UPROPERTY(EditAnywhere, BlueprintReadWrite)
 	TSubclassOf<ARSDungeonItemBase> WeaponClass;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	TArray<FWeaponAttackData> NormalAttackData;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	TArray<FWeaponAttackData> StrongAttackData;
 };
 
 USTRUCT(BlueprintType)

--- a/Source/RogShop/Struct/WeaponAttackData.cpp
+++ b/Source/RogShop/Struct/WeaponAttackData.cpp
@@ -1,0 +1,4 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "WeaponAttackData.h"

--- a/Source/RogShop/Struct/WeaponAttackData.h
+++ b/Source/RogShop/Struct/WeaponAttackData.h
@@ -1,0 +1,19 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "WeaponAttackData.generated.h"
+
+USTRUCT(BlueprintType)
+struct ROGSHOP_API FWeaponAttackData
+{
+	GENERATED_BODY()
+
+public:
+	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	TObjectPtr<UAnimMontage> AttackMontage;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	float WeaponDamage;
+};

--- a/Source/RogShop/Widget/DunShop/RSDunItemWidget.cpp
+++ b/Source/RogShop/Widget/DunShop/RSDunItemWidget.cpp
@@ -141,6 +141,9 @@ bool URSDunItemWidget::BuyItem()
 
             if (SpawnedWeapon && WeaponComp)
             {
+                SpawnedWeapon->SetNormalAttackDatas(WeaponClassData->NormalAttackData);
+                SpawnedWeapon->SetStrongAttackDatas(WeaponClassData->StrongAttackData);
+
                 SpawnedWeapon->SetDataTableKey(CurrentRowName);
                 WeaponComp->EquipWeaponToSlot(SpawnedWeapon);
             }


### PR DESCRIPTION
강공격을 위한 몽타주를 일부 생성했습니다.

무기를 어태치하는 소켓의 회전 및 로케이션을 조금 수정했습니다.

몽타주와 데미지를 저장하는 구조체를 생성해주었습니다.
해당 구조체를 데이터 테이블과 무기 액터에서 가지도록 해주었습니다.

기존 단순 몽타주를 배열로 가지고 있었는데 구조체로 변경해주었으므로, 기존 로직을 수정해주었습니다.

기존에 기본 공격만 가능하던 로직에서 강 공격또한 가능하도록 로직을 수정해주었습니다.

플레이어 캐릭터에서 강공격 입력시 공격 함수를 호출하도록 변경했습니다.