### PR TITLE
[Update] 도움말 위젯 중복 컴포넌트 삭제 및 장식 추가

### DIFF
--- a/Content/Blueprints/Widgets/InGame/WBP_GuideWidget.uasset
+++ b/Content/Blueprints/Widgets/InGame/WBP_GuideWidget.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6849aea6447cf85cb9eddf912aa612185553ef0c780fcad57c7ccc4c1bbc336a
-size 55053
+oid sha256:96ed024bf5a22d195e17da672cb3aa9ff5008c0d5df485ffe7b9f4e76c728cad
+size 53992


### PR DESCRIPTION
- 도움말 위젯의 닫기버튼 위에 같은 텍스쳐를 가진 이미지 컴포넌트가 중복되어있어 삭제하였습니다.
- 도움말 텍스트 앞에 포인트 장식을 추가하였습니다.