### PR TITLE
[Update] 보스룸 입장을 의미하는 델리게이트 추가

### DIFF
--- a/Source/RogShop/Actor/Dungeon/RSDunBossRoomPortal.cpp
+++ b/Source/RogShop/Actor/Dungeon/RSDunBossRoomPortal.cpp
@@ -5,6 +5,7 @@
 #include "Components/BoxComponent.h"
 #include "NiagaraComponent.h"
 #include "RSDunPlayerCharacter.h"
+#include "RSDungeonGameModeBase.h"
 
 ARSDunBossRoomPortal::ARSDunBossRoomPortal()
 {
@@ -35,6 +36,12 @@ void ARSDunBossRoomPortal::Interact(ARSDunPlayerCharacter* Interactor)
 	if (Interactor)
 	{
 		Interactor->SetActorTransform(TargetTransform);
+	}
+
+	ARSDungeonGameModeBase* DungeonGameMode = GetWorld()->GetAuthGameMode<ARSDungeonGameModeBase>();
+	if (DungeonGameMode)
+	{
+		DungeonGameMode->OnBossRoomPortalEntered.Broadcast();
 	}
 }
 

--- a/Source/RogShop/GameModeBase/RSDungeonGameModeBase.h
+++ b/Source/RogShop/GameModeBase/RSDungeonGameModeBase.h
@@ -9,9 +9,10 @@
 #include "RSSpawnManagerAccessor.h"
 #include "RSDungeonGameModeBase.generated.h"
 
-DECLARE_DYNAMIC_MULTICAST_DELEGATE(FOnBossDead);
 DECLARE_DYNAMIC_MULTICAST_DELEGATE(FOnGameReady);
 DECLARE_DYNAMIC_MULTICAST_DELEGATE(FOnMapFullyLoaded);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE(FOnBossDead);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE(FOnBossRoomPortalEntered);
 
 // 던전 게임모드 클래스 정의
 UCLASS()
@@ -39,6 +40,9 @@ public:
 
 	UPROPERTY(BlueprintAssignable)
 	FOnMapFullyLoaded OnMapFullyLoaded;
+
+	UPROPERTY(BlueprintAssignable)
+	FOnBossRoomPortalEntered OnBossRoomPortalEntered;
 #pragma endregion
 
 #pragma region MapGenerator


### PR DESCRIPTION
보스룸 입장을 의미하는 델리게이트를 추가해주었습니다.

해당 델리게이트는 보스룸을 입장했을 때, 보스를 스폰시키기 위함입니다.

보스가 미리 스폰되는 경우 최초 애니메이션이 재생된 상태가 되고, 보스 체력바 UI가 화면에 나타나게 되는 문제가 있기 때문에 보스의 스폰 시점을 뒤로 미룹니다.