### PR TITLE
[Fix] 로딩창의 이미지가 계속 갱신되지 않도록 수정

### DIFF
--- a/Content/Blueprints/Widgets/Dungeon/WBP_LoadingWidget.uasset
+++ b/Content/Blueprints/Widgets/Dungeon/WBP_LoadingWidget.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cd148121bb4b3bbdace91279b63109ff169d7da761a3f990951d77dd4bd2a1b7
-size 71949
+oid sha256:a56121be59d431157536fc6976a7d23e2f2da150421a4061f6b880c94d1a7dab
+size 37821

--- a/Source/RogShop/Widget/Dungeon/RSLoadingWidget.cpp
+++ b/Source/RogShop/Widget/Dungeon/RSLoadingWidget.cpp
@@ -3,13 +3,25 @@
 
 #include "RSLoadingWidget.h"
 #include "RSDungeonGameModeBase.h"
+#include "Components/Image.h"
 
 void URSLoadingWidget::NativeConstruct()
 {
+	Super::NativeConstruct();
+
 	ARSDungeonGameModeBase* DungeonGameModeBase = GetWorld()->GetAuthGameMode<ARSDungeonGameModeBase>();
 	if (DungeonGameModeBase)
 	{
 		DungeonGameModeBase->OnGameReady.AddDynamic(this, &URSLoadingWidget::HideLoading);
+	}
+
+	if (LoadingImage)
+	{
+		int32 ImageIndex = FMath::RandRange(0, BackGroundImages.Num());
+		if (BackGroundImages.IsValidIndex(ImageIndex))
+		{
+			LoadingImage->SetBrushFromTexture(BackGroundImages[ImageIndex]);
+		}
 	}
 }
 

--- a/Source/RogShop/Widget/Dungeon/RSLoadingWidget.h
+++ b/Source/RogShop/Widget/Dungeon/RSLoadingWidget.h
@@ -6,9 +6,8 @@
 #include "Blueprint/UserWidget.h"
 #include "RSLoadingWidget.generated.h"
 
-/**
- * 
- */
+class UImage;
+
 UCLASS()
 class ROGSHOP_API URSLoadingWidget : public UUserWidget
 {
@@ -20,4 +19,11 @@ protected:
 private:
 	UFUNCTION()
 	void HideLoading();
+
+private:
+	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, meta = (AllowPrivateAccess = "true"))
+	TArray<TObjectPtr<UTexture2D>> BackGroundImages;
+
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, meta = (BindWidget, AllowPrivateAccess = "true"))
+	TObjectPtr<UImage> LoadingImage;
 };


### PR DESCRIPTION
로딩창에 이미지가 매 틱마다 갱신되는 문제가 있었습니다.

해당 문제는 위젯 블루프린트에서 참조 중인 텍스쳐들을 매 틱마다 랜덤으로 하나 선택해서 이미지를 갱신하기 때문이라는 것을 알 수 있었습니다.

이 문제를 해결하기 위해서 NativeConstruct함수에서 참조중인 텍스처 중 한가지를 선택해 해당 이미지를 선택하도록 변경해주었습니다.