### PR TITLE
[Add] 몬스터 처치시 발동되는 유물 클래스 구현

### DIFF
--- a/Content/Blueprints/Actor/Dungeon/Relic/BP_AttackPower_Relic.uasset
+++ b/Content/Blueprints/Actor/Dungeon/Relic/BP_AttackPower_Relic.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c12152e465446ca1b25dedc499fbb0fa7ca7f066aa03d4d6db1e8f1c6bb3bb2d
-size 5671
+oid sha256:55d5d8273afd8fbd05527580b0bba3e5d9d9d339c09423cd5cb119dd4fd4436a
+size 5689

--- a/Content/Blueprints/Actor/Dungeon/Relic/BP_AttackSpeed_Relic.uasset
+++ b/Content/Blueprints/Actor/Dungeon/Relic/BP_AttackSpeed_Relic.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1b1dd7c0e9f825fd7673d4bfba7daceb303997723c894dadaab7536299e13e14
-size 5671
+oid sha256:dd3f810315ac30ac98aedea4a7fa9cb517117b39add57b3ad238d9699c6b76ec
+size 5689

--- a/Content/Blueprints/Actor/Dungeon/Relic/BP_HP_Relic.uasset
+++ b/Content/Blueprints/Actor/Dungeon/Relic/BP_HP_Relic.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c9649fe61581b1f8fd02a9356978efe3bd8e6103146d64d8a066562b0794307d
-size 5976
+oid sha256:0d889edbf8f8ed4b92cc93dfb76d52f680695b3b8230d813586a3705882416be
+size 5994

--- a/Content/Blueprints/Actor/Dungeon/Relic/BP_KillAttackPower_Relic.uasset
+++ b/Content/Blueprints/Actor/Dungeon/Relic/BP_KillAttackPower_Relic.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dfdcacd5186447f551abd3a45791d3a301068e22a0d3d59566ea0247595aa099
+size 5810

--- a/Content/Blueprints/Actor/Dungeon/Relic/BP_KillAttackSpeed_Relic.uasset
+++ b/Content/Blueprints/Actor/Dungeon/Relic/BP_KillAttackSpeed_Relic.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4e9cd012c526f2b6ba0a7d36b27752625bd8e8efd7e4f9270d527179216ee4c6
+size 5810

--- a/Content/Blueprints/Actor/Dungeon/Relic/BP_KillHP_Relic.uasset
+++ b/Content/Blueprints/Actor/Dungeon/Relic/BP_KillHP_Relic.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6a50dafd485f4bba655efa112b17790d5426e9a2806acee21434a8ba642a406f
+size 5684

--- a/Content/Blueprints/Actor/Dungeon/Relic/BP_KillMaxHP_Relic.uasset
+++ b/Content/Blueprints/Actor/Dungeon/Relic/BP_KillMaxHP_Relic.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9b04c6fba8f9ffc1b272eda06556084ad411024f0dba40ae959756fce461a5ed
+size 6157

--- a/Content/Blueprints/Actor/Dungeon/Relic/BP_KillMoveSpeed_Relic.uasset
+++ b/Content/Blueprints/Actor/Dungeon/Relic/BP_KillMoveSpeed_Relic.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bbe73ba6f0b18497aa965c0efa309a145d1c2b228f3fdfa09031aeb60a6484eb
+size 5782

--- a/Content/Blueprints/Actor/Dungeon/Relic/BP_MaxHP_Relic.uasset
+++ b/Content/Blueprints/Actor/Dungeon/Relic/BP_MaxHP_Relic.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:df3cd781c4ca8cccae50aaf76f8d5acf330bc01a1f052d81eb138b79307cc9d9
-size 5587
+oid sha256:6a2fb2d5e388a83b86a2d312a6a2907a3abe8aae49683772cc479d7c3bc013b6
+size 5605

--- a/Content/Blueprints/Actor/Dungeon/Relic/BP_MoveSpeed_Relic.uasset
+++ b/Content/Blueprints/Actor/Dungeon/Relic/BP_MoveSpeed_Relic.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c6bc23134cbd286e1a702fc1c5600d7718360b9c9cbe58633ffa6acdac2d15d8
-size 5643
+oid sha256:8fc9ce54de3d941887c756b42fd269eeaa64e91a8fc3307f425244b99d8b2a8b
+size 5661

