### PR TITLE
[Update] 던전의 포탈 액터에 나이아가라 적용

### DIFF
--- a/Content/Blueprints/Actor/Dungeon/BP_BossRoomPortal.uasset
+++ b/Content/Blueprints/Actor/Dungeon/BP_BossRoomPortal.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:58c2d9f4da8f5b4edbec5ad30b190abce1db1a802032ce0b5651ae90b78d314e
-size 35019
+oid sha256:c8685d01926545b684a9859bc0b5b83384112497a7834f793a4dc559ac63691d
+size 38482

--- a/Content/Blueprints/Actor/Dungeon/BP_DunNextStagePortal.uasset
+++ b/Content/Blueprints/Actor/Dungeon/BP_DunNextStagePortal.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b671bbc0ba65efd2449016befc2bbb61fb494f7e3710ba21f738fc4ad4fd5dca
-size 38909
+oid sha256:c46e4fe01bf7610baa9d6ac2b55bf28498f82f4693eefc01f8c375df06a01b06
+size 43071

--- a/Source/RogShop/Actor/Dungeon/RSDunBossRoomPortal.cpp
+++ b/Source/RogShop/Actor/Dungeon/RSDunBossRoomPortal.cpp
@@ -2,6 +2,8 @@
 
 
 #include "RSDunBossRoomPortal.h"
+#include "Components/BoxComponent.h"
+#include "NiagaraComponent.h"
 #include "RSDunPlayerCharacter.h"
 
 ARSDunBossRoomPortal::ARSDunBossRoomPortal()
@@ -11,9 +13,12 @@ ARSDunBossRoomPortal::ARSDunBossRoomPortal()
 	SceneComp = CreateDefaultSubobject<USceneComponent>(TEXT("Scene"));
 	SetRootComponent(SceneComp);
 
-	MeshComp = CreateDefaultSubobject<UStaticMeshComponent>(TEXT("StaticMesh"));
-	MeshComp->SetupAttachment(SceneComp);
-	MeshComp->SetCollisionProfileName("Interactable");
+	NiagaraComp = CreateDefaultSubobject<UNiagaraComponent>(TEXT("Niagara"));
+	NiagaraComp->SetupAttachment(SceneComp);
+
+	BoxComp = CreateDefaultSubobject<UBoxComponent>(TEXT("Box"));
+	BoxComp->SetupAttachment(SceneComp);
+	BoxComp->SetCollisionProfileName("Interactable");
 
 	InteractName = FText::FromString(TEXT("보스 방으로"));
 	bIsAutoInteract = false;

--- a/Source/RogShop/Actor/Dungeon/RSDunBossRoomPortal.h
+++ b/Source/RogShop/Actor/Dungeon/RSDunBossRoomPortal.h
@@ -7,6 +7,9 @@
 #include "RSInteractable.h"
 #include "RSDunBossRoomPortal.generated.h"
 
+class UNiagaraComponent;
+class UBoxComponent;
+
 UCLASS()
 class ROGSHOP_API ARSDunBossRoomPortal : public AActor, public IRSInteractable
 {
@@ -43,8 +46,10 @@ private:
 
 // 컴포넌트
 private:
-	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Component", meta = (AllowPrivateAccess = true))
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Component", meta = (AllowPrivateAccess = "true"))
 	TObjectPtr<USceneComponent> SceneComp;
-	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Component", meta = (AllowPrivateAccess = true))
-	TObjectPtr<UStaticMeshComponent> MeshComp;
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Component", meta = (AllowPrivateAccess = "true"))
+	TObjectPtr<UNiagaraComponent> NiagaraComp;
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Component", meta = (AllowPrivateAccess = "true"))
+	TObjectPtr<UBoxComponent> BoxComp;	// 상호작용의 충돌체크를 위한 콜리전 용도의 컴포넌트
 };

--- a/Source/RogShop/Actor/Dungeon/RSDunNextStagePortal.cpp
+++ b/Source/RogShop/Actor/Dungeon/RSDunNextStagePortal.cpp
@@ -2,6 +2,8 @@
 
 
 #include "RSDunNextStagePortal.h"
