### PR TITLE
[Add] 유물 시스템의 기본 베이스를 구현

### DIFF
--- a/Content/Blueprints/Actor/Dungeon/BP_SpawnManager.uasset
+++ b/Content/Blueprints/Actor/Dungeon/BP_SpawnManager.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d9e80bf0aa9567525a2926ee9ca8278655bac5869f20fae0315e4312bc9cc2c5
-size 7239
+oid sha256:27c8636ebc205418e3c869fdcc43c0802ff5f0f5018b96428080f0d8fefb43b6
+size 7473

--- a/Content/Datas/AL_Datas.uasset
+++ b/Content/Datas/AL_Datas.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:60b29e3d580cf587e54b621ffcab49bd8c80ad708fa0a50d278252cc2fba3da2
-size 5188
+oid sha256:e880f48d1ed31648928fc56e2534cf27614957b59fbf60ee84e3dfad6f73bc0b
+size 5704

--- a/Content/Datas/RelicDataTable.uasset
+++ b/Content/Datas/RelicDataTable.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2e3b0ddaccc018350fc76fd610e075f54a3f1e0005d3b79775bb9176dc0cc471
-size 5267
+oid sha256:6d9a750e1f7c5b0126f11583c7edb8f8e8a220890484afed21d38efef18f78d4
+size 1516

--- a/Content/Datas/RelicDetailDataTable.uasset
+++ b/Content/Datas/RelicDetailDataTable.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:89fb86c3b2a1c39a35ad8a59f6d5b1f24c1055f43febbe27e0823ddb6f4b2e74
-size 3326
+oid sha256:1e0f805e2649b5956eae37d141b20b39d100104da7ef27c568881d8696c9f2e9
+size 3311

--- a/Content/Datas/RelicInfoDataTable.uasset
+++ b/Content/Datas/RelicInfoDataTable.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4300dcdf9cd588ff7097766c018aa5c4c783f4eb6542f1d8cfc3b22899565424
+size 6268

--- a/Source/RogShop/Actor/Dungeon/GroundItem/RSDungeonGroundRelic.cpp
+++ b/Source/RogShop/Actor/Dungeon/GroundItem/RSDungeonGroundRelic.cpp
@@ -22,7 +22,7 @@ void ARSDungeonGroundRelic::Interact(ARSDunPlayerCharacter* Interactor)
 	FString ObjectString = DataTableKey.ToString() + TEXT("Object");
 	FName ObjectName = FName(*ObjectString);
 
-	URSBaseRelic* SpawnRelic = NewObject<URSBaseRelic>(Interactor, ObjectName, EObjectFlags::RF_Transient, RelicClass->StaticClass());
+	URSBaseRelic* SpawnRelic = NewObject<URSBaseRelic>(Interactor, RelicClass, ObjectName, EObjectFlags::RF_Transient);
 
 	URSRelicInventoryComponent* RSPlayerWeaponComponent = Interactor->GetRSRelicInventoryComponent();
 	if (SpawnRelic && RSPlayerWeaponComponent)

--- a/Source/RogShop/Actor/Dungeon/Relic/RSBaseRelic.cpp
+++ b/Source/RogShop/Actor/Dungeon/Relic/RSBaseRelic.cpp
@@ -8,3 +8,8 @@ void URSBaseRelic::ApplyEffect(ARSDunPlayerCharacter* OwnerCharacter)
 {
 
 }
+
+void URSBaseRelic::LoadEffect(ARSDunPlayerCharacter* OwnerCharacter)
+{
+
+}

--- a/Source/RogShop/Actor/Dungeon/Relic/RSBaseRelic.h
+++ b/Source/RogShop/Actor/Dungeon/Relic/RSBaseRelic.h
@@ -15,4 +15,6 @@ class ROGSHOP_API URSBaseRelic : public UObject
 	
 public:
 	virtual void ApplyEffect(ARSDunPlayerCharacter* OwnerCharacter);
+
+	virtual void LoadEffect(ARSDunPlayerCharacter* OwnerCharacter);
 };