--- a/Content/Datas/RelicDetailDataTable.uasset
+++ b/Content/Datas/RelicDetailDataTable.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1e0f805e2649b5956eae37d141b20b39d100104da7ef27c568881d8696c9f2e9
-size 3311
+oid sha256:8e4af83db4e24bd7084561af4554abefac95e7eed5cb4c7faafd1518a95abb8a
+size 4530

--- a/Content/Datas/RelicInfoDataTable.uasset
+++ b/Content/Datas/RelicInfoDataTable.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4300dcdf9cd588ff7097766c018aa5c4c783f4eb6542f1d8cfc3b22899565424
-size 6268
+oid sha256:118f9afb000429470cf90cc7fd291b235cee1acc1b61a7fb4017661eaf2d11a3
+size 9286

--- a/Source/RogShop/Actor/Dungeon/Relic/RSKillStatusRelic.cpp
+++ b/Source/RogShop/Actor/Dungeon/Relic/RSKillStatusRelic.cpp
@@ -1,0 +1,81 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "RSKillStatusRelic.h"
+#include "GameFramework/GameModeBase.h"
+#include "GameFramework/CharacterMovementComponent.h"
+#include "RSSpawnManagerAccessor.h"
+#include "RSDunBaseCharacter.h"
+#include "RSDunPlayerCharacter.h"
+
+void URSKillStatusRelic::ApplyEffect(ARSDunPlayerCharacter* OwnerCharacter)
+{
+	if (!OwnerCharacter)
+	{
+		return;
+	}
+
+	IRSSpawnManagerAccessor* SpawnManagerAccessor = GetWorld()->GetAuthGameMode<IRSSpawnManagerAccessor>();
+	if (SpawnManagerAccessor)
+	{
+		URSSpawnManager* SpawnManager = SpawnManagerAccessor->GetSpawnManager();
+		if (SpawnManager)
+		{
+			SpawnManager->OnEnemySpawn.AddDynamic(this, &URSKillStatusRelic::BindFunc);
+		}
+	}
+
+	PlayerCharacter = OwnerCharacter;
+}
+
+void URSKillStatusRelic::LoadEffect(ARSDunPlayerCharacter* OwnerCharacter)
+{
+	ApplyEffect(OwnerCharacter);
+}
+
+void URSKillStatusRelic::BindFunc(ARSDunBaseCharacter* TargetCharacter)
+{
+	TargetCharacter->OnCharacterDied.AddDynamic(this, &URSKillStatusRelic::KillEffectStatus);
+}
+
+void URSKillStatusRelic::KillEffectStatus(ARSDunBaseCharacter* DeadCharacter)
+{
+	if (!PlayerCharacter.IsValid())
+	{
+		return;
+	}
+
+	// 로직 실행 확률이 더 낮은 경우 실행 취소
+	int32 Rand = FMath::RandRange(1, 100);
+	if (Rand > Persent)
+	{
+		return;
+	}
+
+	if (TargetStatus == ECharacterStatus::HP)
+	{
+		PlayerCharacter->IncreaseHP(Amount);
+	}
+	else if (TargetStatus == ECharacterStatus::MaxHP)
+	{
+		PlayerCharacter->IncreaseMaxHP(Amount);
+	}
+	else if (TargetStatus == ECharacterStatus::MoveSpeed)
+	{
+		UCharacterMovementComponent* MovementComp = PlayerCharacter->GetCharacterMovement();
+		if (MovementComp)
+		{
+			float CurrentSpeed = MovementComp->GetMaxSpeed();
+			CurrentSpeed += Amount;
+			PlayerCharacter->ChangeMoveSpeed(CurrentSpeed);
+		}
+	}
+	else if (TargetStatus == ECharacterStatus::AttackPower)
+	{
+		PlayerCharacter->IncreaseAttackPower(Amount);
+	}
+	else if (TargetStatus == ECharacterStatus::AttackSpeed)
+	{
+		PlayerCharacter->IncreaseAttackSpeed(Amount);
+	}
+}

