### PR TITLE
[Fix] 재단에서 생명의 정수가 1개씩 적게 되는 현상 수정

### DIFF
--- a/Source/RogShop/Actor/Dungeon/Altar/RSHPToLifeEssenceAltar.cpp
+++ b/Source/RogShop/Actor/Dungeon/Altar/RSHPToLifeEssenceAltar.cpp
@@ -50,15 +50,15 @@ void ARSHPToLifeEssenceAltar::Interact(ARSDunPlayerCharacter* Interactor)
 		
 	}
 
-	for (int32 i = 0; i < HPCost; ++i)
+	for (int32 i = 0; i <= HPCost; ++i)
 	{
 		FTimerHandle SpawnDelayTimerHandle;
 
 		GetWorld()->GetTimerManager().SetTimer(SpawnDelayTimerHandle, FTimerDelegate::CreateLambda([=, this]()
 			{
-				if (IsValid(this) && IsValid(SpawnManager))
+				if (IsValid(this) && IsValid(SpawnManager) && IsValid(Interactor))
 				{
-					SpawnManager->SpawnGroundLifeEssenceAtTransform(GetActorTransform(), 1);
+					SpawnManager->SpawnGroundLifeEssenceAtTransform(Interactor->GetActorTransform(), 1);
 				}
 
 			}),

--- a/Source/RogShop/Actor/Dungeon/TreasureChest/RSLifeEssenceTreasureChest.cpp
+++ b/Source/RogShop/Actor/Dungeon/TreasureChest/RSLifeEssenceTreasureChest.cpp
@@ -44,7 +44,7 @@ void ARSLifeEssenceTreasureChest::OpenChest()
 
 	TargetTransform.SetLocation(TargetLocation);
 
-	for (int32 i = 0; i < RandQuantity; ++i)
+	for (int32 i = 0; i <= RandQuantity; ++i)
 	{
 		FTimerHandle SpawnDelayTimerHandle;
 


### PR DESCRIPTION
재단에서 생명의 정수가 1개씩 적게 되는 문제를 해결해주었습니다.
반복문의 조건식이 잘못 된 상태였습니다.

재단과 상호작용할 경우 생명의 정수가 플레이어 캐릭터 기준으로 스폰되도록 수정했습니다.