### PR TITLE
[Update] 무기에 적용할 Trail 애셋을 데이터테이블에 적용할 수 있도록 수정

### DIFF
--- a/Source/RogShop/DataTable/ItemInfoData.h
+++ b/Source/RogShop/DataTable/ItemInfoData.h
@@ -8,6 +8,7 @@
 #include "WeaponAttackData.h"
 #include "ItemInfoData.generated.h"
 
+class UNiagaraSystem;
 class URSBaseRelic;
 
 UENUM(BlueprintType)
@@ -67,6 +68,9 @@ struct ROGSHOP_API FDungeonWeaponData : public FTableRowBase
 public:
 	UPROPERTY(EditAnywhere, BlueprintReadWrite)
 	TSubclassOf<ARSDungeonItemBase> WeaponClass;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	TObjectPtr<UNiagaraSystem> WeaponTrail;
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite)
 	TArray<FWeaponAttackData> NormalAttackData;


### PR DESCRIPTION
FDungeonWeaponData 에 나이아가라 애셋을 데이터테이블에 적용할 수 있도록 수정해주었습니다.