--- a/Source/RogShop/Actor/Dungeon/Relic/RSKillStatusRelic.h
+++ b/Source/RogShop/Actor/Dungeon/Relic/RSKillStatusRelic.h
@@ -1,0 +1,47 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "RSBaseRelic.h"
+#include "CharacterStatus.h"
+#include "RSKillStatusRelic.generated.h"
+
+class ARSDunBaseCharacter;
+
+// 몬스터 처치시 플레이어 캐릭터의 특정 스탯이 올라가는 동작을 수행합니다.
+UCLASS(Blueprintable)
+class ROGSHOP_API URSKillStatusRelic : public URSBaseRelic
+{
+	GENERATED_BODY()
+
+public:
+	virtual void ApplyEffect(ARSDunPlayerCharacter* OwnerCharacter);
+
+	virtual void LoadEffect(ARSDunPlayerCharacter* OwnerCharacter);
+
+private:
+	// 해당 유물을 획득 했을 때에만 바인딩할 수 있도록 바인딩이 2중으로 이루어져있습니다.
+	// 몬스터가 죽었을 때 호출될 함수가 몬스터가 스폰됐을 때 바인딩됩니다.
+
+	// 적(몬스터, 보스)가 스폰될 때 바인딩될 함수를 연결하는 함수
+	UFUNCTION()
+	void BindFunc(ARSDunBaseCharacter* TargetCharacter);
+
+	// 적이 죽었을 때 호출될 함수
+	UFUNCTION()
+	void KillEffectStatus(ARSDunBaseCharacter* TargetCharacter);
+
+private:
+	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, category = "Status", meta = (AllowPrivateAccess = "true"))
+	ECharacterStatus TargetStatus;
+
+	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, category = "Status", meta = (AllowPrivateAccess = "true"))
+	float Amount;
+
+	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, category = "Status", meta = (AllowPrivateAccess = "true"))
+	int32 Persent;
+
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, category = "Status|OwnerCharacter", meta = (AllowPrivateAccess = "true"))
+	TWeakObjectPtr<ARSDunPlayerCharacter> PlayerCharacter;
+};

--- a/Source/RogShop/Actor/Dungeon/Relic/RSStatusRelic.cpp
+++ b/Source/RogShop/Actor/Dungeon/Relic/RSStatusRelic.cpp
@@ -12,15 +12,15 @@ void URSStatusRelic::ApplyEffect(ARSDunPlayerCharacter* OwnerCharacter)
 		return;
 	}
 
-	if (TargetStatus == EStatus::HP)
+	if (TargetStatus == ECharacterStatus::HP)
 	{
 		OwnerCharacter->IncreaseHP(Amount);
 	}
-	else if (TargetStatus == EStatus::MaxHP)
+	else if (TargetStatus == ECharacterStatus::MaxHP)
 	{
 		OwnerCharacter->IncreaseMaxHP(Amount);
 	}
-	else if (TargetStatus == EStatus::MoveSpeed)
+	else if (TargetStatus == ECharacterStatus::MoveSpeed)
 	{
 		UCharacterMovementComponent* MovementComp = OwnerCharacter->GetCharacterMovement();
 		if (MovementComp)
@@ -30,11 +30,11 @@ void URSStatusRelic::ApplyEffect(ARSDunPlayerCharacter* OwnerCharacter)
 			OwnerCharacter->ChangeMoveSpeed(CurrentSpeed);
 		}
 	}
-	else if (TargetStatus == EStatus::AttackPower)
+	else if (TargetStatus == ECharacterStatus::AttackPower)
 	{
 		OwnerCharacter->IncreaseAttackPower(Amount);
 	}
-	else if (TargetStatus == EStatus::AttackSpeed)
+	else if (TargetStatus == ECharacterStatus::AttackSpeed)
 	{
 		OwnerCharacter->IncreaseAttackSpeed(Amount);
 	}
