### PR TITLE
[Bugfix] 몬스터와 보스가 재료 아이템 및 재화를 드랍하지 않던 문제 해결

### DIFF
--- a/Source/RogShop/Actor/MapGenerator/RSSpawnManager.cpp
+++ b/Source/RogShop/Actor/MapGenerator/RSSpawnManager.cpp
@@ -556,6 +556,9 @@ void URSSpawnManager::SpawnBossMonster()
 	BossMonster->IncreaseHP(BossData->MaxHP);
 	BossMonster->ChangeMoveSpeed(BossData->MoveSpeed);
 
+	// 사망 시 오브젝트 스폰 함수 바인딩
+	BossMonster->OnCharacterDied.AddDynamic(this, &URSSpawnManager::SpawnGroundIngredientFromCharacter);
+	BossMonster->OnCharacterDied.AddDynamic(this, &URSSpawnManager::SpawnGroundLifeEssenceFromCharacter);
 
 }
 
@@ -623,6 +626,10 @@ void URSSpawnManager::SpawnMonstersAtTile(FIntPoint TileCoord) // 특정 타일 
 			Monster->IncreaseHP(StateRow->MaxHP); 
 			Monster->ChangeMoveSpeed(StateRow->MoveSpeed); 
 			Monster->OnCharacterDied.AddDynamic(this, &URSSpawnManager::OnMonsterDiedFromTile); // 몬스터 사망 시 호출될 델리게이트 바인딩
+
+			// 사망 시 오브젝트 스폰 함수 바인딩
+			Monster->OnCharacterDied.AddDynamic(this, &URSSpawnManager::SpawnGroundIngredientFromCharacter);
+			Monster->OnCharacterDied.AddDynamic(this, &URSSpawnManager::SpawnGroundLifeEssenceFromCharacter);
 
 			AliveMonstersPerTile.FindOrAdd(TileCoord) += 1;
 			TotalSpawned++;

--- a/Source/RogShop/Character/RSDunMonsterCharacter.cpp
+++ b/Source/RogShop/Character/RSDunMonsterCharacter.cpp
@@ -361,17 +361,14 @@ void ARSDunMonsterCharacter::OnDeath()
 		ctrl->Destroy();
 	}
 
-	if (GetFMonsterData())
+	ARSDungeonGameModeBase* DungeonGameMode = Cast<ARSDungeonGameModeBase>(GetWorld()->GetAuthGameMode());
+	if (GetFMonsterData() && DungeonGameMode)
 	{
 		// 몬스터의 타입이 보스인 경우 게임모드에 보스가 죽었다고 알린다.
 		EMonsterType CurMonsterType = GetFMonsterData()->MonsterType;
 		if (CurMonsterType == EMonsterType::Boss)
-		{
-			ARSDungeonGameModeBase* DungeonGameMode = Cast<ARSDungeonGameModeBase>(GetWorld()->GetAuthGameMode());
-			if (DungeonGameMode)
-			{
-				DungeonGameMode->OnBossDead.Broadcast();
-			}
+		{			
+			DungeonGameMode->OnBossDead.Broadcast();
 		}
 	}
 }


### PR DESCRIPTION
기존 몬스터와 보스에서 재료 아이템과 재화를 드랍하는 함수를 델리게이트에 바인딩하지 않은 상태였습니다.

몬스터가 죽었음을 의미하는 델리게이트에 관련 함수를 바인딩하여 해결했습니다.