### PR TITLE
[fix] 던전 재화의 콜리전 설정 변경

### DIFF
--- a/Source/RogShop/Actor/Dungeon/GroundItem/RSDungeonGroundLifeEssence.cpp
+++ b/Source/RogShop/Actor/Dungeon/GroundItem/RSDungeonGroundLifeEssence.cpp
@@ -57,12 +57,15 @@ void ARSDungeonGroundLifeEssence::Interact(ARSDunPlayerCharacter* Interactor)
 	// 더이상 상호작용 함수가 호출되지 않도록 한다.
 	bIsAutoInteract = false;
 
-	MeshComp->SetSimulatePhysics(false);
-	MeshComp->SetEnableGravity(false);
-	MeshComp->SetCollisionEnabled(ECollisionEnabled::NoCollision);
+	MeshComp->SetCollisionEnabled(ECollisionEnabled::PhysicsOnly);
 
 	GetWorld()->GetTimerManager().SetTimer(InteractDelayTimer, FTimerDelegate::CreateLambda([=, this]()
 	{
+		MeshComp->SetCollisionEnabled(ECollisionEnabled::NoCollision);
+
+		MeshComp->SetSimulatePhysics(false);
+		MeshComp->SetEnableGravity(false);
+
 		// 틱 활성화
 		SetActorTickEnabled(true);
 


### PR DESCRIPTION
현재 던전 재화가 몬스터에서 드랍될 경우 상호작용이 되자마자 물리 연산이 꺼지는 문제가 있었습니다.

물리 연산은 하되, 상호작용은 되지 않도록 콜리전 설정을 PhysicsOnly로 변경하여 트레이스에 감지되지 않도록 해주었습니다.