### PR TITLE
[Fix] 던전 재화 습득 중 경고 발생 해결

### DIFF
--- a/Source/RogShop/Actor/Dungeon/GroundItem/RSDungeonGroundLifeEssence.cpp
+++ b/Source/RogShop/Actor/Dungeon/GroundItem/RSDungeonGroundLifeEssence.cpp
@@ -57,14 +57,16 @@ void ARSDungeonGroundLifeEssence::Interact(ARSDunPlayerCharacter* Interactor)
 	// 더이상 상호작용 함수가 호출되지 않도록 한다.
 	bIsAutoInteract = false;
 
+	MeshComp->SetSimulatePhysics(false);
 	MeshComp->SetCollisionEnabled(ECollisionEnabled::PhysicsOnly);
+	MeshComp->SetSimulatePhysics(true);
 
 	GetWorld()->GetTimerManager().SetTimer(InteractDelayTimer, FTimerDelegate::CreateLambda([=, this]()
 	{
-		MeshComp->SetCollisionEnabled(ECollisionEnabled::NoCollision);
-
 		MeshComp->SetSimulatePhysics(false);
 		MeshComp->SetEnableGravity(false);
+
+		MeshComp->SetCollisionEnabled(ECollisionEnabled::NoCollision);
 
 		// 틱 활성화
 		SetActorTickEnabled(true);


### PR DESCRIPTION
SetCollisionEnabled을 호출하기 전에 SetSimulatePhysics을 false로 설정하여 발생하는 경고를 해결했습니다.