### PR TITLE
[Fix] this의 암시적 사용 문제 해결

### DIFF
--- a/Source/RogShop/Actor/Dungeon/Altar/RSHPToLifeEssenceAltar.cpp
+++ b/Source/RogShop/Actor/Dungeon/Altar/RSHPToLifeEssenceAltar.cpp
@@ -54,7 +54,7 @@ void ARSHPToLifeEssenceAltar::Interact(ARSDunPlayerCharacter* Interactor)
 	{
 		FTimerHandle SpawnDelayTimerHandle;
 
-		GetWorld()->GetTimerManager().SetTimer(SpawnDelayTimerHandle, FTimerDelegate::CreateLambda([=]()
+		GetWorld()->GetTimerManager().SetTimer(SpawnDelayTimerHandle, FTimerDelegate::CreateLambda([=, this]()
 			{
 				if (SpawnManager)
 				{


### PR DESCRIPTION
타이머 델리게이트에서 람다함수를 만들어 사용할 때 this에 대해 암시적으로 this가 캡처되는 경우 빌드에 오류가 발생하기 때문에 해당 코드를 수정해주었습니다.