--- a/Source/RogShop/Actor/Dungeon/Relic/RSStatusRelic.cpp
+++ b/Source/RogShop/Actor/Dungeon/Relic/RSStatusRelic.cpp
@@ -39,3 +39,16 @@ void URSStatusRelic::ApplyEffect(ARSDunPlayerCharacter* OwnerCharacter)
 		OwnerCharacter->IncreaseAttackSpeed(Amount);
 	}
 }
+
+void URSStatusRelic::LoadEffect(ARSDunPlayerCharacter* OwnerCharacter)
+{
+	if (TargetStatus == EStatus::HP)
+	{
+		// HP를 회복시키는 개념이므로 로드시 해당 기능을 제외한 스탯 상승 부분만 적용한다.
+		return;
+	}
+	else
+	{
+		ApplyEffect(OwnerCharacter);
+	}
+}

--- a/Source/RogShop/Actor/Dungeon/Relic/RSStatusRelic.h
+++ b/Source/RogShop/Actor/Dungeon/Relic/RSStatusRelic.h
@@ -25,6 +25,8 @@ class ROGSHOP_API URSStatusRelic : public URSBaseRelic
 public:
 	virtual void ApplyEffect(ARSDunPlayerCharacter* OwnerCharacter) override;
 
+	virtual void LoadEffect(ARSDunPlayerCharacter* OwnerCharacter) override;
+
 private:
 	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, category = "Status", meta = (AllowPrivateAccess = "true"))
 	EStatus TargetStatus;

--- a/Source/RogShop/Actor/MapGenerator/RSSpawnManager.cpp
+++ b/Source/RogShop/Actor/MapGenerator/RSSpawnManager.cpp
@@ -21,8 +21,9 @@
 #include "ItemInfoData.h"
 #include "RSDungeonGroundWeapon.h"
 #include "RSDungeonGroundIngredient.h"
-#include "RSTileBlocker.h"
+#include "RSDungeonGroundRelic.h"
 #include "RSDungeonGroundLifeEssence.h"
+#include "RSTileBlocker.h"
 
 // 외부에서 전달받은 월드 및 테이블 초기화
 void URSSpawnManager::Initialize(UWorld* InWorld, UGameInstance* GameInstance, int32 TargetLevelIndex)
@@ -198,6 +199,44 @@ void URSSpawnManager::SpawnGroundIngredientAtTransform(FName TargetName, FTransf
 			DungeonIngredient->InitGroundItemInfo(ItemName, false, TargetName, ItemStaticMesh);
 			DungeonIngredient->SetQuantity(Amount);
 			DungeonIngredient->RandImpulse();
+		}
+	}
+}
+
+void URSSpawnManager::SpawnGroundRelicAtTransform(FName TargetName, FTransform TargetTransform)
+{
+	UGameInstance* CurGameInstance = GetWorld()->GetGameInstance();
+	if (!CurGameInstance)
+	{
+		return;
+	}
+
+	URSDataSubsystem* DataSubsystem = CurGameInstance->GetSubsystem<URSDataSubsystem>();
+	if (!DataSubsystem)
+	{
+		return;
+	}
+
+	UDataTable* RelicInfoDataTable = DataSubsystem->RelicInfo;
+	UDataTable* RelicClassDataTable = DataSubsystem->RelicDetail;
+	if (!RelicInfoDataTable || !RelicClassDataTable)
+	{
+		return;
+	}
+
+	FItemInfoData* RelicInfoDataRow = RelicInfoDataTable->FindRow<FItemInfoData>(TargetName, TEXT("Get ItemInfoData"));
+	FDungeonRelicData* RelicClassDataRow = RelicClassDataTable->FindRow<FDungeonRelicData>(TargetName, TEXT("Get RelicClassData"));
+	if (RelicInfoDataRow && RelicClassDataRow)
+	{
+		ARSDungeonGroundRelic* GroundRelic = GetWorld()->SpawnActor<ARSDungeonGroundRelic>(DungeonGroundRelicClass, TargetTransform);
+		
+		if (GroundRelic)
+		{
+			FText ItemName = RelicInfoDataRow->ItemName;
+			UStaticMesh* ItemStaticMesh = RelicInfoDataRow->ItemStaticMesh;
+
+			GroundRelic->InitGroundItemInfo(ItemName, false, TargetName, ItemStaticMesh);
+			GroundRelic->SetRelicClass(RelicClassDataRow->RelicClass);
 		}
 	}
 }