+#include "Components/BoxComponent.h"
+#include "NiagaraComponent.h"
 #include "Blueprint/UserWidget.h"
 #include "RSDunPlayerCharacter.h"
 #include "GameFramework/PlayerController.h"
@@ -16,9 +18,12 @@ ARSDunNextStagePortal::ARSDunNextStagePortal()
 	SceneComp = CreateDefaultSubobject<USceneComponent>(TEXT("Scene"));
 	SetRootComponent(SceneComp);
 
-	MeshComp = CreateDefaultSubobject<UStaticMeshComponent>(TEXT("StaticMesh"));
-	MeshComp->SetupAttachment(SceneComp);
-	MeshComp->SetCollisionProfileName("Interactable");
+	NiagaraComp = CreateDefaultSubobject<UNiagaraComponent>(TEXT("Niagara"));
+	NiagaraComp->SetupAttachment(SceneComp);
+
+	BoxComp = CreateDefaultSubobject<UBoxComponent>(TEXT("Box"));
+	BoxComp->SetupAttachment(SceneComp);
+	BoxComp->SetCollisionProfileName("Interactable");
 
 	InteractName = FText::FromString(TEXT("다음 스테이지로"));
 	bIsAutoInteract = false;

--- a/Source/RogShop/Actor/Dungeon/RSDunNextStagePortal.h
+++ b/Source/RogShop/Actor/Dungeon/RSDunNextStagePortal.h
@@ -7,6 +7,8 @@
 #include "RSInteractable.h"
 #include "RSDunNextStagePortal.generated.h"
 
+class UNiagaraComponent;
+class UBoxComponent;
 class URSSendIngredientWidget;
 
 UCLASS()
@@ -22,10 +24,12 @@ protected:
 
 // 컴포넌트
 private:
-	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Component", meta = (AllowPrivateAccess = true))
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Component", meta = (AllowPrivateAccess = "true"))
 	TObjectPtr<USceneComponent> SceneComp;
-	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Component", meta = (AllowPrivateAccess = true))
-	TObjectPtr<UStaticMeshComponent> MeshComp;
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Component", meta = (AllowPrivateAccess = "true"))
+	TObjectPtr<UNiagaraComponent> NiagaraComp;
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Component", meta = (AllowPrivateAccess = "true"))
+	TObjectPtr<UBoxComponent> BoxComp;	// 상호작용의 충돌체크를 위한 콜리전 용도의 컴포넌트
 
 // 상호작용
 public:

--- a/Source/RogShop/RogShop.Build.cs
+++ b/Source/RogShop/RogShop.Build.cs
@@ -42,7 +42,7 @@ public class RogShop : ModuleRules
             Path.Combine(ModuleDirectory, "DeveloperSettings"),
         });
 
-        PublicDependencyModuleNames.AddRange(new string[] { "Core", "CoreUObject", "Engine", "InputCore", "EnhancedInput", "AIModule", "NavigationSystem", "DeveloperSettings", "SkeletalMerging", "UMG", "PhysicsCore" });
+        PublicDependencyModuleNames.AddRange(new string[] { "Core", "CoreUObject", "Engine", "InputCore", "EnhancedInput", "AIModule", "NavigationSystem", "DeveloperSettings", "SkeletalMerging", "UMG", "PhysicsCore", "Niagara" });
 
 		PrivateDependencyModuleNames.AddRange(new string[] {  });
 


### PR DESCRIPTION
기존의 스테틱 메시 컴포넌트는 제거했습니다.

나이아가라 컴포넌트를 추가해주었습니다.
블루프린트 클래스에서 해당 컴포넌트에서 사용할 나이아가라 시스템을 적용합니다.

상호작용의 충돌 처리를 위해서 박스 컴포넌트를 추가해주었습니다.
박스 컴포넌트의 스케일 및 사이즈는 기본 크기입니다.

나이아가라 시스템을 사용하기 위해서 모듈을 추가해주었습니다.