### PR TITLE
[Fix] 스폰 매니저의 세이브 및 로드 시점 변경

### DIFF
--- a/Content/Blueprints/Actor/Dungeon/BP_RSDungeonGroundLifeEssence.uasset
+++ b/Content/Blueprints/Actor/Dungeon/BP_RSDungeonGroundLifeEssence.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:dcf6330dec12e1a0385f1aa9d0f5c15ea82a52b8114de5a55a382f05df5adaa6
-size 34220
+oid sha256:6a920fd9f33190bc629753cb38157e3192006ad26600c9b23d7d5c8d2071984f
+size 34359

--- a/Source/RogShop/Actor/MapGenerator/RSSpawnManager.h
+++ b/Source/RogShop/Actor/MapGenerator/RSSpawnManager.h
@@ -239,4 +239,13 @@ private:
 private:
 	int32 LevelIndex; // 현재 레벨 인덱스
 #pragma endregion
+
+#pragma region SaveData
+public:
+	UFUNCTION()
+	void SaveSpawnInfo();
+
+private:
+	void LoadSpawnInfo();
+#pragma endregion
 };

--- a/Source/RogShop/GameModeBase/RSBaseAreaGameModeBase.cpp
+++ b/Source/RogShop/GameModeBase/RSBaseAreaGameModeBase.cpp
@@ -60,13 +60,6 @@ void ARSBaseAreaGameModeBase::SaveDungeonInfo()
     }
 
     // 세이브
-    if (SpawnManager)
-    {
-        TSet<FName> UnspawnedWeapons = SpawnManager->GetUnspawnedWeapons();
-        TSet<FName> UnspawnedRelics = SpawnManager->GetUnspawnedRelics();
-        DungeonStageSaveGame->UnspawnedWeapons = UnspawnedWeapons.Array();
-        DungeonStageSaveGame->UnspawnedRelics = UnspawnedWeapons.Array();
-    }
 
     // 저장
     UGameInstance* CurGameInstance = GetGameInstance();
@@ -81,7 +74,8 @@ void ARSBaseAreaGameModeBase::SaveDungeonInfo()
         return;
     }
 
-    UGameplayStatics::SaveGameToSlot(DungeonStageSaveGame, SaveGameSubsystem->DungeonInfoSaveSlotName, 0);
+    // 현재 세이브 할 데이터가 없습니다.
+    //UGameplayStatics::SaveGameToSlot(DungeonStageSaveGame, SaveGameSubsystem->DungeonInfoSaveSlotName, 0);
 }
 
 void ARSBaseAreaGameModeBase::LoadDungeonInfo()
@@ -102,16 +96,6 @@ void ARSBaseAreaGameModeBase::LoadDungeonInfo()
     URSDungeonStageSaveGame* DungeonInfoLoadGame = Cast<URSDungeonStageSaveGame>(UGameplayStatics::LoadGameFromSlot(SaveGameSubsystem->DungeonInfoSaveSlotName, 0));
     if (DungeonInfoLoadGame)
     {
-        if (SpawnManager)
-        {
-            SpawnManager->SetUnspawnedWeapons(DungeonInfoLoadGame->UnspawnedWeapons);
-            SpawnManager->SetUnspawnedRelics(DungeonInfoLoadGame->UnspawnedRelics);
-        }
-    }
-    // 세이브 파일이 없는 경우
-    else
-    {
-        SpawnManager->ResetUnspawnedWeapons();
-        SpawnManager->ResetUnspawnedRelics();
+        // 현재 로드 할 데이터가 없습니다.
     }
 }

--- a/Source/RogShop/GameModeBase/RSDungeonGameModeBase.cpp
+++ b/Source/RogShop/GameModeBase/RSDungeonGameModeBase.cpp
@@ -135,14 +135,6 @@ void ARSDungeonGameModeBase::SaveDungeonInfo()
     DungeonStageSaveGame->LevelIndex = LevelIndex;
     DungeonStageSaveGame->Seed = Seed;
 
-    if (SpawnManager)
-    {
-        TSet<FName> UnspawnedWeapons = SpawnManager->GetUnspawnedWeapons();
-        TSet<FName> UnspawnedRelics = SpawnManager->GetUnspawnedRelics();
-        DungeonStageSaveGame->UnspawnedWeapons = UnspawnedWeapons.Array();
-        DungeonStageSaveGame->UnspawnedRelics = UnspawnedWeapons.Array();
-    }
-
     // 저장
     UGameInstance* CurGameInstance = GetGameInstance();
     if (!CurGameInstance)
@@ -179,12 +171,6 @@ void ARSDungeonGameModeBase::LoadDungeonInfo()
     {
         LevelIndex = DungeonInfoLoadGame->LevelIndex;
         Seed = DungeonInfoLoadGame->Seed;
-
-        if (SpawnManager)
-        {
-            SpawnManager->SetUnspawnedWeapons(DungeonInfoLoadGame->UnspawnedWeapons);
-            SpawnManager->SetUnspawnedRelics(DungeonInfoLoadGame->UnspawnedRelics);
-        }
     }
     // 세이브 파일이 없는 경우
     else
@@ -194,9 +180,6 @@ void ARSDungeonGameModeBase::LoadDungeonInfo()
         {
             InitRandSeed();
         }
-
-        SpawnManager->ResetUnspawnedWeapons();
-        SpawnManager->ResetUnspawnedRelics();
     }
 }
 


### PR DESCRIPTION
스폰 매니저가 게임 모드의 로드 시점에 호출될 경우 아직 World가 설정되지 않아 프로그램이 터지는 문제가 있었습니다.

스폰 매니저가 초기화 될 때 로드 로직을 수행할 수 있도록 수정해주었습니다.

세이브 로직 또한 스폰 매니저가 직접 가지도록 해주었습니다.