@@ -42,7 +42,7 @@ void URSStatusRelic::ApplyEffect(ARSDunPlayerCharacter* OwnerCharacter)
 
 void URSStatusRelic::LoadEffect(ARSDunPlayerCharacter* OwnerCharacter)
 {
-	if (TargetStatus == EStatus::HP)
+	if (TargetStatus == ECharacterStatus::HP)
 	{
 		// HP를 회복시키는 개념이므로 로드시 해당 기능을 제외한 스탯 상승 부분만 적용한다.
 		return;

--- a/Source/RogShop/Actor/Dungeon/Relic/RSStatusRelic.h
+++ b/Source/RogShop/Actor/Dungeon/Relic/RSStatusRelic.h
@@ -4,18 +4,8 @@
 
 #include "CoreMinimal.h"
 #include "RSBaseRelic.h"
+#include "CharacterStatus.h"
 #include "RSStatusRelic.generated.h"
-
-UENUM(BlueprintType)
-enum class EStatus : uint8
-{
-	NONE,
-	HP,
-	MaxHP,
-	MoveSpeed,
-	AttackPower,
-	AttackSpeed,
-};
 
 UCLASS(Blueprintable)
 class ROGSHOP_API URSStatusRelic : public URSBaseRelic
@@ -29,7 +19,7 @@ public:
 
 private:
 	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, category = "Status", meta = (AllowPrivateAccess = "true"))
-	EStatus TargetStatus;
+	ECharacterStatus TargetStatus;
 
 	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, category = "Status", meta = (AllowPrivateAccess = "true"))
 	float Amount;

--- a/Source/RogShop/Actor/MapGenerator/RSSpawnManager.cpp
+++ b/Source/RogShop/Actor/MapGenerator/RSSpawnManager.cpp
@@ -600,6 +600,8 @@ void URSSpawnManager::SpawnBossMonster()
 	BossMonster->OnCharacterDied.AddDynamic(this, &URSSpawnManager::SpawnGroundIngredientFromCharacter);
 	BossMonster->OnCharacterDied.AddDynamic(this, &URSSpawnManager::SpawnGroundLifeEssenceFromCharacter);
 
+	// 적이 스폰됐음을 알려 필요한 함수 바인딩
+	OnEnemySpawn.Broadcast(BossMonster);
 }
 
 void URSSpawnManager::SpawnMonstersAtTile(FIntPoint TileCoord) // 특정 타일 좌표에 몬스터 스폰하는 함수
@@ -670,6 +672,9 @@ void URSSpawnManager::SpawnMonstersAtTile(FIntPoint TileCoord) // 특정 타일 
 			// 사망 시 오브젝트 스폰 함수 바인딩
 			Monster->OnCharacterDied.AddDynamic(this, &URSSpawnManager::SpawnGroundIngredientFromCharacter);
 			Monster->OnCharacterDied.AddDynamic(this, &URSSpawnManager::SpawnGroundLifeEssenceFromCharacter);
+
+			// 적이 스폰됐음을 알려 필요한 함수 바인딩
+			OnEnemySpawn.Broadcast(Monster);
 
 			AliveMonstersPerTile.FindOrAdd(TileCoord) += 1;
 			TotalSpawned++;

