### PR TITLE
[Fix] 던전 재화에 대해 상호작용 UI가 나타나지 않도록 수정

### DIFF
--- a/Source/RogShop/Actor/Dungeon/GroundItem/RSDungeonGroundLifeEssence.cpp
+++ b/Source/RogShop/Actor/Dungeon/GroundItem/RSDungeonGroundLifeEssence.cpp
@@ -57,14 +57,14 @@ void ARSDungeonGroundLifeEssence::Interact(ARSDunPlayerCharacter* Interactor)
 	// 더이상 상호작용 함수가 호출되지 않도록 한다.
 	bIsAutoInteract = false;
 
+	MeshComp->SetSimulatePhysics(false);
+	MeshComp->SetEnableGravity(false);
+	MeshComp->SetCollisionEnabled(ECollisionEnabled::NoCollision);
+
 	GetWorld()->GetTimerManager().SetTimer(InteractDelayTimer, FTimerDelegate::CreateLambda([=, this]()
 	{
 		// 틱 활성화
 		SetActorTickEnabled(true);
-
-		MeshComp->SetSimulatePhysics(false);
-		MeshComp->SetEnableGravity(false);
-		MeshComp->SetCollisionEnabled(ECollisionEnabled::NoCollision);
 
 		// 루트 컴포넌트를 메시 위치로 이동 및 루트 컴포넌트에 다시 부착후 메시 컴포넌트의 위치 및 회전 초기화
 		SceneComp->SetWorldLocationAndRotation(MeshComp->GetComponentLocation(), MeshComp->GetComponentRotation());


### PR DESCRIPTION
던전 재화는 자동적으로 상호작용 되기 때문에 상호작용이 되는 즉시 콜리전을 제거해주었습니다.

던전 재화가 슥듭되는 속도를 증가했습니다.