### PR TITLE
[Update] 데이터테이블 관련 설정 추가 및 상호작용 액터BP에 클래스 설정, 2번째 UI도 잘 나오도록 버그 임시 해결

### DIFF
--- a/Config/DefaultGame.ini
+++ b/Config/DefaultGame.ini
@@ -20,6 +20,7 @@ RelicDetailDataTable=/Game/Datas/RelicDetailDataTable.RelicDetailDataTable
 DesetMonsterSpawnGroupDataTable=/Game/Datas/DesertMonsterSpawnGroupDataTable1.DesertMonsterSpawnGroupDataTable1
 CaveMonsterSpawnGroupDataTable=/Game/Datas/CaveMonsterSpawnGroupDataTable.CaveMonsterSpawnGroupDataTable
 GuideDataTable=/Game/Datas/GuideDataTable.GuideDataTable
+GameFlowInfoDataTable=/Game/Datas/GameFlowInfoDataTable.GameFlowInfoDataTable
 
 [/Script/UnrealEd.ProjectPackagingSettings]
 Build=IfProjectHasCode

--- a/Content/Assets/UI/Image/T_GameInfoBorderImage.uasset
+++ b/Content/Assets/UI/Image/T_GameInfoBorderImage.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8a2ced6f5f84c8446ac995a2de35435fe2c97e11626e7b561e7a4e62622b8d33
+size 2692233

--- a/Content/Blueprints/Actor/BaseArea/BP_GameFlowDisplay.uasset
+++ b/Content/Blueprints/Actor/BaseArea/BP_GameFlowDisplay.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2e9732235bcba43035ad7bb1758030acbc1f7dfa6335f511f0a07e718337f75d
-size 33528
+oid sha256:e4b71e5729188ad73ba40f9abbaf122b0b540c09858e5d4d73d10f3c3ff4ded2
+size 33429

--- a/Content/Blueprints/Widgets/Dungeon/WBP_GameInfoContainer.uasset
+++ b/Content/Blueprints/Widgets/Dungeon/WBP_GameInfoContainer.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4ef8dcb713ef86c889af1711b114c39696c9520ba4c30ef95a8c41381ffb40b1
-size 51382
+oid sha256:911ef800128dc84b321d8ca5bd1f192198b29522aa91fb47e674258598661e1b
+size 58912

--- a/Content/Blueprints/Widgets/Dungeon/WBP_GameInfoWidget.uasset
+++ b/Content/Blueprints/Widgets/Dungeon/WBP_GameInfoWidget.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:46c03845d5cd7b527ef7361be575753431cf3168a61462d63bc5e876f4e10c7f
+size 26861

--- a/Content/Datas/GameFlowInfoDataTable.uasset
+++ b/Content/Datas/GameFlowInfoDataTable.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fb8bf0e59a37a35e58c4f81414fdc126a4ccb53326116dc055e767c19ca160b4
+size 8738

--- a/Source/RogShop/Actor/BaseArea/RSGameFlowDisplayActor.cpp
+++ b/Source/RogShop/Actor/BaseArea/RSGameFlowDisplayActor.cpp
@@ -67,6 +67,9 @@ void ARSGameFlowDisplayActor::Interact(ARSDunPlayerCharacter* Interactor)
 		PC->SetInputMode(InputMode);
 		PC->SetShowMouseCursor(true);
 		PC->FlushPressedKeys();
+
+		// TODO : 2번째 UI부터 여러 시도 후에도 위젯 생성된게 눈에 안보여서 이렇게 했습니다.
+		GameFlowDisplayWidgetInstance = nullptr;	
 	}
 }
 

--- a/Source/RogShop/DataTable/GameFlowInfoData.cpp
+++ b/Source/RogShop/DataTable/GameFlowInfoData.cpp
@@ -1,0 +1,5 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "GameFlowInfoData.h"
+

--- a/Source/RogShop/DataTable/GameFlowInfoData.h
+++ b/Source/RogShop/DataTable/GameFlowInfoData.h
@@ -1,0 +1,29 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Engine/DataTable.h"
+#include "GameFlowInfoData.generated.h"
+
+class UImage;
+
+USTRUCT(BlueprintType)
+struct ROGSHOP_API FGameFlowInfoData : public FTableRowBase
+{
+	GENERATED_BODY()
+
+public:
+	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly)
+	FText CategoryText;
+
+	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly)
+	FText DescriptionText;
+
+	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly)
+	FText PageText;
+
+    UPROPERTY(EditDefaultsOnly, BlueprintReadOnly)
+    TObjectPtr<UTexture2D> GameInfoImage;
+	
+};

