### PR TITLE
[Update] 마지막 스테이지 클리어시 거점으로 이동되도록 변경

### DIFF
--- a/Source/RogShop/Actor/Dungeon/RSDunNextStagePortal.cpp
+++ b/Source/RogShop/Actor/Dungeon/RSDunNextStagePortal.cpp
@@ -7,6 +7,7 @@
 #include "GameFramework/PlayerController.h"
 #include "RSSendIngredientWidget.h"
 #include "RSDungeonIngredientInventoryComponent.h"
+#include "RSDungeonGameModeBase.h"
 
 ARSDunNextStagePortal::ARSDunNextStagePortal()
 {
@@ -27,6 +28,17 @@ void ARSDunNextStagePortal::BeginPlay()
 {
 	Super::BeginPlay();
 	
+	ARSDungeonGameModeBase* DungeonGameMode = GetWorld()->GetAuthGameMode<ARSDungeonGameModeBase>();
+	if (DungeonGameMode)
+	{
+		// 마지막 스테이지인 경우
+		int32 MaxStageCount = DungeonGameMode->GetMaxStageCount();
+		int32 LevelIndex = DungeonGameMode->GetLevelIndex();
+		if ((MaxStageCount - 1) == LevelIndex)
+		{
+			InteractName = FText::FromString(TEXT("거점으로"));
+		}
+	}
 }
 
 void ARSDunNextStagePortal::Interact(ARSDunPlayerCharacter* Interactor)
@@ -53,7 +65,15 @@ void ARSDunNextStagePortal::Interact(ARSDunPlayerCharacter* Interactor)
 
 		const TArray<FItemSlot>& IngredientItems = IngredientInventoryComp->GetItems();
 
-		SendIngredientWidgetInstance->CreateSendIngredientSlots(2);
+		ARSDungeonGameModeBase* DungeonGameMode = GetWorld()->GetAuthGameMode<ARSDungeonGameModeBase>();
+		if (DungeonGameMode)
+		{
+			// 보스 잡은 횟수 + 1개의 슬롯을 적용한다.
+			int32 LevelIndex = DungeonGameMode->GetLevelIndex();
+
+			SendIngredientWidgetInstance->CreateSendIngredientSlots(LevelIndex + 1);
+		}
+
 		SendIngredientWidgetInstance->CreatePlayerIngredientSlots(IngredientItems);
 		SendIngredientWidgetInstance->AddToViewport();
 

--- a/Source/RogShop/Actor/MapGenerator/RSSpawnManager.cpp
+++ b/Source/RogShop/Actor/MapGenerator/RSSpawnManager.cpp
@@ -24,10 +24,10 @@
 #include "RSDungeonGroundLifeEssence.h"
 
 // 외부에서 전달받은 월드 및 테이블 초기화
-void URSSpawnManager::Initialize(UWorld* InWorld, UGameInstance* GameInstance,int32 TileIndex)
+void URSSpawnManager::Initialize(UWorld* InWorld, UGameInstance* GameInstance, int32 TargetLevelIndex)
 {
 	World = InWorld;
-	LevelIndex = TileIndex;
+	LevelIndex = TargetLevelIndex;
 
 	if (!GameInstance) return;
 

--- a/Source/RogShop/Actor/MapGenerator/RSSpawnManager.h
+++ b/Source/RogShop/Actor/MapGenerator/RSSpawnManager.h
@@ -37,7 +37,7 @@ public:
 #pragma region 공개 함수
 
 	// 월드와 데이터테이블 초기화
-	void Initialize(UWorld* InWorld, UGameInstance* GameInstance,int32 TileIndex);
+	void Initialize(UWorld* InWorld, UGameInstance* GameInstance,int32 TargetLevelIndex);
 
 	// 몬스터들을 타겟포인트 위치에 스폰
 	void SpawnMonstersInLevel();

--- a/Source/RogShop/GameModeBase/RSDungeonGameModeBase.cpp
+++ b/Source/RogShop/GameModeBase/RSDungeonGameModeBase.cpp
@@ -17,6 +17,7 @@
 
 ARSDungeonGameModeBase::ARSDungeonGameModeBase()
 {
+    MaxStageCount = 3;
 }
 
 
@@ -70,7 +71,7 @@ void ARSDungeonGameModeBase::SpawnMap()// 선택된 맵 타입에 따라 맵 생
         return;
     }
 
-    FDungeonLevelData* Level = AllGroups[TileIndex];
+    FDungeonLevelData* Level = AllGroups[LevelIndex];
 
     FActorSpawnParameters SpawnParams;
     SpawnParams.SpawnCollisionHandlingOverride = ESpawnActorCollisionHandlingMethod::AlwaysSpawn; //무슨일이 있어도 스폰// 충돌 무시하고 항상 스폰하도록 설정
@@ -100,14 +101,19 @@ void ARSDungeonGameModeBase::InitRandSeed()
     Seed = FMath::RandRange(1, INT32_MAX);
 }
 
-int32 ARSDungeonGameModeBase::GetTileIndex() const
+int32 ARSDungeonGameModeBase::GetLevelIndex() const
 {
-    return TileIndex;
+    return LevelIndex;
 }
 
-void ARSDungeonGameModeBase::IncrementAtTileIndex()
+void ARSDungeonGameModeBase::IncrementAtLevelIndex()
 {
-    TileIndex += 1;
+    LevelIndex += 1;
+}
+
+int32 ARSDungeonGameModeBase::GetMaxStageCount() const
+{
+    return MaxStageCount;
 }
 
 void ARSDungeonGameModeBase::SaveDungeonInfo()
