### PR TITLE
[Fix] 관리 모드 보더가 처음부터 나와있고, 클릭 시 튕기던 버그 수정

### DIFF
--- a/Source/RogShop/Widget/Tycoon/RSTycoonManagementWidget.cpp
+++ b/Source/RogShop/Widget/Tycoon/RSTycoonManagementWidget.cpp
@@ -38,10 +38,6 @@ void URSTycoonManagementWidget::NativeOnInitialized()
 		BuyTileSlot->SetPadding(FMargin(0, 10));
 	}
 
-	// 보더 초기 위치 세팅
-	BuyTileParentBorder->SetRenderTranslation(FVector2D(0.f, 0.f));
-	BuyNPCBorder->SetRenderTranslation(FVector2D(0.f, 0.f));
-
 	ExpandTileButton->OnClicked.AddDynamic(this, &URSTycoonManagementWidget::OnClickExpandTile);
 	ReturnBaseAreaButton->OnClicked.AddDynamic(this, &URSTycoonManagementWidget::OnClickWaitMode);
 	CreateNPCButton->OnClicked.AddDynamic(this, &URSTycoonManagementWidget::OpenAndCloseNPCLayout);
@@ -68,6 +64,12 @@ void URSTycoonManagementWidget::NativeConstruct()
 	
 	WidthBox->SetValue(TileMap->GetWidth());
 	HeightBox->SetValue(TileMap->GetHeight());
+
+	// 보더 초기 세팅
+	bOpenBuyTileLayout = false;
+	bOpenBuyNPCLayout = false;
+	BuyTileParentBorder->SetRenderTranslation(FVector2D(0.f, 0.f));
+	BuyNPCBorder->SetRenderTranslation(FVector2D(0.f, 0.f));
 }
 
 void URSTycoonManagementWidget::OnClickExpandTile()


### PR DESCRIPTION
고친줄 알았는데 안고쳐져있던 버그를 수정했습니다

관리 모드에서 보더를 선택하고 대기 모드로 갔다가 다시 관리 모드로 왔을 시
보더가 처음부터 나와있고, 클릭 시 튕기던 버그를 수정했습니다