### PR TITLE
[Fix] 생명의 정수 스폰 로직 변경

### DIFF
--- a/Source/RogShop/Actor/Dungeon/Altar/RSHPToLifeEssenceAltar.cpp
+++ b/Source/RogShop/Actor/Dungeon/Altar/RSHPToLifeEssenceAltar.cpp
@@ -50,16 +50,24 @@ void ARSHPToLifeEssenceAltar::Interact(ARSDunPlayerCharacter* Interactor)
 		
 	}
 
-	if (SpawnManager)
+	for (int32 i = 0; i < HPCost; ++i)
 	{
-		for (int32 i = 0; i < HPCost; ++i)
-		{
-			SpawnManager->SpawnGroundLifeEssenceAtTransform(GetActorTransform(), 1);
-		}
+		FTimerHandle SpawnDelayTimerHandle;
 
-		// 비용을 2배로 증가시킨다.
-		Cost *= 2;
+		GetWorld()->GetTimerManager().SetTimer(SpawnDelayTimerHandle, FTimerDelegate::CreateLambda([=]()
+			{
+				if (SpawnManager)
+				{
+					SpawnManager->SpawnGroundLifeEssenceAtTransform(GetActorTransform(), 1);
+				}
+
+			}),
+			i * 0.05f,
+			false);
 	}
+
+	// 비용을 2배로 증가시킨다.
+	Cost *= 2;
 
 	// 비용 업데이트
 	URSAltarCostWidget* CostWidget = Cast<URSAltarCostWidget>(GetCostWidgetObject());

--- a/Source/RogShop/Actor/Dungeon/TreasureChest/RSLifeEssenceTreasureChest.cpp
+++ b/Source/RogShop/Actor/Dungeon/TreasureChest/RSLifeEssenceTreasureChest.cpp
@@ -46,6 +46,16 @@ void ARSLifeEssenceTreasureChest::OpenChest()
 
 	for (int32 i = 0; i < RandQuantity; ++i)
 	{
-		SpawnManager->SpawnGroundLifeEssenceAtTransform(TargetTransform, 1);
+		FTimerHandle SpawnDelayTimerHandle;
+
+		GetWorld()->GetTimerManager().SetTimer(SpawnDelayTimerHandle, FTimerDelegate::CreateLambda([=]()
+		{
+				if (SpawnManager)
+				{
+					SpawnManager->SpawnGroundLifeEssenceAtTransform(TargetTransform, 1);
+				}
+		}),
+		i * 0.05f,
+		false);
 	}
 }


### PR DESCRIPTION
생명의 정수가 한번에 여러번 스폰될 경우 서로 밀어내는 문제 때문에 시간차를 두고 스폰되도록 로직을 수정했습니다.