### PR TITLE
[Update] Trail VFX의 크기와 위치 변경

### DIFF
--- a/Source/RogShop/Actor/Dungeon/Weapon/RSBaseWeapon.cpp
+++ b/Source/RogShop/Actor/Dungeon/Weapon/RSBaseWeapon.cpp
@@ -199,9 +199,25 @@ void ARSBaseWeapon::Initialization()
 
 		HitImpactEffect = WeaponData->HitImpactEffect;
 
-		//TODO : 서승우님이 나이아가라 크기 조절에 대해 알아봐주시고 아래 코드 사용하기
-		//FVector BoxExtent = BoxComp->GetScaledBoxExtent();
-		//FVector BoxLength = BoxExtent * 2;
-		//TrailNiagaraComp->SetVectorParameter(TEXT("MeshBounds"), BoxLength);
+		// Trail 나이아가라 크기 및 위치 조절
+		// 박스 컴포넌트의 월드 기준 크기의 절반
+		FVector BoxExtent = BoxComp->GetScaledBoxExtent();
+
+		// 4배 크기로 설정
+		// 2배할 경우 박스의 월드 기준 크기
+		// 한번 더 2배하여 Trail에 맞는 크기 설정
+		FVector BoxLength = BoxExtent * 4;
+		TrailNiagaraComp->SetFloatParameter(TEXT("User.EffectWidth"), BoxLength.Z);
+
+		// 박스 컴포넌트의 월드 기준 위치
+		FVector BoxWorldLocation = BoxComp->GetComponentLocation();
+
+		// 박스 컴포넌트의 최하단 위치
+		FVector Position = { BoxWorldLocation.X, BoxWorldLocation.Y, BoxWorldLocation.Z - BoxExtent.Z };
+		
+		// TrailNiagaraComp의 상대 위치로 변환
+		FVector RelativePosition = TrailNiagaraComp->GetComponentTransform().InverseTransformPosition(Position);
+
+		TrailNiagaraComp->SetVectorParameter(TEXT("User.EffectPosition"), RelativePosition);
 	}
 }


### PR DESCRIPTION
박스 컴포넌트의 월드 기준 크기 절반을 가져와 Trail의 나이아가가라에 이펙트 반경 값을 Set합니다.
SetFloatParameter함수를 사용하여 User.EffectWidth의 값을 설정합니다.

박스 컴포넌트의 월드 기준 위치에서 Z축 방향으로 절반 크기만큼 아래로 이동한 값을 계산하여 박스의 최하단 중심 위치를 구합니다.
구한 위치를 나이아가라 컴포넌트 기준의 상대 위치로 변환하여 나이아가라 이펙트 내부의 위치값을 변경할 수 있도록 해주었습니다.
SetVectorParameter함수를 사용하여 User.EffectPosition의 값을 설정합니다.