### PR TITLE
[Fix] 던전의 세이브 파일이 초기화되는 문제 수정

### DIFF
--- a/Source/RogShop/Actor/MapGenerator/RSSpawnManager.cpp
+++ b/Source/RogShop/Actor/MapGenerator/RSSpawnManager.cpp
@@ -463,17 +463,6 @@ void URSSpawnManager::ResetUnspawnedRelics()
 void URSSpawnManager::SaveSpawnInfo()
 {
 	// SaveGame 오브젝트 생성
-	URSDungeonStageSaveGame* DungeonStageSaveGame = Cast<URSDungeonStageSaveGame>(UGameplayStatics::CreateSaveGameObject(URSDungeonStageSaveGame::StaticClass()));
-	if (!DungeonStageSaveGame)
-	{
-		return;
-	}
-
-	// 세이브 데이터 설정
-	DungeonStageSaveGame->UnspawnedWeapons = UnspawnedWeapons.Array();
-	DungeonStageSaveGame->UnspawnedRelics = UnspawnedWeapons.Array();
-
-	// 저장
 	UGameInstance* CurGameInstance = GetWorld()->GetGameInstance();
 	if (!CurGameInstance)
 	{
@@ -485,6 +474,25 @@ void URSSpawnManager::SaveSpawnInfo()
 	{
 		return;
 	}
+	
+	URSDungeonStageSaveGame* DungeonStageSaveGame = Cast<URSDungeonStageSaveGame>(UGameplayStatics::LoadGameFromSlot(SaveGameSubsystem->DungeonInfoSaveSlotName, 0));
+	// 저장된 세이브 파일이 없는 경우
+	if (!DungeonStageSaveGame)
+	{
+		// 새로운 세이브 파일 생성
+		DungeonStageSaveGame = Cast<URSDungeonStageSaveGame>(UGameplayStatics::CreateSaveGameObject(URSDungeonStageSaveGame::StaticClass()));
+		if (!DungeonStageSaveGame)
+		{
+			return;
+		}
+	}
+
+
+	// 세이브 데이터 설정
+	DungeonStageSaveGame->UnspawnedWeapons = UnspawnedWeapons.Array();
+	DungeonStageSaveGame->UnspawnedRelics = UnspawnedWeapons.Array();
+
+	// 저장
 
 	UGameplayStatics::SaveGameToSlot(DungeonStageSaveGame, SaveGameSubsystem->DungeonInfoSaveSlotName, 0);
 }

--- a/Source/RogShop/Character/RSDunPlayerCharacter.cpp
+++ b/Source/RogShop/Character/RSDunPlayerCharacter.cpp
@@ -809,24 +809,24 @@ void ARSDunPlayerCharacter::LoadStatus()
     URSDungeonStatusSaveGame* PlayerStatusLoadGame = Cast<URSDungeonStatusSaveGame>(UGameplayStatics::LoadGameFromSlot(SaveGameSubsystem->StatusSaveSlotName, 0));
     URSDungeonStatusSaveGame* FoodStatusLoadGame = Cast<URSDungeonStatusSaveGame>(UGameplayStatics::LoadGameFromSlot(SaveGameSubsystem->FoodStatusSaveSlotName, 0));
 
-    float PlayerMaxHP = 0.f;
-    float PlayerHP = 0.f;
-    float PlayerMoveSpeed = 0.f;
-    float PlayerAttackPower = 0.f;
-    float PlayerAttackSpeed = 0.f;
-
-    if (FoodStatusLoadGame)
-    {
-        PlayerMaxHP += FoodStatusLoadGame->MaxHP;
-        PlayerHP += FoodStatusLoadGame->HP;
-        PlayerMoveSpeed += FoodStatusLoadGame->MoveSpeed;
-        PlayerAttackPower += FoodStatusLoadGame->AttackPower;
-        PlayerAttackSpeed += FoodStatusLoadGame->AttackSpeed;
-    }
-
+    // 저장된 값이 없는 경우 타이쿤에서 추가된 스탯을 반영하여 초기화합니다.
     if (!PlayerStatusLoadGame)
     {
-        // 저장된 값이 없는 경우 타이쿤에서 추가된 스탯을 반영하여 초기화합니다.
+        float PlayerMaxHP = 0.f;
+        float PlayerHP = 0.f;
+        float PlayerMoveSpeed = 0.f;
+        float PlayerAttackPower = 0.f;
+        float PlayerAttackSpeed = 0.f;
+
+        if (FoodStatusLoadGame)
+        {
+            PlayerMaxHP += FoodStatusLoadGame->MaxHP;
+            PlayerHP += FoodStatusLoadGame->HP;
+            PlayerMoveSpeed += FoodStatusLoadGame->MoveSpeed;
+            PlayerAttackPower += FoodStatusLoadGame->AttackPower;
+            PlayerAttackSpeed += FoodStatusLoadGame->AttackSpeed;
+        }
+
         ChangeMaxHP(PlayerMaxHP + GetMaxHP());
         ChangeHP(PlayerHP + GetMaxHP());
         ChangeMoveSpeed(PlayerMoveSpeed + GetMoveSpeed());


### PR DESCRIPTION
스폰 매니저에서 기존 세이브파일을 무시하고 새로 생성한 세이브만 저장하여 기존 세이브 파일이 초기화되는 문제를 해결했습니다.

세이브파일이 이미 존재하는 경우 해당 세이브파일을 로드하고, 기존 값에 갱신을 하도록 수정했습니다.