--- a/Source/RogShop/Actor/MapGenerator/RSSpawnManager.h
+++ b/Source/RogShop/Actor/MapGenerator/RSSpawnManager.h
@@ -18,9 +18,10 @@ class ARSDunBossRoomPortal;
 class ARSDunNextStagePortal;
 class ARSDunLifeEssenceShop;
 class ARSDunBaseCharacter;
-class ARSDungeonGroundWeapon;
 class ARSTileBlocker;
+class ARSDungeonGroundWeapon;
 class ARSDungeonGroundIngredient;
+class ARSDungeonGroundRelic;
 class ARSDungeonGroundLifeEssence;
 
 /**
@@ -130,6 +131,9 @@ public:
 	UFUNCTION()
 	void SpawnGroundIngredientAtTransform(FName TargetName, FTransform TargetTransform, int32 Amount);
 
+	UFUNCTION()
+	void SpawnGroundRelicAtTransform(FName TargetName, FTransform TargetTransform);
+
 private:
 	UFUNCTION()
 	void SpawnGroundIngredientFromCharacter(ARSDunBaseCharacter* DiedCharacter);
@@ -143,6 +147,9 @@ private:
 
 	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Object", meta = (AllowPrivateAccess = "true"))
 	TSubclassOf<ARSDungeonGroundIngredient> DungeonGroundIngredientClass; // 아이템으로 드랍되는 요리 재료 클래스
+
+	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Object", meta = (AllowPrivateAccess = "true"))
+	TSubclassOf<ARSDungeonGroundRelic> DungeonGroundRelicClass; // 아이템으로 드랍되는 유물 클래스
 
 	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Object", meta = (AllowPrivateAccess = "true"))
 	TSubclassOf<ARSDungeonGroundLifeEssence> DungeonGroundLifeEssenceClass; // 아이템으로 드랍되는 생명의 정수 클래스

--- a/Source/RogShop/ActorComponent/RSRelicInventoryComponent.cpp
+++ b/Source/RogShop/ActorComponent/RSRelicInventoryComponent.cpp
@@ -174,7 +174,7 @@ void URSRelicInventoryComponent::LoadRelicData()
 				return;
 			}
 
-			URSBaseRelic* SpawnRelic = NewObject<URSBaseRelic>(OwnerCharacter, ObjectName, EObjectFlags::RF_Transient, RelicClassData->RelicClass);
+			URSBaseRelic* SpawnRelic = NewObject<URSBaseRelic>(OwnerCharacter, RelicClassData->RelicClass, ObjectName, EObjectFlags::RF_Transient);
 			if (!SpawnRelic)
 			{
 				return;
@@ -184,7 +184,7 @@ void URSRelicInventoryComponent::LoadRelicData()
 			AddRelic(CurRelicName);
 
 			// 유물의 로직을 적용
-			SpawnRelic->ApplyEffect(OwnerCharacter);
+			SpawnRelic->LoadEffect(OwnerCharacter);
 		}
 	}
 }

--- a/Source/RogShop/Character/RSDunBaseCharacter.cpp
+++ b/Source/RogShop/Character/RSDunBaseCharacter.cpp
@@ -7,9 +7,9 @@
 
 ARSDunBaseCharacter::ARSDunBaseCharacter()
 {	
-	MoveSpeed = 600.f;
 	MaxHP = 100.f;
 	HP = MaxHP;
+	MoveSpeed = 600.f;
 
 	GetCharacterMovement()->MaxWalkSpeed = MoveSpeed;
 

--- a/Source/RogShop/Character/RSDunPlayerCharacter.cpp
+++ b/Source/RogShop/Character/RSDunPlayerCharacter.cpp
@@ -713,6 +713,11 @@ float ARSDunPlayerCharacter::GetAttackPower() const
     return AttackPower;
 }
 
+void ARSDunPlayerCharacter::ChangeAttackPower(float Amount)
+{
+    AttackPower = Amount;
+}
+
 void ARSDunPlayerCharacter::IncreaseAttackPower(float Amount)
 {
     float NewAttackPower = AttackPower + Amount;
@@ -728,6 +733,11 @@ void ARSDunPlayerCharacter::DecreaseAttackPower(float Amount)
 float ARSDunPlayerCharacter::GetAttackSpeed() const
 {
     return AttackSpeed;
+}
+
+void ARSDunPlayerCharacter::ChangeAttackSpeed(float Amount)
+{
+    AttackSpeed = Amount;
 }
 
 void ARSDunPlayerCharacter::IncreaseAttackSpeed(float Amount)
@@ -752,7 +762,11 @@ void ARSDunPlayerCharacter::SaveStatus()
         return;
     }
 
+    StatusSaveGame->MaxHP = GetMaxHP();
     StatusSaveGame->HP = GetHP();
+    StatusSaveGame->MoveSpeed = GetMoveSpeed();
+    StatusSaveGame->AttackPower = GetAttackPower();
+    StatusSaveGame->AttackSpeed = GetAttackSpeed();
     StatusSaveGame->LifeEssence = LifeEssence;
 
     // 저장
@@ -790,14 +804,19 @@ void ARSDunPlayerCharacter::LoadStatus()
     if (!StatusLoadGame)
     {
         // 저장된 값이 없는 경우 기본값으로 설정
-        ChangeMaxHP(GetMaxHP());
-        ChangeHP(GetHP());
+
+        // 최대 체력, 현재 체력, 이동 속도는 부모 클래스에서 기본값을 설정합니다.
+        
+        // 공격력과 공격 속도는 캐릭터에 기본값을 설정합니다.
         return;
     }
     
     // 로드
-    ChangeMaxHP(GetMaxHP());
+    ChangeMaxHP(StatusLoadGame->MaxHP);
     ChangeHP(StatusLoadGame->HP);
+    ChangeMoveSpeed(StatusLoadGame->MoveSpeed);
+    ChangeAttackPower(StatusLoadGame->AttackPower);
+    ChangeAttackSpeed(StatusLoadGame->AttackSpeed);
     LifeEssence = StatusLoadGame->LifeEssence;
 }
 

--- a/Source/RogShop/Character/RSDunPlayerCharacter.h
+++ b/Source/RogShop/Character/RSDunPlayerCharacter.h
@@ -40,14 +40,6 @@ public:
 
 	void OnDeath();
 
-	virtual void ChangeMaxHP(float Amount) override;
-	virtual void IncreaseMaxHP(float Amount) override;
-	virtual void DecreaseMaxHP(float Amount) override;
-
-	virtual void ChangeHP(float Amount) override;
-	virtual void IncreaseHP(float Amount) override;
-	virtual void DecreaseHP(float Amount) override;
-
 protected:
 	UFUNCTION()
 	void Move(const FInputActionValue& value);
@@ -157,11 +149,21 @@ private:
 
 // 스탯 관련
 public:
+	virtual void ChangeMaxHP(float Amount) override;
+	virtual void IncreaseMaxHP(float Amount) override;
+	virtual void DecreaseMaxHP(float Amount) override;
+
+	virtual void ChangeHP(float Amount) override;
+	virtual void IncreaseHP(float Amount) override;
+	virtual void DecreaseHP(float Amount) override;
+
 	float GetAttackPower() const;
+	void ChangeAttackPower(float Amount);
 	void IncreaseAttackPower(float Amount);
 	void DecreaseAttackPower(float Amount);
 
 	float GetAttackSpeed() const;
+	void ChangeAttackSpeed(float Amount);
 	void IncreaseAttackSpeed(float Amount);
 	void DecreaseAttackSpeed(float Amount);
 

--- a/Source/RogShop/CheatManager/RSCheatManager.cpp
+++ b/Source/RogShop/CheatManager/RSCheatManager.cpp
@@ -6,8 +6,11 @@
 #include "RSDunPlayerController.h"
 #include "RSGameInstance.h"
 #include "RSDunPlayerCharacter.h"
-
+#include "RSDataSubsystem.h"
+#include "ItemInfoData.h"
+#include "RSSpawnManagerAccessor.h"
 #include "Blueprint/UserWidget.h"
+#include "GameFramework/GameModeBase.h"
 #include "Kismet/GameplayStatics.h"
 #include "RogShop/UtilDefine.h"
 
@@ -98,6 +101,35 @@ void URSCheatManager::SpawnMonster(FString MonsterName)
     else
     {
         RS_LOG_DEBUG("Monster not found for key: %s", *Key);
+    }
+}
+
+void URSCheatManager::SpawnRelic(FName RelicName)
+{
+    UWorld* World = GetWorld();
+    if (!World)
+    {
+        return;
+    }
+
+    IRSSpawnManagerAccessor* SpawnManagerAccessor = World->GetAuthGameMode<IRSSpawnManagerAccessor>();
+    URSSpawnManager* SpawnManager = nullptr;
+    if (SpawnManagerAccessor)
+    {
+        SpawnManager = SpawnManagerAccessor->GetSpawnManager();
+    }
+
+    if (SpawnManager)
+    {
+        FVector PlayerLocation = GetOuterAPlayerController()->GetPawn()->GetActorLocation();
+        FVector Forward = GetOuterAPlayerController()->GetPawn()->GetActorForwardVector();
+
+        FTransform TargetTransform;
+        TargetTransform.SetLocation(PlayerLocation + Forward * 100.0f);
+        TargetTransform.SetRotation(FQuat::Identity);
+        TargetTransform.SetScale3D(FVector::OneVector);
+
+        SpawnManager->SpawnGroundRelicAtTransform(RelicName, TargetTransform);
     }
 }
 

--- a/Source/RogShop/CheatManager/RSCheatManager.h
+++ b/Source/RogShop/CheatManager/RSCheatManager.h
@@ -33,6 +33,9 @@ public:
 	void SpawnMonster(FString MonsterName);
 
 	UFUNCTION(Exec)
+	void SpawnRelic(FName RelicName);
+
+	UFUNCTION(Exec)
 	void SpawnDunShopNPC();
   
 	UFUNCTION(exec)

--- a/Source/RogShop/SaveGame/Dungeon/RSDungeonStatusSaveGame.h
+++ b/Source/RogShop/SaveGame/Dungeon/RSDungeonStatusSaveGame.h
@@ -16,7 +16,19 @@ class ROGSHOP_API URSDungeonStatusSaveGame : public USaveGame
 	
 public:
 	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	float MaxHP; // 플레이어 캐릭터의 최대 체력
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite)
 	float HP; // 플레이어 캐릭터의 체력
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	float MoveSpeed; // 플레이어 캐릭터의 이동 속도
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	float AttackPower;	// 플레이어 캐릭터의 공격력
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	float AttackSpeed;	// 플레이어 캐릭터의 공격 속도
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite)
 	int32 LifeEssence;	// 던전 재화


### PR DESCRIPTION
데이터 테이블의 유물에 대한 RowName을 수정했습니다.

스폰 매니저에 유물을 스폰시키는 함수를 추가하여 구현했습니다.

유물이 사용되는 함수와 세이브 파일을 불러올 때 적용될 함수를 분리해주었습니다.
이 함수를 분리한 이유는 게임 중에 획득되어 1회성으로 사용되는 유물의 경우 세이브 파일을 로드할 때 사용되면 안되기 때문에 분리해주었습니다.

치트 매니저에서 유물을 소환할 수 있는 함수를 추가해주었습니다.
매개변수로 유물에 대한 데이터테이블의 RowName을 받습니다.

세이브 파일에서 플레이어 캐릭터의 체력과 던전 재화를 제외한 다른 데이터는 저장하지 않았는데 이를 수정했습니다.
저장에 추가된 데이터는 최대 체력, 이동 속도, 공격력, 공격 속도가 있습니다.
해당 데이터에 대한 세이브와 로드를 구현해주었습니다.

현재 유물은 획득시 1회성으로 플레이어 캐릭터에 스탯을 변화시키는 것을 구현했습니다.