### PR TITLE
[update] 보스 잡고 보낼 재료를 적게 선택한 경우 경고창이 나타나도록 구현

### DIFF
--- a/Content/Blueprints/Widgets/Dungeon/WBP_SendIngredient.uasset
+++ b/Content/Blueprints/Widgets/Dungeon/WBP_SendIngredient.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:28957f9f7d594b0695f248c89b946f7363804c318ced27d95b45e96777dbc12b
-size 39894
+oid sha256:9548521daf331931103aa684ee84e4d4f5b3a4e90f6933fabd5a29e34bca4092
+size 59077

--- a/Source/RogShop/Widget/Dungeon/RSSendIngredientWidget.cpp
+++ b/Source/RogShop/Widget/Dungeon/RSSendIngredientWidget.cpp
@@ -5,6 +5,7 @@
 #include "RogShop/UtilDefine.h"
 #include "Components/Button.h"
 #include "Components/UniformGridPanel.h"
+#include "Components/CanvasPanel.h"
 #include "GameFramework/PlayerController.h"
 #include "RSDungeonGameModeBase.h"
 #include "RSGameInstance.h"
@@ -30,14 +31,26 @@ void URSSendIngredientWidget::NativeConstruct()
 	// 확인 버튼 바인딩
 	if (OKButton)
 	{
-		OKButton->OnClicked.AddDynamic(this, &URSSendIngredientWidget::NextStageTravel);
+		OKButton->OnClicked.AddDynamic(this, &URSSendIngredientWidget::SendIngredientSlotCheck);
 	}
+
+	// 경고의 확인 버튼 바인딩
+	if (WarningOkButton)
+	{
+		WarningOkButton->OnClicked.AddDynamic(this, &URSSendIngredientWidget::SendIngredientAndNextStageTravel);
+	}
+
+	// 경고의 취소 버튼 바인딩
+	if (WarningCancelButton)
+	{
+		WarningCancelButton->OnClicked.AddDynamic(this, &URSSendIngredientWidget::WarningHide);
+	}
+
+	WarningHide();
 }
 
-void URSSendIngredientWidget::NextStageTravel()
+void URSSendIngredientWidget::SendIngredientAndNextStageTravel()
 {
-	// TODO : 재료를 보낼 수 있는 만큼 골랐는지 확인 후 적게 골랐다면 경고창을 띄운다.
-
 	URSGameInstance* RSGameInstance = GetGameInstance<URSGameInstance>();
 	if (!RSGameInstance)
 	{
@@ -247,6 +260,26 @@ void URSSendIngredientWidget::CreatePlayerIngredientSlots(const TArray<FItemSlot
 	}
 }
 
+void URSSendIngredientWidget::SendIngredientSlotCheck()
+{
+	// 재료를 보낼 수 있는 만큼 골랐는지 확인한다.
+	for (const auto& e : SendIngredientSlots)
+	{
+		FName ItemDataTableKey = e->GetItemDataTableKey();
+
+		// 보낼 재료를 선택하지 않은 경우 경고창을 띄운다.
+		if (ItemDataTableKey == NAME_None)
+		{
+			WarningShow();
+
+			return;
+		}
+	}
+
+	// 재료를 보낼 수 있는 만큼 모두 골랐으므로, 재료를 보내고 레벨을 이동하는 함수 호출
+	SendIngredientAndNextStageTravel();
+}
+
 void URSSendIngredientWidget::SetClickIngredientName(FName NewClickIngredientName)
 {
 	ClickIngredientName = NewClickIngredientName;
@@ -319,4 +352,14 @@ void URSSendIngredientWidget::PlayerIngredientSlotPress()
 	}
 
 	ClickIngredientName = NAME_None;
+}
+
+void URSSendIngredientWidget::WarningShow()
+{
+	WarningCanvasPanel->SetVisibility(ESlateVisibility::SelfHitTestInvisible);
+}
+
+void URSSendIngredientWidget::WarningHide()
+{
+	WarningCanvasPanel->SetVisibility(ESlateVisibility::Hidden);
 }

--- a/Source/RogShop/Widget/Dungeon/RSSendIngredientWidget.h
+++ b/Source/RogShop/Widget/Dungeon/RSSendIngredientWidget.h
@@ -9,6 +9,7 @@
 class UButton;
 class UUniformGridPanel;
 class URSInventorySlotWidget;
+class UCanvasPanel;
 
 struct FItemSlot;
 
@@ -22,7 +23,7 @@ public:
 
 private:
 	UFUNCTION()
-	void NextStageTravel();
+	void SendIngredientAndNextStageTravel();
 
 	UFUNCTION()
 	void ExitWidget();
@@ -42,6 +43,9 @@ public:
 
 private:
 	UFUNCTION()
+	void SendIngredientSlotCheck();
+
+	UFUNCTION()
 	void SetClickIngredientName(FName NewClickIngredientName);
 
 	UFUNCTION()
@@ -51,12 +55,14 @@ private:
 	void PlayerIngredientSlotPress();
 
 private:
+	// 바인드 위젯
 	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Widget", meta = (BindWidget, AllowPrivateAccess = "true"))
 	TObjectPtr<UUniformGridPanel> SendIngredientPanel;	// 보낼 재료 슬롯을 배치할 패널
 
 	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Widget", meta = (BindWidget, AllowPrivateAccess = "true"))
 	TObjectPtr<UUniformGridPanel> PlayerIngredientPanel;	// 플레이어가 획득한 재료 슬롯을 배치할 패널
 
+	// 위젯에 적용할 슬롯
 	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Widget", meta = (AllowPrivateAccess = "true"))
 	TSubclassOf<URSInventorySlotWidget> InvecntorySlotWidgetClass;	// 슬롯 클래스
 
@@ -67,4 +73,21 @@ private:
 	TArray<TObjectPtr<URSInventorySlotWidget>> PlayerIngredientSlots;	// 플레이어 재료를 보여줄 슬롯
 
 	FName ClickIngredientName;  // 클릭한 슬롯의 재료의 데이터 테이블 RowName
+
+// 경고창
+private:
+	void WarningShow();
+
+	UFUNCTION()
+	void WarningHide();
+
+private:
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Widget", meta = (BindWidget, AllowPrivateAccess = "true"))
+	TObjectPtr<UCanvasPanel> WarningCanvasPanel;
+
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Widget", meta = (BindWidget, AllowPrivateAccess = "true"))
+	TObjectPtr<UButton> WarningOkButton;
+
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Widget", meta = (BindWidget, AllowPrivateAccess = "true"))
+	TObjectPtr<UButton> WarningCancelButton;
 };


### PR DESCRIPTION
위젯 블루프린트에 경고창 관련한 UI을 추가해주었습니다.

위젯 클래스의 C++에서 경고창을 나타나게 하거나 숨기도록 해주었습니다.

경고창이 나타나는 조건은 타이쿤으로 보낼 재료가 보낼 수 있는 재료의 수보다 적게 선택된 경우입니다.

만약 보낼 수 있는 재료의 수만큼 모두 보낼 재료를 채우면 경고창이 나타나지 않고 즉시 이동합니다.

위의 기능을 위한 변수 및 함수들을 추가했습니다.