### PR TITLE
[Add] 던전 가이드 위젯 및 커스텀 버튼 파일 추가

### DIFF
--- a/Config/DefaultGame.ini
+++ b/Config/DefaultGame.ini
@@ -19,6 +19,7 @@ WeaponDetailDataTable=/Game/Datas/WeaponDetailDataTable.WeaponDetailDataTable
 RelicDetailDataTable=/Game/Datas/RelicDetailDataTable.RelicDetailDataTable
 DesetMonsterSpawnGroupDataTable=/Game/Datas/DesertMonsterSpawnGroupDataTable1.DesertMonsterSpawnGroupDataTable1
 CaveMonsterSpawnGroupDataTable=/Game/Datas/CaveMonsterSpawnGroupDataTable.CaveMonsterSpawnGroupDataTable
+GuideDataTable=/Game/Datas/GuideDataTable.GuideDataTable
 
 [/Script/UnrealEd.ProjectPackagingSettings]
 Build=IfProjectHasCode

--- a/Content/Blueprints/Widgets/InGame/WBP_GuideButtonWidget.uasset
+++ b/Content/Blueprints/Widgets/InGame/WBP_GuideButtonWidget.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:41a76b8cbf7520362e6b5f2e39dc17c7d45bf0d89a495711ffe1f958f25b4828
+size 24943

--- a/Content/Blueprints/Widgets/InGame/WBP_GuideWidget.uasset
+++ b/Content/Blueprints/Widgets/InGame/WBP_GuideWidget.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7d07a1086f7e60e613dbfd8978772b9f6a0466ee8c8563745c845c9b563fd051
+size 45908

--- a/Content/Datas/GuideDataTable.uasset
+++ b/Content/Datas/GuideDataTable.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9b209be78228c1b2f267cd60ad93d69518b1d04c93aec6411c1f783a84a40c08
+size 6636

--- a/Source/RogShop/DataTable/GuideData.cpp
+++ b/Source/RogShop/DataTable/GuideData.cpp
@@ -1,0 +1,4 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "GuideData.h"

--- a/Source/RogShop/DataTable/GuideData.h
+++ b/Source/RogShop/DataTable/GuideData.h
@@ -1,0 +1,23 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Engine/DataTable.h"
+#include "GuideData.generated.h"
+
+USTRUCT(BlueprintType)
+struct ROGSHOP_API FGuideData : public FTableRowBase
+{
+	GENERATED_BODY()
+
+public:
+    UPROPERTY(EditAnywhere, BlueprintReadWrite)
+    FText ButtonTitle;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite)
+    FText GuideDescription;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite)
+    TObjectPtr<UTexture2D> GuideImage;
+};

--- a/Source/RogShop/DeveloperSettings/RSDataSubsystemSettings.h
+++ b/Source/RogShop/DeveloperSettings/RSDataSubsystemSettings.h
@@ -50,4 +50,7 @@ public:
 
 	UPROPERTY(Config, EditAnywhere)
 	TSoftObjectPtr<UDataTable> DungeonLevelDataTable;
+
+	UPROPERTY(Config, EditAnywhere)
+	TSoftObjectPtr<UDataTable> GuideDataTable;
 };

--- a/Source/RogShop/GameInstanceSubsystem/RSDataSubsystem.cpp
+++ b/Source/RogShop/GameInstanceSubsystem/RSDataSubsystem.cpp
@@ -23,6 +23,7 @@ void URSDataSubsystem::Initialize(FSubsystemCollectionBase& Collection)
 	CaveMonsterSpawnGroup = DataSettings->CaveMonsterSpawnGroupDataTable.LoadSynchronous();
 	Monster = DataSettings->MonsterDataTable.LoadSynchronous();
 	DungeonLevel = DataSettings->DungeonLevelDataTable.LoadSynchronous();
+	Guide = DataSettings->GuideDataTable.LoadSynchronous();
 
 	check(Food)
 	check(IngredientInfo)
