### PR TITLE
[Update] VFX 수치 조절 변수 추가

### DIFF
--- a/Content/Assets/SwordTrailVFX/VFX/NS_Trail_11.uasset
+++ b/Content/Assets/SwordTrailVFX/VFX/NS_Trail_11.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ad1ddadf5b952c7b7fc558d8cd140dfdfcdce00601b7bd2e3a35f25de5d47ca3
-size 818344
+oid sha256:7aee357fcc79ede755b40b21dd9b3d54ba79c74c355fa7447bd4785be74c0891
+size 828695


### PR DESCRIPTION
NS_Trail_11 이펙트에 변수를 추가했습니다.
- User.EffectWidth (float) 변수로 이펙트가 발현되는 범위의 길이를 조절할 수 있습니다. 현재 기본값은 60입니다.
- User.EffectPosition (vector)변수의 Z값으로 이펙트의 중심 위치를 조절할 수 있습니다. 현재 기본값은 55입니다.