### PR TITLE
[Update] 카메라, 체력바, 버그 수정 등 작업

### DIFF
--- a/Content/Assets/UI/Image/T_HPBarPlayerLine.uasset
+++ b/Content/Assets/UI/Image/T_HPBarPlayerLine.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:92003d3a191495b07b4e59e7374100f8f3248428cc0a53b714bbd967ecda426c
+oid sha256:00942e4aea71535cb6d071f9c0584cc4dd4a6bb8eb49c808379650f34c7fc5b8
 size 15520

--- a/Content/Blueprints/Characters/BP_DunPlayerCharacter.uasset
+++ b/Content/Blueprints/Characters/BP_DunPlayerCharacter.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1686b86bc5a48e4de15b93aeeaaa5912532404f3a027a1b4360ce3f03b4a9094
-size 40197
+oid sha256:39310dc886fd7ba3bcec452945f342fcbf27cdf1fe2618e1dbaec161ec9ad350
+size 40384

--- a/Content/Blueprints/Widgets/Dungeon/WBP_PlayerHPBar.uasset
+++ b/Content/Blueprints/Widgets/Dungeon/WBP_PlayerHPBar.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9784ecf1e967aa6edf32ea86bcffae8e4baee3e08ff438a81d844d874de90c14
-size 47354
+oid sha256:d0954fb09f082354819b8498733ae071949012f4fb53ed436bc0db6c0be649e4
+size 53077

--- a/Source/RogShop/Actor/Dungeon/GroundItem/RSDungeonGroundLifeEssence.cpp
+++ b/Source/RogShop/Actor/Dungeon/GroundItem/RSDungeonGroundLifeEssence.cpp
@@ -61,23 +61,29 @@ void ARSDungeonGroundLifeEssence::Interact(ARSDunPlayerCharacter* Interactor)
 
 	GetWorld()->GetTimerManager().SetTimer(InteractDelayTimer, FTimerDelegate::CreateLambda([=, this]()
 	{
-		MeshComp->SetSimulatePhysics(false);
-		MeshComp->SetEnableGravity(false);
+		if (MeshComp && SceneComp)
+		{
+			MeshComp->SetSimulatePhysics(false);
+			MeshComp->SetEnableGravity(false);
 
-		MeshComp->SetCollisionEnabled(ECollisionEnabled::NoCollision);
+			MeshComp->SetCollisionEnabled(ECollisionEnabled::NoCollision);
+
+			// 루트 컴포넌트를 메시 위치로 이동 및 루트 컴포넌트에 다시 부착후 메시 컴포넌트의 위치 및 회전 초기화
+			SceneComp->SetWorldLocationAndRotation(MeshComp->GetComponentLocation(), MeshComp->GetComponentRotation());
+
+			MeshComp->AttachToComponent(GetRootComponent(), FAttachmentTransformRules::KeepRelativeTransform);
+			MeshComp->SetRelativeLocation(FVector::ZeroVector);
+			MeshComp->SetRelativeRotation(FRotator::ZeroRotator);
+		}
 
 		// 틱 활성화
 		SetActorTickEnabled(true);
 
-		// 루트 컴포넌트를 메시 위치로 이동 및 루트 컴포넌트에 다시 부착후 메시 컴포넌트의 위치 및 회전 초기화
-		SceneComp->SetWorldLocationAndRotation(MeshComp->GetComponentLocation(), MeshComp->GetComponentRotation());
-
-		MeshComp->AttachToComponent(GetRootComponent(), FAttachmentTransformRules::KeepRelativeTransform);
-		MeshComp->SetRelativeLocation(FVector::ZeroVector);
-		MeshComp->SetRelativeRotation(FRotator::ZeroRotator);
-
 		// 타겟 액터 저장
-		TargetActor = Interactor;
+		if (Interactor)
+		{
+			TargetActor = Interactor;
+		}
 	}),
 		InteractDelayTime,
 		false);

--- a/Source/RogShop/ActorComponent/RSPlayerWeaponComponent.cpp
+++ b/Source/RogShop/ActorComponent/RSPlayerWeaponComponent.cpp
@@ -531,6 +531,8 @@ void URSPlayerWeaponComponent::PerformBoxSweepAttack()
 
 				FVector Start = BoxLocation;
 				FVector End = BoxLocation + BoxRotation.RotateVector(FVector(BoxExtent.X * 2.f, 0.f, 0.f));
+				Start.Z = 0.f;
+				End.Z *= 2.f;
 
 				FCollisionShape BoxShape = FCollisionShape::MakeBox(BoxExtent);
 				FCollisionQueryParams Params;

