### PR TITLE
[Fix] 무기 공격력이 재대로 적용되지 않던 문제 수정

### DIFF
--- a/Source/RogShop/ActorComponent/RSPlayerWeaponComponent.cpp
+++ b/Source/RogShop/ActorComponent/RSPlayerWeaponComponent.cpp
@@ -538,12 +538,12 @@ void URSPlayerWeaponComponent::PerformBoxSweepAttack()
 							// 일반 공격
 							if (AttackType == EAttackType::NormalAttack)
 							{
-								WeaponDamage = WeaponActors[Index]->GetNormalAttackMontageDamage(Index);
+								WeaponDamage = WeaponActors[Index]->GetNormalAttackMontageDamage(ComboIndex - 1);
 							}
 							// 강 공격
 							else if (AttackType == EAttackType::StrongAttack)
 							{
-								WeaponDamage = WeaponActors[Index]->GetStrongAttackMontageDamage(Index);
+								WeaponDamage = WeaponActors[Index]->GetStrongAttackMontageDamage(ComboIndex - 1);
 							}
 
 							float AttackPower = OwnerCharacter->GetAttackPower();


### PR DESCRIPTION
플레이어 캐릭터가 공격시 무기의 데미지를 Get할 때 잘못된 인덱스 값을 사용하여 문제가 있었습니다.

다시 제대로 된 인덱스 값을 사용하도록 수정해주었습니다.