### PR TITLE
[Fix] FoodList열면 게임이 터지던 버그 수정

### DIFF
--- a/Source/RogShop/GameModeBase/RSTycoonGameModeBase.cpp
+++ b/Source/RogShop/GameModeBase/RSTycoonGameModeBase.cpp
@@ -225,9 +225,9 @@ void ARSTycoonGameModeBase::BeginPlay()
 {
 	Super::BeginPlay();
 
-#if WITH_EDITOR
-	GetGameInstance<URSGameInstance>()->SetDebugLogEnabled(true);
-#endif
+// #if WITH_EDITOR
+// 	GetGameInstance<URSGameInstance>()->SetDebugLogEnabled(true);
+// #endif
 
 	URSSaveGameSubsystem* SaveSubsystem = GetGameInstance()->GetSubsystem<URSSaveGameSubsystem>();
 	SaveSubsystem->OnSaveRequested.AddDynamic(this, &ARSTycoonGameModeBase::SaveGameData);

--- a/Source/RogShop/Widget/Tycoon/RSTycoonFoodListWidget.h
+++ b/Source/RogShop/Widget/Tycoon/RSTycoonFoodListWidget.h
@@ -65,5 +65,7 @@ protected:
 private:
 	FName NowOpenKey;
 	const FCookFoodData* NowOpenData;
+
+	UPROPERTY()
 	TArray<URSTycoonFoodListButtonWidget*> FoodListButtons;
 };


### PR DESCRIPTION
FoodList 열면 UPROPERTY() 처리가 안되있어 GC가 수거해가서 생기던 문제 해결