--- a/Source/RogShop/Actor/MapGenerator/RSSpawnManager.h
+++ b/Source/RogShop/Actor/MapGenerator/RSSpawnManager.h
@@ -24,6 +24,8 @@ class ARSDungeonGroundIngredient;
 class ARSDungeonGroundRelic;
 class ARSDungeonGroundLifeEssence;
 
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnEnemySpawn, ARSDunBaseCharacter*, SpawnCharacter);
+
 /**
  * URSSpawnManager
  * 레벨 내 플레이어, 몬스터, 상점 NPC 스폰을 담당하는 매니저
@@ -66,6 +68,13 @@ private:
 	
 	TSet<FIntPoint> SpawnedTiles; // 타일별로 몬스터가 한 번이라도 스폰됐는지	
 	TMap<FIntPoint, bool> ClearedTiles; // 타일별로 클리어(= 몬스터 전멸) 여부
+#pragma endregion
+
+#pragma region Delegate
+public:
+	// 적(몬스터, 보스)가 스폰될 때 바인딩될 함수를 연결하는 델리게이트
+	UPROPERTY(BlueprintAssignable)
+	FOnEnemySpawn OnEnemySpawn;
 #pragma endregion
 
 #pragma region Wall

--- a/Source/RogShop/Character/RSDunPlayerCharacter.cpp
+++ b/Source/RogShop/Character/RSDunPlayerCharacter.cpp
@@ -106,9 +106,15 @@ void ARSDunPlayerCharacter::BeginPlay()
         return;
     }
 
+    LoadStatus();
+
     SaveGameSubsystem->OnSaveRequested.AddDynamic(this, &ARSDunPlayerCharacter::SaveStatus);
 
-    LoadStatus();
+    ARSDunPlayerController* DunPlayerController = GetController<ARSDunPlayerController>();
+    if (DunPlayerController)
+    {
+        OnCharacterDied.AddDynamic(DunPlayerController, &ARSDunPlayerController::ShowPlayerDeathWidget);
+    }
 }
 
 // Called every frame
@@ -804,6 +810,9 @@ void ARSDunPlayerCharacter::LoadStatus()
     if (!StatusLoadGame)
     {
         // 저장된 값이 없는 경우 기본값으로 설정
+        // 바인딩된 함수를 호출하기 위한 함수 호출
+        ChangeMaxHP(GetMaxHP());
+        ChangeHP(GetHP());
 
         // 최대 체력, 현재 체력, 이동 속도는 부모 클래스에서 기본값을 설정합니다.
         

--- a/Source/RogShop/Controller/RSDunPlayerController.cpp
+++ b/Source/RogShop/Controller/RSDunPlayerController.cpp
@@ -30,8 +30,6 @@ void ARSDunPlayerController::BeginPlay()
     AddMapping();
 
     InitializeRSDunMainWidget();
-
-    BindCharacterDelegates();
 }
 
 void ARSDunPlayerController::AddMapping()
@@ -141,15 +139,6 @@ void ARSDunPlayerController::HideInteractWidget()
     if (RSDunMainHUDWidget)
     {
         RSDunMainHUDWidget->HideInteractWidget();
-    }
-}
-
-void ARSDunPlayerController::BindCharacterDelegates()
-{
-    ARSDunPlayerCharacter* CurPawn = GetPawn<ARSDunPlayerCharacter>();
-    if (CurPawn)
-    {
-        CurPawn->OnCharacterDied.AddDynamic(this, &ARSDunPlayerController::ShowPlayerDeathWidget);
     }
 }
 

--- a/Source/RogShop/Controller/RSDunPlayerController.h
+++ b/Source/RogShop/Controller/RSDunPlayerController.h
@@ -108,10 +108,6 @@ private:
 	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "UI", meta = (AllowPrivateAccess = "true"))
 	TObjectPtr<UUserWidget> RSDeathWidget;
 
-// 캐릭터의 델리게이트에 바인딩하는 함수를 모은 함수
-private:
-	void BindCharacterDelegates();
-
 // 이벤트 디스패처
 public:
 	UPROPERTY(BlueprintAssignable)

--- a/Source/RogShop/Enum/CharacterStatus.cpp
+++ b/Source/RogShop/Enum/CharacterStatus.cpp
@@ -1,0 +1,4 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "CharacterStatus.h"

--- a/Source/RogShop/Enum/CharacterStatus.h
+++ b/Source/RogShop/Enum/CharacterStatus.h
@@ -1,0 +1,16 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+
+UENUM(BlueprintType)
+enum class ECharacterStatus : uint8
+{
+	NONE,
+	HP,
+	MaxHP,
+	MoveSpeed,
+	AttackPower,
+	AttackSpeed,
+};

--- a/Source/RogShop/RogShop.Build.cs
+++ b/Source/RogShop/RogShop.Build.cs
@@ -39,6 +39,7 @@ public class RogShop : ModuleRules
             Path.Combine(ModuleDirectory, "SaveGame", "Tycoon"),
             Path.Combine(ModuleDirectory, "SaveGame", "Option"),
             Path.Combine(ModuleDirectory, "Struct"),
+            Path.Combine(ModuleDirectory, "Enum"),
             Path.Combine(ModuleDirectory, "DeveloperSettings"),
         });
 


### PR DESCRIPTION
몬스터 처치시 일정 확률로 플레이어 캐릭터의 스탯이 향상되는 유물을 추가했습니다.

기존 유물의 효과 값을 변경했습니다.

처치시 효과는 몬스터가 사망했음을 알리는 델리게이트가 브로드캐스트 될 때 실행됩니다.
해당 델리게이트에 실행 함수를 바인딩 하기 위해서 스폰 매니저가 몬스터를 스폰할 때, 실행 함수를 바인딩 합니다.

몬스터에 실행 함수를 바인딩 하기 위해서 스폰 매니저에서 관련 함수를 바인딩하는 델리게이트를 가집니다.

플레이어 캐릭터의 스탯을 별도의 코드 파일로 이동했습니다.

