### PR TITLE
[Fix] 타이머 중 액터가 파괴됐을 때 프로그램이 터지는 문제 수정

### DIFF
--- a/Source/RogShop/Actor/Dungeon/Altar/RSHPToLifeEssenceAltar.cpp
+++ b/Source/RogShop/Actor/Dungeon/Altar/RSHPToLifeEssenceAltar.cpp
@@ -56,7 +56,7 @@ void ARSHPToLifeEssenceAltar::Interact(ARSDunPlayerCharacter* Interactor)
 
 		GetWorld()->GetTimerManager().SetTimer(SpawnDelayTimerHandle, FTimerDelegate::CreateLambda([=, this]()
 			{
-				if (SpawnManager)
+				if (IsValid(this) && IsValid(SpawnManager))
 				{
 					SpawnManager->SpawnGroundLifeEssenceAtTransform(GetActorTransform(), 1);
 				}

--- a/Source/RogShop/Actor/Dungeon/GroundItem/RSDungeonGroundLifeEssence.cpp
+++ b/Source/RogShop/Actor/Dungeon/GroundItem/RSDungeonGroundLifeEssence.cpp
@@ -52,6 +52,16 @@ void ARSDungeonGroundLifeEssence::Tick(float DeltaTime)
 	}
 }
 
+void ARSDungeonGroundLifeEssence::BeginDestroy()
+{
+	Super::BeginDestroy();
+
+	if (GetWorld())
+	{
+		GetWorld()->GetTimerManager().ClearTimer(InteractDelayTimer);
+	}
+}
+
 void ARSDungeonGroundLifeEssence::Interact(ARSDunPlayerCharacter* Interactor)
 {
 	// 더이상 상호작용 함수가 호출되지 않도록 한다.
@@ -61,7 +71,7 @@ void ARSDungeonGroundLifeEssence::Interact(ARSDunPlayerCharacter* Interactor)
 
 	GetWorld()->GetTimerManager().SetTimer(InteractDelayTimer, FTimerDelegate::CreateLambda([=, this]()
 	{
-		if (MeshComp && SceneComp)
+		if (IsValid(this) && IsValid(MeshComp) && IsValid(SceneComp))
 		{
 			MeshComp->SetSimulatePhysics(false);
 			MeshComp->SetEnableGravity(false);
@@ -77,7 +87,6 @@ void ARSDungeonGroundLifeEssence::Interact(ARSDunPlayerCharacter* Interactor)
 		}
 		else
 		{
-			GetWorld()->GetTimerManager().ClearTimer(InteractDelayTimer);
 			return;
 		}
 

--- a/Source/RogShop/Actor/Dungeon/GroundItem/RSDungeonGroundLifeEssence.h
+++ b/Source/RogShop/Actor/Dungeon/GroundItem/RSDungeonGroundLifeEssence.h
@@ -19,6 +19,9 @@ public:
 
 	virtual void Tick(float DeltaTime) override;
 
+protected:
+	virtual void BeginDestroy() override;
+
 // 상호작용
 public:
 	virtual void Interact(ARSDunPlayerCharacter* Interactor) override;

--- a/Source/RogShop/Actor/Dungeon/TreasureChest/RSLifeEssenceTreasureChest.cpp
+++ b/Source/RogShop/Actor/Dungeon/TreasureChest/RSLifeEssenceTreasureChest.cpp
@@ -48,9 +48,9 @@ void ARSLifeEssenceTreasureChest::OpenChest()
 	{
 		FTimerHandle SpawnDelayTimerHandle;
 
-		GetWorld()->GetTimerManager().SetTimer(SpawnDelayTimerHandle, FTimerDelegate::CreateLambda([=]()
+		GetWorld()->GetTimerManager().SetTimer(SpawnDelayTimerHandle, FTimerDelegate::CreateLambda([=, this]()
 		{
-				if (SpawnManager)
+				if (IsValid(this) && IsValid(SpawnManager))
 				{
 					SpawnManager->SpawnGroundLifeEssenceAtTransform(TargetTransform, 1);
 				}


### PR DESCRIPTION
타이머 등록 후 액터가 파괴된 경우 타이머가 동작하지 않도록 로직을 수정했습니다.
액터가 파괴될 경우 타이머를 제거하거나 타이머에서 현재 객체의 상태를 확인 후 동작하도록 했습니다.

해당 로직 수정 후 프로그램이 터지지 않는 것을 확인했습니다.