@@ -36,4 +37,5 @@ void URSDataSubsystem::Initialize(FSubsystemCollectionBase& Collection)
 	check(CaveMonsterSpawnGroup)
 	check(Monster)
 	check(DungeonLevel)
+	check(Guide)
 }

--- a/Source/RogShop/GameInstanceSubsystem/RSDataSubsystem.h
+++ b/Source/RogShop/GameInstanceSubsystem/RSDataSubsystem.h
@@ -53,4 +53,7 @@ public:
 
 	UPROPERTY()
 	TObjectPtr<UDataTable> DungeonLevel;
+
+	UPROPERTY()
+	TObjectPtr<UDataTable> Guide;
 };

--- a/Source/RogShop/Widget/InGame/RSGuideButtonWidget.cpp
+++ b/Source/RogShop/Widget/InGame/RSGuideButtonWidget.cpp
@@ -1,0 +1,30 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#include "RSGuideButtonWidget.h"
+#include "Components/Button.h"
+#include "Components/TextBlock.h"
+
+void URSGuideButtonWidget::NativeConstruct()
+{
+	Super::NativeConstruct();
+
+	if (GuideButton)
+	{
+		GuideButton->OnClicked.AddDynamic(this, &URSGuideButtonWidget::HandleButtonClicked);
+	}
+}
+
+void URSGuideButtonWidget::SetGuideButtonData(FName InGuideID, const FText& InGuideButtonText)
+{
+	GuideID = InGuideID;
+
+	if (GuideButtonText)
+	{
+		GuideButtonText->SetText(InGuideButtonText);
+	}
+}
+
+void URSGuideButtonWidget::HandleButtonClicked()
+{
+	OnGuideButtonClicked.Broadcast(GuideID);
+}

--- a/Source/RogShop/Widget/InGame/RSGuideButtonWidget.h
+++ b/Source/RogShop/Widget/InGame/RSGuideButtonWidget.h
@@ -1,0 +1,45 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Blueprint/UserWidget.h"
+#include "RSGuideButtonWidget.generated.h"
+
+class UButton;
+class UTextBlock;
+
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnGuideButtonClicked, FName, CategoryID);
+
+UCLASS()
+class ROGSHOP_API URSGuideButtonWidget : public UUserWidget
+{
+	GENERATED_BODY()
+	
+
+public:
+	// 카테고리 아이디 세팅 + 버튼 텍스트 세팅용 함수
+	UFUNCTION()
+	void SetGuideButtonData(FName InGuideID, const FText& InGuideButtonText);
+
+	// 버튼 클릭 이벤트 델리게이트 (부모 위젯에서 바인딩)
+	UPROPERTY(BlueprintAssignable)
+	FOnGuideButtonClicked OnGuideButtonClicked;
+
+protected:
+	virtual void NativeConstruct() override;
+
+	UFUNCTION()
+	void HandleButtonClicked();
+
+private:
+	UPROPERTY(meta = (BindWidget))
+	TObjectPtr<UButton> GuideButton;
+
+	UPROPERTY(meta = (BindWidget))
+	TObjectPtr<UTextBlock> GuideButtonText;
+
+	// 카테고리 아이디 (데이터테이블 RowName 저장)
+	UPROPERTY()
+	FName GuideID;
+};

