### PR TITLE
[Bugfix] 현재 체력과 최대 체력이 제대로 갱신되지 않는 문제 수정

### DIFF
--- a/Source/RogShop/Character/RSDunPlayerCharacter.cpp
+++ b/Source/RogShop/Character/RSDunPlayerCharacter.cpp
@@ -233,6 +233,17 @@ void ARSDunPlayerCharacter::OnDeath()
     }
 }
 
+void ARSDunPlayerCharacter::ChangeMaxHP(float Amount)
+{
+    Super::ChangeMaxHP(Amount);
+
+    ARSDunPlayerController* PC = Cast<ARSDunPlayerController>(GetController());
+    if (PC)
+    {
+        PC->OnMaxHPChange.Broadcast();
+    }
+}
+
 void ARSDunPlayerCharacter::IncreaseMaxHP(float Amount)
 {
     Super::IncreaseMaxHP(Amount);
@@ -252,6 +263,17 @@ void ARSDunPlayerCharacter::DecreaseMaxHP(float Amount)
     if (PC)
     {
         PC->OnMaxHPChange.Broadcast();
+    }
+}
+
+void ARSDunPlayerCharacter::ChangeHP(float Amount)
+{
+    Super::ChangeHP(Amount);
+
+    ARSDunPlayerController* PC = Cast<ARSDunPlayerController>(GetController());
+    if (PC)
+    {
+        PC->OnHPChange.Broadcast();
     }
 }
 
@@ -758,10 +780,14 @@ void ARSDunPlayerCharacter::LoadStatus()
     URSDungeonStatusSaveGame* StatusLoadGame = Cast<URSDungeonStatusSaveGame>(UGameplayStatics::LoadGameFromSlot(SaveGameSubsystem->StatusSaveSlotName, 0));
     if (!StatusLoadGame)
     {
+        // 저장된 값이 없는 경우 기본값으로 설정
+        ChangeMaxHP(GetMaxHP());
+        ChangeHP(GetHP());
         return;
     }
     
     // 로드
+    ChangeMaxHP(GetMaxHP());
     ChangeHP(StatusLoadGame->HP);
     LifeEssence = StatusLoadGame->LifeEssence;
 }

--- a/Source/RogShop/Character/RSDunPlayerCharacter.h
+++ b/Source/RogShop/Character/RSDunPlayerCharacter.h
@@ -40,9 +40,11 @@ public:
 
 	void OnDeath();
 
+	virtual void ChangeMaxHP(float Amount) override;
 	virtual void IncreaseMaxHP(float Amount) override;
 	virtual void DecreaseMaxHP(float Amount) override;
 
+	virtual void ChangeHP(float Amount) override;
 	virtual void IncreaseHP(float Amount) override;
 	virtual void DecreaseHP(float Amount) override;
 

--- a/Source/RogShop/Widget/Dungeon/RSPlayerStatusWidget.cpp
+++ b/Source/RogShop/Widget/Dungeon/RSPlayerStatusWidget.cpp
@@ -32,8 +32,6 @@ void URSPlayerStatusWidget::NativeConstruct()
 {
 	Super::NativeConstruct();
     
-    UpdateHP();
-    UpdateMaxHP();
 }
 
 void URSPlayerStatusWidget::UpdateWeaponSlot(int8 WeaponSlotIndex, FName WeaponKey)


### PR DESCRIPTION
현재 체력과 최대 체력이 UI에 제대로 표기되지 않는다는 문제가 있었습니다.

해당 문제는 세이브된 데이터가 없거나 불러올 때 UI를 갱신시키지 못하기 때문에 발생한 문제입니다.

세이브 파일이 없는 경우 기본적으로 설정된 값을 기준으로 체력을 변경해주어 UI가 갱신되도록 해주었습니다.
세이브 파일이 있는 경우 저장된 체력값을 기준으로 현재체력을 변경해주었습니다.
현재 최대 체력의 경우에는 세이브하지 않으므로, 기본적으로 설정된 값을 기준으로 최대 체력을 변경합니다.

즉, 기본적으로 설정된 값을 사용한다는 것은 적용된 값 자체는 같아 값에 변화는 없지만 델리게이트를 호출하여 브로드캐스트합니다.
그 결과로 체력에 대한 UI가 갱신되도록 합니다.