### PR TITLE
[Fix] 상점을 열 때도 보유 재화값이 갱신될 수 있도록 수정

### DIFF
--- a/Source/RogShop/Widget/DunShop/RSDunShopWidget.cpp
+++ b/Source/RogShop/Widget/DunShop/RSDunShopWidget.cpp
@@ -42,14 +42,22 @@ void URSDunShopWidget::NativeConstruct()
     Super::NativeConstruct();
 
     SetMouseMode(true);
+
+    // 상점을 열 때도 보유 재화값 갱신
+    ARSDunPlayerCharacter* PlayerChar = Cast<ARSDunPlayerCharacter>(GetOwningPlayerPawn());
+
+    if (PlayerChar)
+    {
+        UpdateLifeEssence(PlayerChar->GetLifeEssence());
+    }
 }
 
 void URSDunShopWidget::UpdateLifeEssence(int NewLifeEssence)
 {
     if (LifeEssenceText)
     {
-        FString LifeEssenceString = FString::Printf(TEXT("%d"), NewLifeEssence); // 정수 형태로 변환
-        LifeEssenceText->SetText(FText::FromString(LifeEssenceString));
+        FText DisplayText = FText::AsNumber(NewLifeEssence);
+        LifeEssenceText->SetText(DisplayText);
     }
 }
 


### PR DESCRIPTION
- 현재 상점 위젯이 최초 생성된 이후부터 재화 변동 시 해당 값이 반영되는 상태
- 최초 생성시에도 플레이어의 최신 재화값을 표시할 수 있도록 수정