### PR TITLE
[Update] 무기로 몬스터 타격시 VFX 재생

### DIFF
--- a/Content/Assets/SlashHitVFX/NS/NS_Hit_Katana.uasset
+++ b/Content/Assets/SlashHitVFX/NS/NS_Hit_Katana.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:dbdf270bef5d8d0e6bc1451c59ef9bdeb94f193759855580b335cae34e451e18
-size 3048321
+oid sha256:f8a28443f3250a83a5a226b1f87461cf724eb7d1bec593db39a5755a96d21ae9
+size 3086443

--- a/Content/Datas/WeaponDetailDataTable.uasset
+++ b/Content/Datas/WeaponDetailDataTable.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:018457c49831eb034202cf137e1ff79b37671aa56fcf672535cb766956568d86
-size 10506
+oid sha256:54af5bbd822457f6c32eae4dabc6477b799c54584d4b92ae0df859733dbaae42
+size 10820

--- a/Source/RogShop/Actor/Dungeon/Weapon/RSBaseWeapon.cpp
+++ b/Source/RogShop/Actor/Dungeon/Weapon/RSBaseWeapon.cpp
@@ -5,6 +5,8 @@
 #include "GameFramework/Character.h"
 #include "Components/BoxComponent.h"
 #include "NiagaraComponent.h"
+#include "NiagaraSystem.h"
+#include "NiagaraFunctionLibrary.h"
 #include "RSDataSubsystem.h"
 #include "ItemInfoData.h"
 #include "WeaponAttackData.h"
@@ -25,9 +27,9 @@ ARSBaseWeapon::ARSBaseWeapon()
 	BoxComp->SetCollisionEnabled(ECollisionEnabled::NoCollision);
 	BoxComp->SetGenerateOverlapEvents(false);
 
-	NiagaraComp = CreateDefaultSubobject<UNiagaraComponent>(TEXT("Niagara"));
-	NiagaraComp->SetupAttachment(SceneComp);
-	NiagaraComp->SetAutoActivate(false);
+	TrailNiagaraComp = CreateDefaultSubobject<UNiagaraComponent>(TEXT("Niagara"));
+	TrailNiagaraComp->SetupAttachment(SceneComp);
+	TrailNiagaraComp->SetAutoActivate(false);
 
 	SetActorEnableCollision(false);
 }
@@ -134,18 +136,23 @@ float ARSBaseWeapon::GetStrongAttackMontageDamage(int32 MontageIndex) const
 
 void ARSBaseWeapon::StartTrail()
 {
-	if (NiagaraComp)
+	if (TrailNiagaraComp)
 	{
-		NiagaraComp->Activate();
+		TrailNiagaraComp->Activate();
 	}
 }
 
 void ARSBaseWeapon::EndTrail()
 {
-	if (NiagaraComp)
+	if (TrailNiagaraComp)
 	{
-		NiagaraComp->Deactivate();
+		TrailNiagaraComp->Deactivate();
 	}
+}
+
+void ARSBaseWeapon::SpawnHitImpactEffect(FVector TargetLocation)
+{
+	UNiagaraFunctionLibrary::SpawnSystemAtLocation(GetWorld(), HitImpactEffect, TargetLocation);
 }
 
 FName ARSBaseWeapon::GetDataTableKey() const
@@ -188,11 +195,13 @@ void ARSBaseWeapon::Initialization()
 		NormalAttackDatas = WeaponData->NormalAttackData;
 		StrongAttackDatas = WeaponData->StrongAttackData;
 
-		NiagaraComp->SetAsset(WeaponData->WeaponTrail);
+		TrailNiagaraComp->SetAsset(WeaponData->WeaponTrail);
+
+		HitImpactEffect = WeaponData->HitImpactEffect;
 
 		//TODO : 서승우님이 나이아가라 크기 조절에 대해 알아봐주시고 아래 코드 사용하기
 		//FVector BoxExtent = BoxComp->GetScaledBoxExtent();
 		//FVector BoxLength = BoxExtent * 2;
-		//NiagaraComp->SetVectorParameter(TEXT("MeshBounds"), BoxLength);
+		//TrailNiagaraComp->SetVectorParameter(TEXT("MeshBounds"), BoxLength);
 	}
 }

--- a/Source/RogShop/Actor/Dungeon/Weapon/RSBaseWeapon.h
+++ b/Source/RogShop/Actor/Dungeon/Weapon/RSBaseWeapon.h
@@ -9,6 +9,7 @@
 
 class UBoxComponent;
 class UNiagaraComponent;
+class UNiagaraSystem;
 
 struct FWeaponAttackData;
 
@@ -38,7 +39,7 @@ private:
 	TObjectPtr<UBoxComponent> BoxComp;	// 데미지 로직을 위한 콜리전 용도의 컴포넌트
 
 	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Component", meta = (AllowPrivateAccess = "true"))
-	TObjectPtr<UNiagaraComponent> NiagaraComp;
+	TObjectPtr<UNiagaraComponent> TrailNiagaraComp;
 
 // 애니메이션
 public:
@@ -79,6 +80,12 @@ public:
 	void StartTrail();
 
 	void EndTrail();
+
+	void SpawnHitImpactEffect(FVector TargetLocation);
+
+private:
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Niagara", meta = (AllowPrivateAccess = "true"))
+	TObjectPtr<UNiagaraSystem> HitImpactEffect;
 
 // 데이터 테이블의 RowName을 ID값으로 사용한다.
 public:

--- a/Source/RogShop/ActorComponent/RSPlayerWeaponComponent.cpp
+++ b/Source/RogShop/ActorComponent/RSPlayerWeaponComponent.cpp
@@ -573,6 +573,8 @@ void URSPlayerWeaponComponent::PerformBoxSweepAttack()
 
 							UGameplayStatics::ApplyPointDamage(HitActor, TotalDamage, HitDirection, Hit, OwnerController, WeaponActors[Index], UDamageType::StaticClass());
 
+							WeaponActors[Index]->SpawnHitImpactEffect(Hit.ImpactPoint);
+
 							// 무기 데미지를 중복으로 주는 경우를 방지하기 위한 배열에 값 추가
 							DamagedActors.Add(HitActor);
 

--- a/Source/RogShop/DataTable/ItemInfoData.h
+++ b/Source/RogShop/DataTable/ItemInfoData.h
@@ -73,6 +73,9 @@ public:
 	TObjectPtr<UNiagaraSystem> WeaponTrail;
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	TObjectPtr<UNiagaraSystem> HitImpactEffect;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite)
 	TArray<FWeaponAttackData> NormalAttackData;
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite)


### PR DESCRIPTION
무기 액터가 HitImpact시 재생할 나이아가라를 참조하도록 했습니다.

데이터 테이블에서 HitImpact시 재생할 나이아가라에 대한 정보를 가지도록 해주었습니다.

URSPlayerWeaponComponent의 PerformBoxSweepAttack 중 Hit가 발생할 경우 ImpactPoint를 통해 위치를 가져와 VFX를 스폰시켜 재생시키도록 해주었습니다.