### PR TITLE
[Update] 타일맵이 액터의 위치를 중앙으로 생성되게 변경

### DIFF
--- a/Content/Maps/TycoonMap.umap
+++ b/Content/Maps/TycoonMap.umap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:74fa6cbb3fac01cbd0346cb57d3f14db0ef0db38342f0504d8dff4731beb077d
-size 6647375
+oid sha256:4bfe1bf8f8d066a3f175678383bf37a429b2568c670fcb9d58cc8b069d438269
+size 6647127

--- a/Source/RogShop/Actor/Tycoon/RSTileMap.cpp
+++ b/Source/RogShop/Actor/Tycoon/RSTileMap.cpp
@@ -164,13 +164,14 @@ void ARSTileMap::SaveTileMap()
 
 FVector ARSTileMap::GetMapCenter()
 {
-	FVector Size = GetMapSize();
 	FVector Center = GetActorLocation();
-	FVector HalfTileSize = DefaultTileType.GetDefaultObject()->GetTileSize() * 0.5f;
+	///왼쪽 아래가 기준일 경우
+	// FVector Size = GetMapSize();
+	// FVector HalfTileSize = DefaultTileType.GetDefaultObject()->GetTileSize() * 0.5f;
 
 	//Center에서 타일의 중심이 생성되기 때문에 위치를 보정해줘야함
-	Center.Y += Size.Y * 0.5f - HalfTileSize.Y;
-	Center.X += Size.X * 0.5f - HalfTileSize.X;
+	// Center.Y += Size.Y * 0.5f - HalfTileSize.Y;
+	// Center.X += Size.X * 0.5f - HalfTileSize.X;
 
 	return Center;
 }
@@ -313,7 +314,13 @@ ARSBaseTile* ARSTileMap::CreateTile(const TSubclassOf<ARSBaseTile>& TileClass, i
 #endif
 
 	FVector TileSize = DefaultTileType.GetDefaultObject()->GetTileSize();
+
+	//중앙 정렬
 	FVector Location = GetActorLocation();
+	FVector MapSize = GetMapSize();
+	Location.X = Location.X - MapSize.X * 0.5f + TileSize.X * 0.5f;
+	Location.Y = Location.Y - MapSize.Y * 0.5f + TileSize.Y * 0.5f;
+	
 	Location.X += TileSize.X * Row;
 	Location.Y += TileSize.Y * Column;
 
@@ -429,7 +436,7 @@ FVector ARSTileMap::GetRandomLocationInMap()
 	FVector HalfTileSize = DefaultTileType->GetDefaultObject<ARSBaseTile>()->GetTileSize() * 0.5f;
 	FVector MapSize = GetMapSize();
 	FVector RandomLocation = FVector(FMath::FRand()) * MapSize;
-	FVector SpawnLocation = GetActorLocation() + RandomLocation - HalfTileSize;
+	FVector SpawnLocation = GetActorLocation() - MapSize * 0.5f  + RandomLocation;
 	SpawnLocation.Z = GetActorLocation().Z + 100;
 
 	return SpawnLocation;

--- a/Source/RogShop/Actor/Tycoon/Tile/RSDoorTile.cpp
+++ b/Source/RogShop/Actor/Tycoon/Tile/RSDoorTile.cpp
@@ -26,7 +26,12 @@ ARSTycoonCustomerCharacter* ARSDoorTile::SpawnCustomer(const FName& FoodKey, ARS
 	Customer->WantFoodKey = FoodKey;
 
 	int32 Index = TargetTable->GetCanSitingLocationIndex();
-	Customer->MoveToTarget(TargetTable->GetSitTransform(Index).GetLocation(), TargetTable);	
+	if (Index == INDEX_NONE)
+	{
+		verify("Sit Location Index Is None")
+	}
+
+	Customer->MoveToTarget(TargetTable->GetSitTransform(Index).GetLocation(), TargetTable);
 
 	return Customer;
 }

--- a/Source/RogShop/Actor/Tycoon/Tile/RSTableTile.cpp
+++ b/Source/RogShop/Actor/Tycoon/Tile/RSTableTile.cpp
@@ -43,7 +43,7 @@ void ARSTableTile::ResetAll()
 
 	for (auto& FoodActor : FoodActors)
 	{
-		if (FoodActor->IsValidLowLevel())
+		if (FoodActor.IsValid())
 		{
 			FoodActor->Destroy();
 			FoodActor = nullptr;


### PR DESCRIPTION
타일맵이 액터의 위치를 중앙으로 생성되게 변경했습니다
그 외에 사소한 버그가 생길만한 곳을 고쳤습니다 