--- a/Source/RogShop/Widget/InGame/RSGuideWidget.cpp
+++ b/Source/RogShop/Widget/InGame/RSGuideWidget.cpp
@@ -1,0 +1,86 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#include "RSGuideWidget.h"
+#include "RSDataSubsystem.h"
+#include "RSGuideButtonWidget.h"
+
+#include "Components/ScrollBox.h"
+#include "Components/TextBlock.h"
+#include "Components/Image.h"
+
+void URSGuideWidget::NativeOnInitialized()
+{
+	Super::NativeOnInitialized();
+
+	CreateButtons();
+}
+
+void URSGuideWidget::CreateButtons()
+{
+    URSDataSubsystem* DataSubsystem = GetGameInstance()->GetSubsystem<URSDataSubsystem>();
+
+    if (!DataSubsystem || !DataSubsystem->Guide)
+    {
+        return;
+    }
+
+    if (!GuideScrollBox)
+    {
+        return;
+    }
+
+    GuideScrollBox->ClearChildren();
+
+    TArray<FName> RowNames = DataSubsystem->Guide->GetRowNames();
+
+    for (const FName& RowName : RowNames)
+    {
+        const FGuideData* RowData = DataSubsystem->Guide->FindRow<FGuideData>(RowName, TEXT("CreateButtons"));
+
+        if (!RowData)
+        {
+            continue;
+        }
+
+        URSGuideButtonWidget* GuideButton = CreateWidget<URSGuideButtonWidget>(GetWorld(), GuideButtonClass);
+
+        if (!GuideButton)
+        {
+            continue;
+        }
+
+        GuideButton->SetGuideButtonData(RowName, RowData->ButtonTitle);
+
+        // 클릭 이벤트 바인딩
+        GuideButton->OnGuideButtonClicked.AddDynamic(this, &URSGuideWidget::OnGuideButtonClicked);
+
+        GuideScrollBox->AddChild(GuideButton);
+    }
+}
+
+void URSGuideWidget::OnGuideButtonClicked(FName CategoryID)
+{
+    URSDataSubsystem* DataSubsystem = GetGameInstance()->GetSubsystem<URSDataSubsystem>();
+
+    if (!DataSubsystem || !DataSubsystem->Guide)
+    {
+        return;
+    }
+
+    const FGuideData* GuideData = DataSubsystem->Guide->FindRow<FGuideData>(CategoryID, TEXT("OnGuideButtonClicked"));
+
+    if (!GuideData)
+    {
+        return;
+    }
+
+    if (GuideText)
+    {
+        GuideText->SetText(GuideData->GuideDescription);
+    }
+
+    if (GuideImage)
+    {
+        GuideImage->SetBrushFromTexture(GuideData->GuideImage);
+    }
+}

--- a/Source/RogShop/Widget/InGame/RSGuideWidget.h
+++ b/Source/RogShop/Widget/InGame/RSGuideWidget.h
@@ -1,0 +1,42 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Blueprint/UserWidget.h"
+#include "GuideData.h"
+#include "RSGuideWidget.generated.h"
+
+class URSGuideButtonWidget;
+class UScrollBox;
+class UTextBlock;
+class UImage;
+
+UCLASS()
+class ROGSHOP_API URSGuideWidget : public UUserWidget
+{
+	GENERATED_BODY()
+	
+protected:
+	virtual void NativeOnInitialized() override;
+
+	// 버튼 클릭 시 호출되는 함수
+	UFUNCTION()
+	void OnGuideButtonClicked(FName CategoryID);
+
+private:
+	// 데이터테이블에서 버튼 리스트 동적 생성 함수
+	void CreateButtons();
+
+	UPROPERTY(meta = (BindWidget))
+	TObjectPtr<UScrollBox> GuideScrollBox;
+
+	UPROPERTY(meta = (BindWidget))
+	TObjectPtr<UTextBlock> GuideText;
+
+	UPROPERTY(meta = (BindWidget))
+	TObjectPtr<UImage> GuideImage;
+
+	UPROPERTY(EditDefaultsOnly)
+	TSubclassOf<URSGuideButtonWidget> GuideButtonClass;
+};


### PR DESCRIPTION
- 던전 가이드 위젯 및 버튼 프레임 추가
- 버튼 동적 생성 및 버튼 클릭 시 오른쪽 영역에 있는 이미지와 텍스트 변경 로직 구현
- 가이드 버튼에 필요한 목록 및 내용 데이터 테이블로 관리할 수 있도록 구조체 및 데이터 테이블 추가
- SubSystem에 해당 데이터 테이블 할당 후 사용하는 형태로 구현, 관련해서 제대로 구현된건지 체크 작업 필요
- 현재 해당 위젯 출력에 대해서 테스트는 진행이 안 된 상태