--- a/Source/RogShop/DeveloperSettings/RSDataSubsystemSettings.h
+++ b/Source/RogShop/DeveloperSettings/RSDataSubsystemSettings.h
@@ -53,4 +53,7 @@ public:
 
 	UPROPERTY(Config, EditAnywhere)
 	TSoftObjectPtr<UDataTable> GuideDataTable;
+
+	UPROPERTY(Config, EditAnywhere)
+	TSoftObjectPtr<UDataTable> GameFlowInfoDataTable;
 };

--- a/Source/RogShop/GameInstanceSubsystem/RSDataSubsystem.cpp
+++ b/Source/RogShop/GameInstanceSubsystem/RSDataSubsystem.cpp
@@ -24,6 +24,7 @@ void URSDataSubsystem::Initialize(FSubsystemCollectionBase& Collection)
 	Monster = DataSettings->MonsterDataTable.LoadSynchronous();
 	DungeonLevel = DataSettings->DungeonLevelDataTable.LoadSynchronous();
 	Guide = DataSettings->GuideDataTable.LoadSynchronous();
+	GameFlowInfo = DataSettings->GameFlowInfoDataTable.LoadSynchronous();
 
 	check(Food)
 	check(IngredientInfo)
@@ -38,4 +39,5 @@ void URSDataSubsystem::Initialize(FSubsystemCollectionBase& Collection)
 	check(Monster)
 	check(DungeonLevel)
 	check(Guide)
+	check(GameFlowInfo)
 }

--- a/Source/RogShop/GameInstanceSubsystem/RSDataSubsystem.h
+++ b/Source/RogShop/GameInstanceSubsystem/RSDataSubsystem.h
@@ -56,4 +56,7 @@ public:
 
 	UPROPERTY()
 	TObjectPtr<UDataTable> Guide;
+
+	UPROPERTY()
+	TObjectPtr<UDataTable> GameFlowInfo;
 };

--- a/Source/RogShop/Widget/InGame/RSGameInfoWidget.cpp
+++ b/Source/RogShop/Widget/InGame/RSGameInfoWidget.cpp
@@ -1,0 +1,109 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#include "RSGameInfoWidget.h"
+#include "Components/Button.h"
+#include "Components/TextBlock.h"
+#include "Components/Image.h"
+#include "RSDataSubsystem.h"
+#include "GameFlowInfoData.h"
+
+void URSGameInfoWidget::NativeConstruct()
+{
+	Super::NativeConstruct();
+
+	if (ConfirmButton)
+	{
+		ConfirmButton->OnClicked.AddDynamic(this, &URSGameInfoWidget::OnClickConfirmButton);
+	}
+
+	if (GameInfoLeftButton)
+	{
+		GameInfoLeftButton->OnClicked.AddDynamic(this, &URSGameInfoWidget::HandleLeftButtonClicked);
+	}
+
+	if (GameInfoLeftButton)
+	{
+		GameInfoRightButton->OnClicked.AddDynamic(this, &URSGameInfoWidget::HandleRightButtonClicked);
+	}
+
+	DataSubsystem = GetGameInstance()->GetSubsystem<URSDataSubsystem>();
+
+	if (DataSubsystem && DataSubsystem->GameFlowInfo)
+	{
+		PageRowNames = DataSubsystem->GameFlowInfo->GetRowNames();
+		CurrentPageIndex = 0;
+		UpdatePage(CurrentPageIndex);
+	}
+}
+
+void URSGameInfoWidget::OnClickConfirmButton()
+{
+	APlayerController* PC = GetOwningPlayer();
+	if (PC)
+	{
+		PC->SetShowMouseCursor(false);
+
+		// InputMode 변경
+		FInputModeGameOnly InputMode;
+		PC->SetInputMode(InputMode);
+
+		PC->FlushPressedKeys();
+	}
+
+	RemoveFromParent();
+}
+
+void URSGameInfoWidget::HandleLeftButtonClicked()
+{
+	if (!DataSubsystem || !DataSubsystem->GameFlowInfo)
+	{
+		return;
+	}
+
+	if (PageRowNames.Num() == 0)
+	{
+		return;
+	}
+
+	CurrentPageIndex = (CurrentPageIndex - 1 + PageRowNames.Num()) % PageRowNames.Num();
+	UpdatePage(CurrentPageIndex);
+}
+
+void URSGameInfoWidget::HandleRightButtonClicked()
+{
+	if (!DataSubsystem || !DataSubsystem->GameFlowInfo)
+	{
+		return;
+	}
+
+	if (PageRowNames.Num() == 0)
+	{
+		return;
+	}
+
+	CurrentPageIndex = (CurrentPageIndex + 1) % PageRowNames.Num();
+	UpdatePage(CurrentPageIndex);
+}
+
+void URSGameInfoWidget::UpdatePage(int32 PageIndex)
+{
+	if (!DataSubsystem || !DataSubsystem->GameFlowInfo)
+	{
+		return;
+	}
+
+	if (!PageRowNames.IsValidIndex(PageIndex))
+	{
+		return;
+	}
+
+	const FName& RowName = PageRowNames[PageIndex];
+	const FGameFlowInfoData* GameFlowInfoData = DataSubsystem->GameFlowInfo->FindRow<FGameFlowInfoData>(RowName, TEXT("UpdatePage"));
+
+	if (!GameFlowInfoData) return;
+
+	CategoryTextBlock->SetText(GameFlowInfoData->CategoryText);
+	DescriptionTextBlock->SetText(GameFlowInfoData->DescriptionText);
+	PageTextBlock->SetText(GameFlowInfoData->PageText);
+	GameInfoImage->SetBrushFromTexture(GameFlowInfoData->GameInfoImage);
+}

