### PR TITLE
[Fix] 아이템 드랍시 1개만 드랍되는 문제 수정

### DIFF
--- a/Source/RogShop/Actor/Dungeon/GroundItem/RSDungeonGroundLifeEssence.cpp
+++ b/Source/RogShop/Actor/Dungeon/GroundItem/RSDungeonGroundLifeEssence.cpp
@@ -57,9 +57,7 @@ void ARSDungeonGroundLifeEssence::Interact(ARSDunPlayerCharacter* Interactor)
 	// 더이상 상호작용 함수가 호출되지 않도록 한다.
 	bIsAutoInteract = false;
 
-	MeshComp->SetSimulatePhysics(false);
 	MeshComp->SetCollisionEnabled(ECollisionEnabled::PhysicsOnly);
-	MeshComp->SetSimulatePhysics(true);
 
 	GetWorld()->GetTimerManager().SetTimer(InteractDelayTimer, FTimerDelegate::CreateLambda([=, this]()
 	{

--- a/Source/RogShop/Actor/MapGenerator/RSSpawnManager.cpp
+++ b/Source/RogShop/Actor/MapGenerator/RSSpawnManager.cpp
@@ -158,7 +158,7 @@ void URSSpawnManager::SpawnGroundWeaponAtTransform(FName TargetName, FTransform 
 	}
 }
 
-void URSSpawnManager::SpawnGroundIngredientAtTransform(FName TargetName, FTransform TargetTransform)
+void URSSpawnManager::SpawnGroundIngredientAtTransform(FName TargetName, FTransform TargetTransform, int32 Amount)
 {
 	URSGameInstance* RSGameInstance = GetWorld()->GetGameInstance<URSGameInstance>();
 	if (!RSGameInstance)
@@ -196,7 +196,7 @@ void URSSpawnManager::SpawnGroundIngredientAtTransform(FName TargetName, FTransf
 			UStaticMesh* ItemStaticMesh = IngredientInfoDataRow->ItemStaticMesh;
 
 			DungeonIngredient->InitGroundItemInfo(ItemName, false, TargetName, ItemStaticMesh);
-			DungeonIngredient->SetQuantity(1);
+			DungeonIngredient->SetQuantity(Amount);
 			DungeonIngredient->RandImpulse();
 		}
 	}

--- a/Source/RogShop/Actor/MapGenerator/RSSpawnManager.h
+++ b/Source/RogShop/Actor/MapGenerator/RSSpawnManager.h
@@ -128,7 +128,7 @@ public:
 	void SpawnGroundWeaponAtTransform(FName TargetName, FTransform TargetTransform, bool AddImpulse);
 
 	UFUNCTION()
-	void SpawnGroundIngredientAtTransform(FName TargetName, FTransform TargetTransform);
+	void SpawnGroundIngredientAtTransform(FName TargetName, FTransform TargetTransform, int32 Amount);
 
 private:
 	UFUNCTION()

--- a/Source/RogShop/ActorComponent/RSDungeonIngredientInventoryComponent.cpp
+++ b/Source/RogShop/ActorComponent/RSDungeonIngredientInventoryComponent.cpp
@@ -126,7 +126,7 @@ void URSDungeonIngredientInventoryComponent::DropItem(FName ItemKey)
 		return;
 	}
 
-	SpawnManager->SpawnGroundIngredientAtTransform(ItemKey, CurCharacter->GetActorTransform());
+	SpawnManager->SpawnGroundIngredientAtTransform(ItemKey, CurCharacter->GetActorTransform(), CurItemQuantity);
 
 	int32 ItemIndex = RemoveItem(ItemKey, INT32_MAX);
 


### PR DESCRIPTION
재료 아이템을 스폰하는 함수에서 고정적으로 재료 아이템을 1개만 스폰하던 문제가 있었습니다.

스폰할 개수를 매개변수로 받아서 스폰할 때 수량을 정할 수 있도록 해주었습니다.

ARSDungeonGroundLifeEssence의 불필요한 코드를 제거했습니다.