--- a/Source/RogShop/Widget/Dungeon/RSPlayerHPBarWidget.cpp
+++ b/Source/RogShop/Widget/Dungeon/RSPlayerHPBarWidget.cpp
@@ -25,6 +25,10 @@ void URSPlayerHPBarWidget::NativeOnInitialized()
 
     LastUpdateHP = 0.f;
     LastUpdateMaxHP = 0.f;
+
+    TargetPercent = 1.0f;
+    CurrentPercent = 1.0f;
+    InterpSpeed = 5.0f;
 }
 
 void URSPlayerHPBarWidget::NativeConstruct()
@@ -32,6 +36,17 @@ void URSPlayerHPBarWidget::NativeConstruct()
     Super::NativeConstruct();
 
 
+}
+
+void URSPlayerHPBarWidget::NativeTick(const FGeometry& MyGeometry, float InDeltaTime)
+{
+    Super::NativeTick(MyGeometry, InDeltaTime);
+
+    if (HPProgressBar && HPBackProgressBar)
+    {
+        CurrentPercent = FMath::FInterpTo(CurrentPercent, TargetPercent, InDeltaTime, InterpSpeed);
+        HPBackProgressBar->SetPercent(CurrentPercent);
+    }
 }
 
 void URSPlayerHPBarWidget::UpdateHP(float HP, float MaxHP)
@@ -53,7 +68,7 @@ void URSPlayerHPBarWidget::UpdateHP(float HP, float MaxHP)
     if (HPProgressBar)
     {
         const float HPPercent = (HP > 0.f) ? (float)HP / MaxHP : 0.f;
-        float TargetPercent = FMath::Clamp(HPPercent, 0.0f, 1.0f);  // 0 ~ 1 사이로 고정
+        TargetPercent = FMath::Clamp(HPPercent, 0.0f, 1.0f);  // 0 ~ 1 사이로 고정
         HPProgressBar->SetPercent(TargetPercent);
     }
 
@@ -69,8 +84,6 @@ void URSPlayerHPBarWidget::UpdateHP(float HP, float MaxHP)
         // 변경된 체력을 기준으로 마커의 크기를 변경합니다.
         if (HPBarHorizontalBox && MarkerHorizontalBox)
         {
-
-
             float HPBarBoxSize = HPBarHorizontalBox->GetDesiredSize().X;
 
             if (HPBarBoxSize == 0)

--- a/Source/RogShop/Widget/Dungeon/RSPlayerHPBarWidget.h
+++ b/Source/RogShop/Widget/Dungeon/RSPlayerHPBarWidget.h
@@ -22,6 +22,8 @@ protected:
 
 	virtual void NativeConstruct() override;
 
+	virtual void NativeTick(const FGeometry& MyGeometry, float InDeltaTime) override;
+
 private:
 	UFUNCTION()
 	void UpdateHP(float HP, float MaxHP);
@@ -50,6 +52,9 @@ private:
 	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, meta = (BindWidget, AllowPrivateAccess = "true"))
 	TObjectPtr<UProgressBar> HPProgressBar;
 
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, meta = (BindWidget, AllowPrivateAccess = "true"))
+	TObjectPtr<UProgressBar> HPBackProgressBar;
+
 	// HP 바의 마커
 	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, meta = (BindWidget, AllowPrivateAccess = "true"))
 	TObjectPtr<UHorizontalBox> MarkerHorizontalBox;
@@ -64,4 +69,14 @@ private:
 
 	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, meta = (AllowPrivateAccess = "true"))
 	TArray<TObjectPtr<UImage>> MarkerArray;	// 생성한 마커 목록
+
+	// HP바 갱신
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, meta = (AllowPrivateAccess = "true"))
+	float TargetPercent;
+
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, meta = (AllowPrivateAccess = "true"))
+	float CurrentPercent;
+
+	UPROPERTY(EditAnywhere, BlueprintReadOnly, meta = (AllowPrivateAccess = "true"))
+	float InterpSpeed;
 };


### PR DESCRIPTION
플레이어 캐릭터의 카메라 위치를 z축으로 25만큼 위로 올렸습니다.

체력바를 몬스터와 같이 자연스럽게 감소하게 하여 시각적인 효과를 주었습니다.
해당 과정에서 프로그레스바를 2개로 분리하고, 백그라운드를 별도의 이미지로 분리했습니다.

던전 재화 습득 중 캐릭터가 사라지는 경우 nullptr을 체크하도록 해주었습니다.