--- a/Source/RogShop/Widget/InGame/RSGameInfoWidget.h
+++ b/Source/RogShop/Widget/InGame/RSGameInfoWidget.h
@@ -1,0 +1,62 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Blueprint/UserWidget.h"
+#include "RSGameInfoWidget.generated.h"
+
+class UButton;
+class UTextBlock;
+class UImage;
+class URSDataSubsystem;
+
+UCLASS()
+class ROGSHOP_API URSGameInfoWidget : public UUserWidget
+{
+	GENERATED_BODY()
+
+protected:
+	virtual void NativeConstruct() override;
+
+private:
+	UFUNCTION()
+	void OnClickConfirmButton();
+
+	UFUNCTION()
+	void HandleLeftButtonClicked();
+
+	UFUNCTION()
+	void HandleRightButtonClicked();
+
+private:
+	void UpdatePage(int32 PageIndex);
+
+private:
+	UPROPERTY(meta = (BindWidget))
+	TObjectPtr<UButton> GameInfoLeftButton;
+
+	UPROPERTY(meta = (BindWidget))
+	TObjectPtr<UButton> GameInfoRightButton;
+
+	UPROPERTY(meta = (BindWidget))
+	TObjectPtr<UButton> ConfirmButton;
+
+	UPROPERTY(meta = (BindWidget))
+	TObjectPtr<UImage> GameInfoImage;
+
+	UPROPERTY(meta = (BindWidget))
+	TObjectPtr<UTextBlock> CategoryTextBlock;
+
+	UPROPERTY(meta = (BindWidget))
+	TObjectPtr<UTextBlock> DescriptionTextBlock;
+
+	UPROPERTY(meta = (BindWidget))
+	TObjectPtr<UTextBlock> PageTextBlock;
+
+private:
+	int32 CurrentPageIndex = 0; // 현재 페이지
+	TArray<FName> PageRowNames; // DataTable의 RowName 목록
+	URSDataSubsystem* DataSubsystem;
+	
+};


### PR DESCRIPTION
## 읽어주세요
- 게임 Flow 설명 UI 위젯 cpp 추가 / 게임 플로우 데이터 테이블 생성

- 게임 설명 UI 상호작용 액터 cpp에 `GameFlowDisplayWidgetInstance = nullptr;` 코드 추가했는데
ㄴ 2번째 UI부터 해당 코드가 없으면 왜인지 위젯 인스턴스가 있어도 안 보이는 문제때문에
ㄴ 그냥 다시 CreateWidget이 되도록 했습니다. 나중에 검토 좀 해주십시오.
        