@@ -120,7 +126,7 @@ void ARSDungeonGameModeBase::SaveDungeonInfo()
     }
 
     // 세이브
-    DungeonStageSaveGame->TileIndex = TileIndex;
+    DungeonStageSaveGame->LevelIndex = LevelIndex;
     DungeonStageSaveGame->Seed = Seed;
 
     // 저장
@@ -157,7 +163,7 @@ void ARSDungeonGameModeBase::LoadDungeonInfo()
     URSDungeonStageSaveGame* DungeonInfoLoadGame = Cast<URSDungeonStageSaveGame>(UGameplayStatics::LoadGameFromSlot(SaveGameSubsystem->DungeonInfoSaveSlotName, 0));
     if (DungeonInfoLoadGame)
     {
-        TileIndex = DungeonInfoLoadGame->TileIndex;
+        LevelIndex = DungeonInfoLoadGame->LevelIndex;
         Seed = DungeonInfoLoadGame->Seed;
     }
 
@@ -187,7 +193,7 @@ void ARSDungeonGameModeBase::OnMapReady()// 맵 로딩이 완료되었을 때 �
         {
             RS_LOG_DEBUG("스폰 매니저 생성");
             GameMode->SpawnManager = NewObject<URSSpawnManager>(GameMode, GameMode->SpawnManagerClass);
-            GameMode->SpawnManager->Initialize(GameMode->GetWorld(), GameMode->GetGameInstance(), GameMode->TileIndex);
+            GameMode->SpawnManager->Initialize(GameMode->GetWorld(), GameMode->GetGameInstance(), GameMode->LevelIndex);
         
             GameMode->SpawnManager->SpawnPlayerAtStartPoint();
             GameMode->SpawnManager->SpawnMonstersInLevel();

--- a/Source/RogShop/GameModeBase/RSDungeonGameModeBase.h
+++ b/Source/RogShop/GameModeBase/RSDungeonGameModeBase.h
@@ -69,15 +69,20 @@ public:
 	int32 GetSeed() const;
 	void InitRandSeed();
 
-	int32 GetTileIndex() const;
-	void IncrementAtTileIndex();
+	int32 GetLevelIndex() const;
+	void IncrementAtLevelIndex();
+
+	int32 GetMaxStageCount() const;
 
 private:
 	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Dungeon Info", meta = (AllowPrivateAccess = "true"))
 	int32 Seed;	// 해당 값을 기준으로 맵 생성
 
 	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Dungeon Info", meta = (AllowPrivateAccess = "true"))
-	int32 TileIndex;
+	int32 LevelIndex;
+
+	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Dungeon Info", meta = (AllowPrivateAccess = "true"))
+	int32 MaxStageCount;
 #pragma endregion
 
 

--- a/Source/RogShop/SaveGame/Dungeon/RSDungeonStageSaveGame.h
+++ b/Source/RogShop/SaveGame/Dungeon/RSDungeonStageSaveGame.h
@@ -16,7 +16,7 @@ class ROGSHOP_API URSDungeonStageSaveGame : public USaveGame
 	
 public:
 	UPROPERTY(EditAnywhere, BlueprintReadWrite)
-	int32 TileIndex;
+	int32 LevelIndex;
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite)
 	int32 Seed;

--- a/Source/RogShop/Widget/Dungeon/RSSendIngredientWidget.cpp
+++ b/Source/RogShop/Widget/Dungeon/RSSendIngredientWidget.cpp
@@ -90,18 +90,31 @@ void URSSendIngredientWidget::NextStageTravel()
 	{
 		return;
 	}
-	DungeonGameMode->IncrementAtTileIndex();
+	DungeonGameMode->IncrementAtLevelIndex();
 	DungeonGameMode->InitRandSeed();
-
-	// 데이터 세이브 이벤트 호출
-	SaveGameSubsystem->OnSaveRequested.Broadcast();
 
 	// 다음 스테이지로 레벨 이동
 	URSLevelSubsystem* LevelSubsystem = RSGameInstance->GetSubsystem<URSLevelSubsystem>();
 
 	if (LevelSubsystem)
 	{
-		LevelSubsystem->TravelToLevel(ERSLevelCategory::Dungeon);
+		// 모든 스테이지를 클리어 한 경우
+		int32 MaxStageCount = DungeonGameMode->GetMaxStageCount();
+		int32 LevelIndex = DungeonGameMode->GetLevelIndex();
+		if (MaxStageCount == LevelIndex)
+		{
+			SaveGameSubsystem->DeleteDungeonSaveFile();
+
+			LevelSubsystem->TravelToLevel(ERSLevelCategory::BaseArea);
+		}
+		// 남은 스테이지가 있는 경우
+		else
+		{
+			// 데이터 세이브 이벤트 호출
+			SaveGameSubsystem->OnSaveRequested.Broadcast();
+
+			LevelSubsystem->TravelToLevel(ERSLevelCategory::Dungeon);
+		}
 	}
 }
 


### PR DESCRIPTION
위젯에서 스테이지를 이동하기 전에 현재 스테이지가 마지막 스테이지인지 확인하고, 마지막 스테이지인 경우 거점으로 이동되도록 변경해주었습니다.
거점으로 이동할 경우 던전에 대한 세이브파일이 제거되도록 해주었습니다.

보스를 잡고 스폰되는 재료 보내기 및 스테이지 이동 액터가 마지막 스테이지에서 스폰된 경우 상호작용 이름이 "거점으로"가 되도록 수정했습니다.

스테이지별로 보스를 잡고 타이쿤으로 보낼 수 있는 재료의 수를 변경해주었습니다.

