### PR TITLE
[Add] 플레이어 데미지 받을 시 해당 수치 애니메이션으로 왼쪽 상단에 출력될 수 있도록 구현

### DIFF
--- a/Content/Blueprints/Widgets/Dungeon/WBP_PlayerFloatingDamageWidget.uasset
+++ b/Content/Blueprints/Widgets/Dungeon/WBP_PlayerFloatingDamageWidget.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:39a47e8897b5a26b17d72bfb704afed4339c5f111fdc4454c71fac6dfed1f3e6
+size 49544

--- a/Content/Blueprints/Widgets/Dungeon/WBP_PlayerStatusWidget.uasset
+++ b/Content/Blueprints/Widgets/Dungeon/WBP_PlayerStatusWidget.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:43926d9b772e11291ad91b53f3cbbb2bf3d953e0ec3f03cba7f09519e812e736
-size 38166
+oid sha256:fc03e561008794fd03373373a9035d706029a16546d7a40e9324cab3b5d18be9
+size 39374

--- a/Source/RogShop/Character/RSDunPlayerCharacter.cpp
+++ b/Source/RogShop/Character/RSDunPlayerCharacter.cpp
@@ -274,6 +274,7 @@ void ARSDunPlayerCharacter::DecreaseHP(float Amount)
     if (PC)
     {
         PC->OnHPChange.Broadcast();
+        PC->OnFloatDamage.Broadcast(Amount);
     }
 }
 

--- a/Source/RogShop/Controller/RSDunPlayerController.h
+++ b/Source/RogShop/Controller/RSDunPlayerController.h
@@ -15,9 +15,12 @@ class ARSDunBaseCharacter;
 
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_TwoParams(FOnWeaponSlotChange, int8, WeaponSlotIndex, FName, WeaponKey);
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_TwoParams(FOnIngredientChange, int32, IngredientSlotIndex, FItemSlot, IngredientItemSlot);
+
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnInteractableFound, FText, InteractName);
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnRelicAdded, FName, RelicKey);
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnLifeEssenceChange, int32, NewLifeEssence);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnFloatDamage, float, DamageAmount);
+
 DECLARE_DYNAMIC_MULTICAST_DELEGATE(FOnHPChange);
 DECLARE_DYNAMIC_MULTICAST_DELEGATE(FOnMaxHPChange);
 
@@ -125,4 +128,7 @@ public:
 
 	UPROPERTY(BlueprintAssignable)
 	FOnMaxHPChange OnMaxHPChange;
+
+	UPROPERTY(BlueprintAssignable)
+	FOnFloatDamage OnFloatDamage;
 };

--- a/Source/RogShop/Widget/Dungeon/RSPlayerFloatingDamageWidget.cpp
+++ b/Source/RogShop/Widget/Dungeon/RSPlayerFloatingDamageWidget.cpp
@@ -1,0 +1,60 @@
+#include "RSPlayerFloatingDamageWidget.h"
+#include "Components/TextBlock.h"
+#include "RSDunPlayerController.h"
+
+void URSPlayerFloatingDamageWidget::NativeOnInitialized()
+{
+    ARSDunPlayerController* RSDunPlayerController = GetOwningPlayer<ARSDunPlayerController>();
+
+    if (RSDunPlayerController)
+    {
+        RSDunPlayerController->OnFloatDamage.AddDynamic(this, &URSPlayerFloatingDamageWidget::ShowDamage);
+    }
+}
+
+void URSPlayerFloatingDamageWidget::NativeConstruct()
+{
+    Super::NativeConstruct();
+
+    // 텍스트는 기본 숨김 상태로 세팅
+    if (TextDamage)
+    {
+        TextDamage->SetVisibility(ESlateVisibility::Collapsed);
+    }
+}
+
+void URSPlayerFloatingDamageWidget::ShowDamage(float Damage)
+{
+    if (!TextDamage)
+    {
+        return;
+    }
+
+    TextDamage->SetText(FText::AsNumber(FMath::RoundToInt(Damage * -1)));
+    TextDamage->SetVisibility(ESlateVisibility::Visible);
+
+    // 페이드 아웃 애니메이션 재생 (기존 애니 재생 중이면 재시작)
+    if (FadeAnim)
+    {
+        PlayAnimation(FadeAnim);
+    }
+
+    // 1초 후에 숨기기
+    GetWorld()->GetTimerManager().ClearTimer(HideTextTimerHandle);
+    GetWorld()->GetTimerManager().SetTimer(
+        HideTextTimerHandle,
+        this,
+        &URSPlayerFloatingDamageWidget::OnFadeOutFinished,
+        1.0f,
+        false
+    );
+}
+
+void URSPlayerFloatingDamageWidget::OnFadeOutFinished()
+{
+    if (TextDamage)
+    {
+        TextDamage->SetVisibility(ESlateVisibility::Collapsed);
+        TextDamage->SetText(FText::GetEmpty());
+    }
+}

--- a/Source/RogShop/Widget/Dungeon/RSPlayerFloatingDamageWidget.h
+++ b/Source/RogShop/Widget/Dungeon/RSPlayerFloatingDamageWidget.h
@@ -1,0 +1,36 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Blueprint/UserWidget.h"
+#include "RSPlayerFloatingDamageWidget.generated.h"
+
+class UTextBlock;
+
+UCLASS()
+class ROGSHOP_API URSPlayerFloatingDamageWidget : public UUserWidget
+{
+    GENERATED_BODY()
+
+public:
+    UFUNCTION()
+    void ShowDamage(float Damage);
+
+protected:
+    virtual void NativeOnInitialized() override;
+    virtual void NativeConstruct() override;
+
+    UPROPERTY(meta = (BindWidget))
+    TObjectPtr<UTextBlock> TextDamage;
+
+    // 페이드 애니메이션
+    UPROPERTY(Transient, meta = (BindWidgetAnim))
+    TObjectPtr<UWidgetAnimation> FadeAnim;
+
+private:
+    UFUNCTION()
+    void OnFadeOutFinished();
+
+    FTimerHandle HideTextTimerHandle;
+};


### PR DESCRIPTION
- 플레이어 HP 변경시 UI에서 애니메이션으로 해당 변경 수치 정보를 출력할 수 있도록 구현
- DunPlayerController에 전용 델리게이트 하나 선언 후 해당 델리게이트 이용하여 HP 감소시 이벤트 전달
- 맞는 순간 왼쪽 상단에 맞은 데미지가 표시가 되고 1초 동안 텍스트가 위로 올라가면서 점점 사라지는 형태로 애니메이션 적용