### PR TITLE
[Update] 카타나 공격 이펙트 혈흔 제거

### DIFF
--- a/Content/Assets/SlashHitVFX/NS/NS_Hit_Katana.uasset
+++ b/Content/Assets/SlashHitVFX/NS/NS_Hit_Katana.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dbdf270bef5d8d0e6bc1451c59ef9bdeb94f193759855580b335cae34e451e18
+size 3048321


### PR DESCRIPTION
기존 NS_Hit_KatanaBlood 이펙트를 복제하고 혈흔효과를 제외하였습니다.