### PR TITLE
[Fixed] 미니맵에서 보스몬스터 타일이 회전하던 문제 해결

### DIFF
--- a/Source/RogShop/Widget/Dungeon/RSMiniMap.cpp
+++ b/Source/RogShop/Widget/Dungeon/RSMiniMap.cpp
@@ -59,6 +59,7 @@ void URSMiniMap::UpdateTileVisual(const FIntPoint& TileCoord)
         if (TileCoord == MapGen->GetBossTileCoord())
         {
             TextureToUse = BossRoomTexture;
+            Rotation = FRotator::ZeroRotator;
         }
     }
 


### PR DESCRIPTION
[Fixed] 미니맵에서 보스몬스터 타일이 회전하던 문제 해결